### PR TITLE
Simple, temporary fix for android

### DIFF
--- a/src/form/FormInput.js
+++ b/src/form/FormInput.js
@@ -122,12 +122,13 @@ styles = StyleSheet.create({
     ...Platform.select({
       android: {
         height: 46,
+        width: '100%',
       },
       ios: {
+        width: width,
         height: 36,
       }
     }),
-    width: width,
     color: colors.grey3,
     fontSize: normalize(14)
   }


### PR DESCRIPTION
On android devices the input width has some problems and always sticks to the right edge.

https://cloud.githubusercontent.com/assets/26611935/24225107/fe30c7ee-0f5e-11e7-8a74-cf61755b8ad0.png

This fix just makes it to have 100% width of parent's component instead of android's device width.