### PR TITLE
Update to use prop-types instead of React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "logo": "https://opencollective.com/react-native-elements/logo.txt"
   },
   "dependencies": {
+    "prop-types": "^15.5.8",
     "react-native-side-menu": "^0.20.1",
     "react-native-tab-navigator": "^0.3.3"
   },
@@ -53,18 +54,18 @@
     "eslint-plugin-react": "^6.10.0",
     "eslint-plugin-react-native": "^2.3.1",
     "jest": "^19.0.2",
+    "opencollective-postinstall": "^1.0.15",
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-native": "^0.41.2",
     "react-native-vector-icons": "^4.0.0",
-    "webpack": "^2.2.1",
-    "opencollective-postinstall": "^1.0.15"
+    "webpack": "^2.2.1"
   },
   "jest": {
     "preset": "react-native",
     "coverageDirectory": "./coverage/",
-    "collectCoverageFrom" : [
+    "collectCoverageFrom": [
       "src/**/*.js",
       "!src/index.js",
       "!src/tabs/*.js",

--- a/src/avatar/Avatar.js
+++ b/src/avatar/Avatar.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {
   View,
   Image,

--- a/src/badge/badge.js
+++ b/src/badge/badge.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Text, View, StyleSheet } from 'react-native';
 
@@ -18,7 +19,7 @@ const Badge = props => {
 };
 
 Badge.propTypes = {
-  badge: React.PropTypes.any,
+  badge: PropTypes.any,
 };
 
 styles = StyleSheet.create({

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {
   TouchableNativeFeedback,
   TouchableHighlight,

--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { View, Text as NativeText, StyleSheet, TouchableHighlight, Platform } from 'react-native';
 import colors from '../config/colors';
 import Text from '../text/Text';

--- a/src/checkbox/CheckBox.js
+++ b/src/checkbox/CheckBox.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { StyleSheet, TouchableOpacity, View, Platform } from 'react-native';
 import Text from '../text/Text';
 import fonts from '../config/fonts';

--- a/src/containers/Card.js
+++ b/src/containers/Card.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { View, StyleSheet, Platform, Image } from 'react-native';
 import fonts from '../config/fonts';
 import colors from '../config/colors';

--- a/src/form/FormInput.js
+++ b/src/form/FormInput.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { TextInput, StyleSheet, View, Platform, Dimensions } from 'react-native';
 import colors from '../config/colors';
 import normalize from '../helpers/normalizeText';

--- a/src/form/FormLabel.js
+++ b/src/form/FormLabel.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { StyleSheet, View, Platform } from 'react-native';
 import colors from '../config/colors';
 import fonts from '../config/fonts';

--- a/src/form/FormValidationMessage.js
+++ b/src/form/FormValidationMessage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import colors from '../config/colors';
 import Text from '../text/Text';

--- a/src/grid/Col.js
+++ b/src/grid/Col.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
 
 const Col = (props) => {

--- a/src/grid/Grid.js
+++ b/src/grid/Grid.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import Row from './Row';
 

--- a/src/grid/Row.js
+++ b/src/grid/Row.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
 
 const Row = (props) => {

--- a/src/icons/Icon.js
+++ b/src/icons/Icon.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Platform, TouchableHighlight, View, StyleSheet } from 'react-native';
 import getIconType from '../helpers/getIconType';
 

--- a/src/input/Search.js
+++ b/src/input/Search.js
@@ -107,8 +107,8 @@ Search.propTypes = {
   showLoadingIcon: PropTypes.bool,
   loadingIcon: PropTypes.object,
   clearIcon: PropTypes.oneOf(PropTypes.object, PropTypes.bool),
-  textInputRef: PropTypes.string,
-  containerRef: PropTypes.string,
+  textInputRef: PropTypes.func,
+  containerRef: PropTypes.func,
   selectionColor: PropTypes.string,
   underlineColorAndroid: PropTypes.string,
 };
@@ -157,7 +157,7 @@ const styles = StyleSheet.create({
         top: 17
       }
     })
-  },  
+  },
   input: {
     paddingLeft: 26,
     paddingRight: 19,

--- a/src/input/Search.js
+++ b/src/input/Search.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { ActivityIndicator, View, StyleSheet, TextInput, Platform } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import colors from '../config/colors';

--- a/src/list/List.js
+++ b/src/list/List.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import colors from '../config/colors';
 

--- a/src/list/ListItem.js
+++ b/src/list/ListItem.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { View, StyleSheet, TouchableHighlight, Image, Platform, Switch, TextInput } from 'react-native';
 import Badge from '../badge/badge';
 import Icon from '../icons/Icon';

--- a/src/pricing/PricingCard.js
+++ b/src/pricing/PricingCard.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { View, StyleSheet, Platform } from 'react-native';
 import Text from '../text/Text';
 import fonts from '../config/fonts';

--- a/src/slider/Slider.js
+++ b/src/slider/Slider.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { View, StyleSheet, Animated, Easing, PanResponder } from 'react-native';
 
 // import shallowCompare from 'react-addons-shallow-compare';

--- a/src/social/SocialIcon.js
+++ b/src/social/SocialIcon.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { View, StyleSheet, Platform, TouchableHighlight, ActivityIndicator } from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import Text from '../text/Text';

--- a/src/text/Text.js
+++ b/src/text/Text.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Text, StyleSheet, Platform } from 'react-native';
 import fonts from '../config/fonts';
 import normalize from '../helpers/normalizeText';

--- a/src/tile/FeaturedTile.js
+++ b/src/tile/FeaturedTile.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {
   TouchableOpacity,
   Text as NativeText,

--- a/src/tile/Tile.js
+++ b/src/tile/Tile.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {
   View,
   Image,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4069,6 +4069,12 @@ prop-types@^15.5.7, prop-types@~15.5.7:
   dependencies:
     fbjs "^0.8.9"
 
+prop-types@^15.5.8:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"


### PR DESCRIPTION
In preparation for React 16, using to use `prop-types` package to use PropTypes

https://facebook.github.io/react/blog/#new-deprecation-warnings