### PR TITLE
Fix android overflow: ButtonGroup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-elements",
-  "version": "0.11.1",
+  "version": "0.11.0",
   "description": "React Native Elements & UI Toolkit",
   "main": "src/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-elements",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "React Native Elements & UI Toolkit",
   "main": "src/index.js",
   "repository": {

--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -22,6 +22,7 @@ const ButtonGroup = props => {
     onHideUnderlay,
     onShowUnderlay,
     setOpacityTo,
+    containerBorderRadius,
     ...attributes,
   } = props;
 
@@ -45,10 +46,21 @@ const ButtonGroup = props => {
                   borderRightWidth: innerBorderStyle && innerBorderStyle.width || 1,
                   borderRightColor: innerBorderStyle && innerBorderStyle.color || colors.grey4
                 },
-                i === buttons.length - 1 && lastBorderStyle,
-                selectedIndex === i && {backgroundColor: selectedBackgroundColor || 'white'}
+                i === buttons.length - 1 && {
+                  ...lastBorderStyle,
+                  borderTopRightRadius: containerBorderRadius || 0,
+                  borderBottomRightRadius: containerBorderRadius || 0,
+                },
+                i === 0 && {
+                  borderTopLeftRadius: containerBorderRadius || 0,
+                  borderBottomLeftRadius: containerBorderRadius || 0,
+                },
+                selectedIndex === i && {backgroundColor: selectedBackgroundColor || 'white'},
               ]}>
-              <View style={[styles.textContainer, buttonStyle && buttonStyle]}>
+              <View style={[
+                styles.textContainer,
+                buttonStyle && buttonStyle
+              ]}>
               {
                 button.element ? <button.element /> : (
                   <Text
@@ -120,6 +132,7 @@ ButtonGroup.propTypes = {
   lastBorderStyle: PropTypes.oneOf(View.propTypes.style, NativeText.propTypes.style),
   buttonStyle: View.propTypes.style,
   selectedBackgroundColor: PropTypes.string,
+  containerBorderRadius: PropTypes.number,
 };
 
 export default ButtonGroup;

--- a/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
+++ b/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
@@ -36,6 +36,10 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
           "borderRightWidth": 1,
         },
         false,
+        Object {
+          "borderBottomLeftRadius": 0,
+          "borderTopLeftRadius": 0,
+        },
         false,
       ]
     }
@@ -87,6 +91,7 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
         },
         false,
         false,
+        false,
       ]
     }
     underlayColor="#ffffff"
@@ -132,7 +137,11 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
           "flex": 1,
         },
         false,
-        undefined,
+        Object {
+          "borderBottomRightRadius": 0,
+          "borderTopRightRadius": 0,
+        },
+        false,
         false,
       ]
     }
@@ -207,6 +216,10 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
           "borderRightWidth": 1,
         },
         false,
+        Object {
+          "borderBottomLeftRadius": 0,
+          "borderTopLeftRadius": 0,
+        },
         false,
       ]
     }
@@ -254,6 +267,7 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
           "borderRightColor": "#bdc6cf",
           "borderRightWidth": 1,
         },
+        false,
         false,
         Object {
           "backgroundColor": "red",
@@ -305,7 +319,11 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
           "flex": 1,
         },
         false,
-        undefined,
+        Object {
+          "borderBottomRightRadius": 0,
+          "borderTopRightRadius": 0,
+        },
+        false,
         false,
       ]
     }
@@ -378,6 +396,10 @@ exports[`ButtonGroup Component should render with button.element 1`] = `
           "borderRightWidth": 300,
         },
         false,
+        Object {
+          "borderBottomLeftRadius": 0,
+          "borderTopLeftRadius": 0,
+        },
         false,
       ]
     }
@@ -407,7 +429,11 @@ exports[`ButtonGroup Component should render with button.element 1`] = `
           "flex": 1,
         },
         false,
-        undefined,
+        Object {
+          "borderBottomRightRadius": 0,
+          "borderTopRightRadius": 0,
+        },
+        false,
         false,
       ]
     }
@@ -465,6 +491,10 @@ exports[`ButtonGroup Component should render without issues 1`] = `
           "borderRightWidth": 1,
         },
         false,
+        Object {
+          "borderBottomLeftRadius": 0,
+          "borderTopLeftRadius": 0,
+        },
         false,
       ]
     }
@@ -514,6 +544,7 @@ exports[`ButtonGroup Component should render without issues 1`] = `
         },
         false,
         false,
+        false,
       ]
     }
     underlayColor="#ffffff"
@@ -557,7 +588,11 @@ exports[`ButtonGroup Component should render without issues 1`] = `
           "flex": 1,
         },
         false,
-        undefined,
+        Object {
+          "borderBottomRightRadius": 0,
+          "borderTopRightRadius": 0,
+        },
+        false,
         false,
       ]
     }


### PR DESCRIPTION
ButtonGroup: when the first or last button is selected (has a background color), the overflow on Android is broken, causing square corners. This problem does not affect iOS.

Before:
<img width="375" src="https://cloud.githubusercontent.com/assets/11345526/25081291/a23e0c34-2373-11e7-8923-13d7854e8d96.png">

After:
<img width="375" src="https://cloud.githubusercontent.com/assets/11345526/25081332/da3e67dc-2373-11e7-88c5-8c9dab8f129f.png">

This fix allows a border radius on the button which can work-around the issue.

A better solution would be to fix overflow in Android in react-native core. There is an open issue for that but no ongoing work at this time (as per the documentation).