### PR TITLE
SwipeDeck Component- Tinder Cards w/ animations & gestures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.log
 site
 coverage
+jsconfig.json

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ import Col from './grid/Col';
 import Tile from './tile/Tile';
 import Slider from './slider/Slider';
 import Avatar from './avatar/Avatar';
+import SwipeDeck from './swipedeck/SwipeDeck';
 
 const Elements = {
   Button,
@@ -53,7 +54,8 @@ const Elements = {
   Col,
   Tile,
   Slider,
-  Avatar
+  Avatar,
+  SwipeDeck
 };
 
 module.exports = Elements; // eslint-disable-line no-undef

--- a/src/swipedeck/SwipeDeck.js
+++ b/src/swipedeck/SwipeDeck.js
@@ -1,0 +1,143 @@
+import React, { PropTypes, Component } from 'react';
+import {
+  View, 
+  Animated, 
+  PanResponder,
+  Dimensions,
+  StyleSheet,
+  LayoutAnimation,
+  UIManager
+} from 'react-native';
+
+const SCREEN_WIDTH =  Dimensions.get('window').width;
+const SWIPE_THRESHOLD = 0.4 * SCREEN_WIDTH;
+
+export default class SwipeDeck extends Component {
+  static defaultProps = {
+    onSwipeRight: () => {},
+    onSwipeLeft: () => {}
+  }
+  
+  constructor(props) {
+    super(props);
+
+    const position = new Animated.ValueXY();
+
+    const panResponder = PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onPanResponderMove: (event, gesture) => {
+        position.setValue({ x: gesture.dx, y: gesture.dy })
+      },
+      onPanResponderRelease: (event, gesture) => {
+        if (gesture.dx > SWIPE_THRESHOLD) {
+          this.forceSwipe('right');
+        } else if (gesture.dx < -SWIPE_THRESHOLD) {
+          this.forceSwipe('left');
+        } else {
+          this.resetPosition()
+        }        
+      }
+    });
+
+    this.state = { panResponder, position, index: 0 };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.data !== this.props.data) {
+      this.setState({ index: 0 });
+    }
+  }
+
+  componentWillUpdate() {
+    UIManager.setLayoutAnimationEnabledExperimental && UIManager.setLayoutAnimationEnabledExperimental(true);
+    LayoutAnimation.spring();
+  }
+
+  forceSwipe(direction) {
+    const x = direction === 'right' ? SCREEN_WIDTH : -SCREEN_WIDTH
+
+    Animated.timing(this.state.position, {
+      toValue: { x: x * 2, y: direction === 'right' ? -x : x },
+      duration: 750
+    }).start(() => this.onSwipeComplete(direction));
+  }
+
+  onSwipeComplete(direction) {
+    const { onSwipeRight, onSwipeLeft, data } = this.props;
+    const item = data[this.state.index];
+
+    direction === 'right' ? onSwipeRight(item) : onSwipeLeft(item)
+    this.state.position.setValue({x: 0, y: 0})
+    this.setState({ index: this.state.index + 1})
+  }
+
+  resetPosition() {
+    Animated.spring(this.state.position, {
+      toValue: { x: 0, y: 0 }
+    }).start();
+  }
+
+  getCardStyle() {
+    const { position } = this.state
+    const rotate = position.x.interpolate({
+      inputRange: [-SCREEN_WIDTH * 2, 0, SCREEN_WIDTH * 2],
+      outputRange: ['-60deg', '0deg', '60deg']
+    })
+
+    return { 
+      ...this.state.position.getLayout(),
+      transform: [{ rotate }]
+    }
+  }
+
+  renderCards() {
+    if(this.state.index >= this.props.data.length) {
+      return this.props.renderNoMoreCards()
+    }
+
+    return this.props.data.map((item, i) => {
+      if(i < this.state.index) {
+        return null;
+      } else if(i === this.state.index) {
+        return (
+          <Animated.View
+            key={item.id}
+            style={[this.getCardStyle(), styles.cardStyle]} 
+            {...this.state.panResponder.panHandlers}
+          >
+          {this.props.renderCard(item)}
+          </Animated.View>
+        );
+      }
+
+      return (
+        <Animated.View key={item.id} style={styles.cardStyle}>
+          {this.props.renderCard(item)}
+        </Animated.View>
+      )
+    }).reverse();
+  }
+
+  render() {
+    return (
+      <View>
+        {this.renderCards()}
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  cardStyle: {
+    position: 'absolute',
+    width: SCREEN_WIDTH
+  }
+});
+
+SwipeDeck.propTypes = {
+  data: PropTypes.any,
+  renderCard: PropTypes.any,
+  renderNoMoreCards: PropTypes.any,
+  onSwipeRight: PropTypes.any,
+  onSwipeLeft: PropTypes.any,
+};

--- a/src/swipedeck/__tests__/SwipeDeck.js
+++ b/src/swipedeck/__tests__/SwipeDeck.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import SwipeDeck from '../SwipeDeck';
+
+describe('SwipeDeck component', () => {
+  it('should render with props', () => {
+    const renderCard = jest.fn();
+    const renderNoMoreCards = jest.fn();
+
+    const component = shallow(
+      <SwipeDeck 
+        data={[{ 
+          id: 1, 
+          text: 'Amanda', 
+          age: 28, 
+          uri: 'http://f9view.com/wp-content/uploads/2013/10/American-Beautiful-Girls-Wallpapers-Hollywood-Celebs-1920x1200px.jpg' 
+        }, {
+          id: 1, 
+          text: 'Amanda', 
+          age: 28, 
+          uri: 'http://f9view.com/wp-content/uploads/2013/10/American-Beautiful-Girls-Wallpapers-Hollywood-Celebs-1920x1200px.jpg'
+        }]}
+        renderCard={renderCard}
+        renderNoMoreCards={renderNoMoreCards}
+      />
+    );
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+});

--- a/src/swipedeck/__tests__/__snapshots__/SwipeDeck.js.snap
+++ b/src/swipedeck/__tests__/__snapshots__/SwipeDeck.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SwipeDeck component should render with props 1`] = `
+<View>
+  <AnimatedComponent
+    style={
+      Object {
+        "position": "absolute",
+        "width": 750,
+      }
+    }
+  />
+  <AnimatedComponent
+    onMoveShouldSetResponder={[Function]}
+    onMoveShouldSetResponderCapture={[Function]}
+    onResponderEnd={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderReject={[Function]}
+    onResponderRelease={[Function]}
+    onResponderStart={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    onStartShouldSetResponderCapture={[Function]}
+    style={
+      Array [
+        Object {
+          "left": 0,
+          "top": 0,
+          "transform": Array [
+            Object {
+              "rotate": "0deg",
+            },
+          ],
+        },
+        Object {
+          "position": "absolute",
+          "width": 750,
+        },
+      ]
+    }
+  />
+</View>
+`;


### PR DESCRIPTION
**SwipeDeck** component provides Tinder Card like functionality (gestures, animations etc) out of the box.
It has several callbacks for swipeRight, swipeLeft, renderNoMoreCards etc. 

Here's an example of what you can do with it: 

![ezgif com-optimize](https://cloud.githubusercontent.com/assets/7840686/25171310/4263ce86-24a2-11e7-8a75-e1df11e397a3.gif)

Source code for above demo here: https://github.com/Monte9/react-native-tinder-cards

TODO:
- [ ] Add more comprehensive tests
- [ ] Add documentation
- [ ] Add to Hackathon Starter project as demo
- [ ] Add other useful callbacks?

Open to suggestions on enhancing the functionality and adding more callbacks. 