### PR TITLE
Fix #206 - Export Badge as separate component

### DIFF
--- a/docs/API/badge.md
+++ b/docs/API/badge.md
@@ -18,4 +18,8 @@ Example badge usage
 
 | prop | default | type | description |
 | ---- | ---- | ----| ---- |
-| badge | none | object, accepts the following properties: value (string), badgeContainerStyle (object), badgeTextStyle (object). You can override the default badge by providing your own component with it's own styling by providing badge={{ element: <YourCustomElement /> }} | add a badge to the ListItem by using this prop |     
+| value | none | string | text value to be displayed by badge, defaults to empty| 
+| badgeContainerStyle | inherited styling | object (style) | |
+| badgeTextStyle | inherited styling | object (style) | 
+| children | none | React Native Component | override the default badge contents, mutually exclusive with 'value' property |
+| badge | none | object (props) | deprecated method of passing props to the badge |

--- a/src/badge/__tests__/__snapshots__/badge.js.snap
+++ b/src/badge/__tests__/__snapshots__/badge.js.snap
@@ -1,15 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Badge Component should render badge.element if included 1`] = `
-<Text
-  accessible={true}
-  allowFontScaling={true}
-  ellipsizeMode="tail"
-  title="foo"
-/>
+exports[`Badge Component old badge props should still work 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#444",
+        "borderRadius": 20,
+        "padding": 12,
+        "paddingBottom": 3,
+        "paddingTop": 3,
+        "position": "absolute",
+        "right": 30,
+        "top": 2,
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "white",
+          "fontSize": 14,
+        },
+        undefined,
+      ]
+    }
+  >
+    foo
+  </Text>
+</View>
 `;
 
-exports[`Badge Component should render without issues 1`] = `
+exports[`Badge Component should render if element included 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#444",
+        "borderRadius": 20,
+        "padding": 12,
+        "paddingBottom": 3,
+        "paddingTop": 3,
+        "position": "absolute",
+        "right": 30,
+        "top": 2,
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    title="foo"
+  />
+</View>
+`;
+
+exports[`Badge Component should render without issue 1`] = `
 <View
   style={
     Array [

--- a/src/badge/__tests__/badge.js
+++ b/src/badge/__tests__/badge.js
@@ -5,25 +5,31 @@ import toJson from 'enzyme-to-json';
 import Badge from '../badge';
 
 describe('Badge Component', () => {
-  it('should render without issues', () => {
-    const component = shallow(<Badge badge={{}} />);
+  it('should render without issue', () => {
+    const component = shallow(<Badge/>);
 
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();
   });
 
-  it('should throw Error if badge is not sent', () => {
+  it('should throw Error if value and child are included', () => {
     expect(() => {
-      shallow(<Badge />);
-    }).toThrow('badge prop is required');
+      shallow(<Badge value={"hello"}><Text/></Badge>);
+    }).toThrow('Badge can only contain a single child or string value');
   });
 
-  it('should render badge.element if included', () => {
-    const foo = (<Text title='foo' />);
-    const component = shallow(<Badge badge={{ element: foo }} />);
+  it('should render if element included', () => {
+    const component = shallow(<Badge ><Text title='foo' /></Badge>);
 
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();
-    expect(component.props().title).toBe('foo');
+    expect(component.props().children.props.title).toBe('foo');
   });
+
+  it('old badge props should still work', () => {
+    const component = shallow(<Badge badge={{value: 'foo'}} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  })
 });

--- a/src/badge/badge.js
+++ b/src/badge/badge.js
@@ -1,24 +1,34 @@
-import React from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+import React, {PropTypes} from 'react';
+import {Text, View, StyleSheet} from 'react-native';
 
 let styles = {};
 
-const Badge = props => {
-  const { badge } = props;
+const Badge = (props) => {
+  const {containerStyle, textStyle, value, children} = props.badge || props;
 
-  if (!badge) throw Error('badge prop is required');
+  if (children && value) {
+    throw "Badge can only contain a single child or string value"
+  }
 
-  if (badge.element) return badge.element;
+  element = (<Text style={[styles.text, textStyle]}>{value}</Text>);
+
+  if(children) {
+    element = children
+  }
 
   return (
-    <View style={[ styles.badge, badge.badgeContainerStyle ]}>
-      <Text style={[ styles.text, badge.badgeTextStyle ]}>{badge.value}</Text>
+    <View style={[styles.badge, containerStyle]}>
+      {element}
     </View>
   );
 };
 
 Badge.propTypes = {
   badge: React.PropTypes.any,
+  containerStyle: View.propTypes.style,
+  textStyle: View.propTypes.style,
+  children: PropTypes.element,
+  value: PropTypes.string
 };
 
 styles = StyleSheet.create({

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import Badge from './badge/badge'
 import Button from './buttons/Button';
 import ButtonGroup from './buttons/ButtonGroup';
 import Card from './containers/Card';
@@ -27,6 +28,7 @@ import Slider from './slider/Slider';
 import Avatar from './avatar/Avatar';
 
 const Elements = {
+  Badge,
   Button,
   ButtonGroup,
   Card,


### PR DESCRIPTION
- Included the badge prop's properties as top level props, intended to be used going forward
- Kept the 'badge' prop intact for backwards compatibility