### PR TITLE
add a props(autoCapitalize) for searchbar

### DIFF
--- a/docs/API/searchbar.md
+++ b/docs/API/searchbar.md
@@ -43,6 +43,7 @@ import { SearchBar } from 'react-native-elements'
 | loadingIcon | { color: '#86939e' } | object {color (string), style (object)} | specify color, styling of the loading ActivityIndicator effect |
 | showLoadingIcon | false | boolean | show the loading ActivityIndicator effect |
 | placeholder | '' | string | set the placeholder text |
+| autoCapitalize | 'sentences' | string | Can tell TextInput to automatically capitalize certain characters |
 | placeholderTextColor | '#86939e' | string | set the color of the placeholder text |
 | onChangeText | none | function | method to fire when text is changed |
 | clearIcon | { color: '#86939e', name: 'search' } | object {name (string), color (string), style (object)} | specify color, styling, or another [Material Icon Name](https://design.google.com/icons/)

--- a/src/input/Search.js
+++ b/src/input/Search.js
@@ -17,6 +17,7 @@ class Search extends Component {
 
   render () {
     const {
+      autoCapitalize,
       containerStyle,
       inputStyle,
       icon,
@@ -41,6 +42,7 @@ class Search extends Component {
           containerStyle && containerStyle
         ]}>
         <TextInput
+          autoCapitalize={autoCapitalize}
           ref={textInputRef}
           selectionColor={selectionColor || colors.grey3}
           underlineColorAndroid={underlineColorAndroid ? underlineColorAndroid : 'transparent'}


### PR DESCRIPTION
I found a problem when I use react-native-elements in my project .
When I use the component searchbar, the first letter in the textinput is automatically capitalized.