### PR TITLE
added test for search clearInput, closes #234

### DIFF
--- a/src/input/Search.js
+++ b/src/input/Search.js
@@ -18,8 +18,18 @@ class Search extends Component {
   }
 
   clearText() {
-    const ref = this.props.textInputRef;
-    this.refs[ref].clear();
+    if (this.props.onChangeText) {
+      this.props.onChangeText('');
+    }
+    try {
+      const ref = this.props.textInputRef;
+      this.refs[ref].clear();
+    } catch (e) {
+      if (__DEV__)
+        console.warn(
+          'Could not access textInput reference, make sure you supplied the textInputRef'
+        );
+    }
   }
 
   render() {
@@ -102,6 +112,7 @@ Search.propTypes = {
   containerRef: PropTypes.string,
   selectionColor: PropTypes.string,
   underlineColorAndroid: PropTypes.string,
+  onChangeText: PropTypes.func,
 };
 
 Search.defaultProps = {

--- a/src/input/__tests__/Search.js
+++ b/src/input/__tests__/Search.js
@@ -30,6 +30,14 @@ describe('Search component', () => {
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();
   });
+  it('should call onTextChange when close icon is touched', () => {
+    const onChangeTextMock = jest.fn();
+    const component = shallow(
+      <Search textInputRef="ti" clearIcon onChangeText={onChangeTextMock} />
+    );
+    component.find('Icon[name="close"]').simulate('press');
+    expect(onChangeTextMock).toBeCalled();
+  });
 
   it('should render without icon', () => {
     const component = shallow(


### PR DESCRIPTION
The response on the react issue was to change the code to make the behavior work. https://github.com/facebook/react-native/issues/13251

This calls onChangeText when the clearButton is pressed, as expected.

I also added unit tests for this.

Closes https://github.com/react-native-training/react-native-elements/issues/234