### PR TITLE
add secureTextEntry prop for sensitive text

### DIFF
--- a/docs/API/lists.md
+++ b/docs/API/lists.md
@@ -202,6 +202,7 @@ styles = StyleSheet.create({
 | textInputOnChangeText | function | Callback that is called when the text input's text changes. Changed text is passed as an argument to the callback handler. |
 | textInputOnFocus | function | Callback that is called when the text input is focused. |
 | textInputValue | string | Manually set value of the input
+| textInputSecure | boolean | If true, obscures the text entered so that sensitive text like passwords stay secure. |
 | textInputStyle | object (style) | Style for the input text |
 | textInputContainerStyle | object (style) | Style for the container surrounding the input text |
 | textInputOnBlur | function | Callback that is called when the text input is blurred. |

--- a/src/list/ListItem.js
+++ b/src/list/ListItem.js
@@ -64,6 +64,7 @@ const ListItem = props => {
     textInputSelectTextOnFocus,
     textInputReturnKeyType,
     textInputValue,
+    textInputSecure,
     textInputStyle,
     textInputContainerStyle,
     ...attributes
@@ -171,6 +172,7 @@ const ListItem = props => {
               onChangeText={textInputOnChangeText}
               onFocus={textInputOnFocus}
               onBlur={textInputOnBlur}
+              secureTextEntry={textInputSecure}
               selectTextOnFocus={textInputSelectTextOnFocus}
               returnKeyType={textInputReturnKeyType}
             />
@@ -273,6 +275,7 @@ ListItem.propTypes = {
   textInputSelectTextOnFocus: PropTypes.bool,
   textInputReturnKeyType: PropTypes.string,
   textInputValue: PropTypes.string,
+  textInputSecure: PropTypes.bool,
   textInputStyle: PropTypes.any,
   textInputContainerStyle: PropTypes.any,
   component: PropTypes.any,


### PR DESCRIPTION
This is to obscure any sensitive input in the textInput field such as passwords. Using the ListItem elements for a custom account page, I found secureTextEntry prop missing to be able to use it for passwords without implementing the component myself. 