### PR TITLE
Add button styles (transparent, outline, rounded)

### DIFF
--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -48,6 +48,9 @@ const Button = props => {
     disabledStyle,
     fontFamily,
     containerViewStyle,
+    rounded,
+    outline,
+    transparent,
     ...attributes
   } = props;
   let { Component } = props;
@@ -102,6 +105,14 @@ const Button = props => {
     );
   }
 
+  const baseFont = {
+    color: (textStyle && textStyle.color) || color || stylesObject.text.color,
+    size: (textStyle && textStyle.fontSize) ||
+      fontSize ||
+      (!large && stylesObject.smallFont.fontSize) ||
+      stylesObject.text.fontSize,
+  };
+
   return (
     <View
       style={[styles.container, raised && styles.raised, containerViewStyle]}
@@ -123,6 +134,21 @@ const Button = props => {
             backgroundColor && { backgroundColor: backgroundColor },
             borderRadius && { borderRadius },
             !large && styles.small,
+            rounded && {
+            borderRadius: baseFont.size * 3.8,
+            paddingHorizontal: !large ?
+              stylesObject.small.padding * 1.5 :
+              stylesObject.button.padding * 1.5,
+            },
+            outline && {
+              borderWidth: 1,
+              backgroundColor: 'transparent',
+              borderColor: baseFont.color,
+            },
+            transparent && {
+              borderWidth: 0,
+              backgroundColor: 'transparent',
+            },
             buttonStyle && buttonStyle,
             disabled && { backgroundColor: colors.disabled },
             disabled && disabledStyle && disabledStyle,
@@ -181,7 +207,7 @@ Button.propTypes = {
   fontFamily: PropTypes.string,
 };
 
-const styles = StyleSheet.create({
+const stylesObject = {
   container: {
     marginLeft: 15,
     marginRight: 15,
@@ -226,6 +252,8 @@ const styles = StyleSheet.create({
       },
     }),
   },
-});
+};
+
+const styles = StyleSheet.create(stylesObject);
 
 export default Button;

--- a/src/buttons/__tests__/__snapshots__/Button.js.snap
+++ b/src/buttons/__tests__/__snapshots__/Button.js.snap
@@ -42,6 +42,9 @@ exports[`Button Component should render with custom icon component 1`] = `
           undefined,
           undefined,
           undefined,
+          undefined,
+          undefined,
+          undefined,
         ]
       }
     >
@@ -123,6 +126,9 @@ exports[`Button Component should render with default icon 1`] = `
           Object {
             "padding": 12,
           },
+          undefined,
+          undefined,
+          undefined,
           undefined,
           undefined,
           undefined,
@@ -211,6 +217,9 @@ exports[`Button Component should render with icon type 1`] = `
           undefined,
           undefined,
           undefined,
+          undefined,
+          undefined,
+          undefined,
         ]
       }
     >
@@ -291,6 +300,9 @@ exports[`Button Component should render without issues 1`] = `
           Object {
             "padding": 12,
           },
+          undefined,
+          undefined,
+          undefined,
           undefined,
           undefined,
           undefined,


### PR DESCRIPTION
This PR addresses https://github.com/react-native-training/react-native-elements/issues/350 and adds two more styles. Also for convenience while prototyping I opted for having a stylesObject which I'm using to access nested style properties (like stylesObject.text.fontSize) rather than moving properties into separate keys in a StyleSheet (like styles.textFontSize). I don't know if you'll be ok with this solution.

![buttons](https://cloud.githubusercontent.com/assets/23213144/26147391/b31b6316-3af3-11e7-8b52-addd1bef9fe5.png)
