### PR TITLE
fix(socialIcon): fontStyle prototype to Text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-elements",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "React Native Elements & UI Toolkit",
   "main": "src/index.js",
   "repository": {

--- a/src/social/SocialIcon.js
+++ b/src/social/SocialIcon.js
@@ -6,6 +6,7 @@ import {
   Platform,
   TouchableHighlight,
   ActivityIndicator,
+  Text as NativeText,
 } from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import Text from '../text/Text';
@@ -145,7 +146,7 @@ SocialIcon.propTypes = {
   iconSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   light: PropTypes.bool,
   fontWeight: PropTypes.string,
-  fontStyle: View.propTypes.style,
+  fontStyle: NativeText.propTypes.style,
   fontFamily: PropTypes.string,
 };
 


### PR DESCRIPTION
I get a warning message on socialIcon component when using fontStyle prop.
<img width="304" alt="screen shot 2017-05-18 at 7 25 02 pm" src="https://cloud.githubusercontent.com/assets/27906294/26227450/a6099644-3c00-11e7-8bf4-eaf2130ad004.png">
Wondering if prototype for fontStyle should be Text instead of View. 

Submitting a PR with this change, can you please review.
