### PR TITLE
Fix SearchBar overlapped issue

### DIFF
--- a/src/input/Search.js
+++ b/src/input/Search.js
@@ -71,6 +71,8 @@ class Search extends Component {
             noIcon && { paddingLeft: 9 },
             round && { borderRadius: Platform.OS === 'ios' ? 15 : 20 },
             inputStyle && inputStyle,
+            clearIcon && showLoadingIcon && {paddingRight: 50},
+            (clearIcon && !showLoadingIcon || !clearIcon && showLoadingIcon) && {paddingRight: 30}
           ]}
           {...attributes}
         />
@@ -91,7 +93,11 @@ class Search extends Component {
           />}
         {showLoadingIcon &&
           <ActivityIndicator
-            style={[styles.loadingIcon, loadingIcon.style && loadingIcon.style]}
+            style={[
+              styles.loadingIcon,
+              loadingIcon.style && loadingIcon.style,
+              clearIcon && {right: 35}
+            ]}
             color={icon.color || colors.grey3}
           />}
       </View>

--- a/src/input/__tests__/__snapshots__/Search.js.snap
+++ b/src/input/__tests__/__snapshots__/Search.js.snap
@@ -44,6 +44,10 @@ exports[`Search component should render with icons 1`] = `
         false,
         false,
         undefined,
+        Object {
+          "paddingRight": 50,
+        },
+        false,
       ]
     }
     underlineColorAndroid="transparent"
@@ -99,6 +103,9 @@ exports[`Search component should render with icons 1`] = `
         Object {
           "flex": 1,
         },
+        Object {
+          "right": 35,
+        },
       ]
     }
   />
@@ -145,6 +152,8 @@ exports[`Search component should render without icon 1`] = `
           "borderRadius": 15,
         },
         undefined,
+        undefined,
+        false,
       ]
     }
     underlineColorAndroid="red"
@@ -188,6 +197,8 @@ exports[`Search component should render without issues 1`] = `
         false,
         false,
         undefined,
+        undefined,
+        false,
       ]
     }
     underlineColorAndroid="transparent"


### PR DESCRIPTION
Old: 
![4](https://cloud.githubusercontent.com/assets/15075759/26764740/9b36e1b8-4975-11e7-98b1-4234cca0faf7.png)
News:

1. clearIcon && showLoadingIcon 
![1](https://cloud.githubusercontent.com/assets/15075759/26764745/b43f6cde-4975-11e7-92dd-866493774175.png)
2. clearIcon && !showLoadingIcon
![2](https://cloud.githubusercontent.com/assets/15075759/26764749/c794a574-4975-11e7-9c2e-51e2608264a5.png)
3. !clearIcon && showLoadingIcon
![3](https://cloud.githubusercontent.com/assets/15075759/26764751/d054d788-4975-11e7-9f17-01ada40c7c76.png)

this PR fix #263 .
cc @binoy14 , @Monte9 