### PR TITLE
Fix SearchBar icons alignement on Android

### DIFF
--- a/src/input/Search.js
+++ b/src/input/Search.js
@@ -159,7 +159,7 @@ const styles = StyleSheet.create({
     top: 13,
     ...Platform.select({
       android: {
-        top: 17,
+        top: 18,
       },
     }),
   },

--- a/src/input/Search.js
+++ b/src/input/Search.js
@@ -77,14 +77,14 @@ class Search extends Component {
         {!noIcon &&
           <Icon
             size={16}
-            style={[styles.icon, icon.style && icon.style]}
+            style={[styles.icon, styles.searchIcon, icon.style && icon.style]}
             name={icon.name || 'search'}
             color={icon.color || colors.grey3}
           />}
         {clearIcon &&
           <Icon
             size={16}
-            style={[styles.clearIcon, clearIcon.style && clearIcon.style]}
+            style={[styles.icon, styles.clearIcon, clearIcon.style && clearIcon.style]}
             name={clearIcon.name || 'close'}
             onPress={this.clearText.bind(this)}
             color={clearIcon.color || colors.grey3}
@@ -145,7 +145,6 @@ const styles = StyleSheet.create({
   icon: {
     backgroundColor: 'transparent',
     position: 'absolute',
-    left: 16,
     top: 15.5,
     ...Platform.select({
       android: {
@@ -186,16 +185,11 @@ const styles = StyleSheet.create({
   inputLight: {
     backgroundColor: colors.grey4,
   },
+  searchIcon: {
+    left: 16,
+  },
   clearIcon: {
-    backgroundColor: 'transparent',
-    position: 'absolute',
     right: 16,
-    top: 15.5,
-    ...Platform.select({
-      android: {
-        top: 17,
-      },
-    }),
   },
 });
 

--- a/src/input/__tests__/__snapshots__/Search.js.snap
+++ b/src/input/__tests__/__snapshots__/Search.js.snap
@@ -60,9 +60,11 @@ exports[`Search component should render with icons 1`] = `
       Array [
         Object {
           "backgroundColor": "transparent",
-          "left": 16,
           "position": "absolute",
           "top": 15.5,
+        },
+        Object {
+          "left": 16,
         },
         undefined,
       ]
@@ -79,8 +81,10 @@ exports[`Search component should render with icons 1`] = `
         Object {
           "backgroundColor": "transparent",
           "position": "absolute",
-          "right": 16,
           "top": 15.5,
+        },
+        Object {
+          "right": 16,
         },
         undefined,
       ]
@@ -209,9 +213,11 @@ exports[`Search component should render without issues 1`] = `
       Array [
         Object {
           "backgroundColor": "transparent",
-          "left": 16,
           "position": "absolute",
           "top": 15.5,
+        },
+        Object {
+          "left": 16,
         },
         undefined,
       ]


### PR DESCRIPTION
Yo

Just a quick fix for the SearchBar component on Android. I noticed that the clear button and the loading icon are not centered.

The loading icon was just 1 pixel far from the center (so close 😢), but the clear button was clearly not centered.

Before :
![image](https://user-images.githubusercontent.com/17292331/26931834-0f8acf72-4c62-11e7-8889-797c8a141d26.png)

After : 😀
![image](https://user-images.githubusercontent.com/17292331/26931837-1465198a-4c62-11e7-9c2a-87f83111718c.png)

Here are the modifications:
![image](https://user-images.githubusercontent.com/17292331/26931844-1c73167c-4c62-11e7-96de-655f423ca331.png)

And, I use the same style `icon` for the two icons `clear` and `search` to avoid duplication because they have the same layout configuration.

Tell me if there is anything to change, thanks ! 🌵💩
