### PR TITLE
Fix missing border on ButtonGroup

### DIFF
--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -51,22 +51,29 @@ const ButtonGroup = props => {
             key={i}
             style={[
               styles.button,
+              // FIXME: This is a workaround to the borderColor and borderRadius bug
+              // react-native ref: https://github.com/facebook/react-native/issues/8236
               i < buttons.length - 1 && {
-                borderRightWidth: (innerBorderStyle &&
-                  innerBorderStyle.width) ||
-                  1,
-                borderRightColor: (innerBorderStyle &&
-                  innerBorderStyle.color) ||
-                  colors.grey4,
+                borderRightWidth: i === 0
+                  ? 0
+                  : (innerBorderStyle && innerBorderStyle.width) || 1,
+                borderRightColor:
+                  (innerBorderStyle && innerBorderStyle.color) || colors.grey4,
+              },
+              i === 1 && {
+                borderLeftWidth:
+                  (innerBorderStyle && innerBorderStyle.width) || 1,
+                borderLeftColor:
+                  (innerBorderStyle && innerBorderStyle.color) || colors.grey4,
               },
               i === buttons.length - 1 && {
                 ...lastBorderStyle,
-                borderTopRightRadius: containerBorderRadius || 0,
-                borderBottomRightRadius: containerBorderRadius || 0,
+                borderTopRightRadius: containerBorderRadius || 3,
+                borderBottomRightRadius: containerBorderRadius || 3,
               },
               i === 0 && {
-                borderTopLeftRadius: containerBorderRadius || 0,
-                borderBottomLeftRadius: containerBorderRadius || 0,
+                borderTopLeftRadius: containerBorderRadius || 3,
+                borderBottomLeftRadius: containerBorderRadius || 3,
               },
               selectedIndex === i && {
                 backgroundColor: selectedBackgroundColor || 'white',

--- a/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
+++ b/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
@@ -33,12 +33,13 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
         },
         Object {
           "borderRightColor": "#bdc6cf",
-          "borderRightWidth": 1,
+          "borderRightWidth": 0,
         },
         false,
+        false,
         Object {
-          "borderBottomLeftRadius": 0,
-          "borderTopLeftRadius": 0,
+          "borderBottomLeftRadius": 3,
+          "borderTopLeftRadius": 3,
         },
         false,
       ]
@@ -89,6 +90,10 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
           "borderRightColor": "#bdc6cf",
           "borderRightWidth": 1,
         },
+        Object {
+          "borderLeftColor": "#bdc6cf",
+          "borderLeftWidth": 1,
+        },
         false,
         false,
         false,
@@ -137,9 +142,10 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
           "flex": 1,
         },
         false,
+        false,
         Object {
-          "borderBottomRightRadius": 0,
-          "borderTopRightRadius": 0,
+          "borderBottomRightRadius": 3,
+          "borderTopRightRadius": 3,
         },
         false,
         false,
@@ -213,12 +219,13 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
         },
         Object {
           "borderRightColor": "#bdc6cf",
-          "borderRightWidth": 1,
+          "borderRightWidth": 0,
         },
         false,
+        false,
         Object {
-          "borderBottomLeftRadius": 0,
-          "borderTopLeftRadius": 0,
+          "borderBottomLeftRadius": 3,
+          "borderTopLeftRadius": 3,
         },
         false,
       ]
@@ -267,6 +274,10 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
           "borderRightColor": "#bdc6cf",
           "borderRightWidth": 1,
         },
+        Object {
+          "borderLeftColor": "#bdc6cf",
+          "borderLeftWidth": 1,
+        },
         false,
         false,
         false,
@@ -313,10 +324,11 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
           "flex": 1,
         },
         false,
+        false,
         Object {
           "backgroundColor": "red",
-          "borderBottomRightRadius": 0,
-          "borderTopRightRadius": 0,
+          "borderBottomRightRadius": 3,
+          "borderTopRightRadius": 3,
         },
         false,
         false,
@@ -388,12 +400,13 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
         },
         Object {
           "borderRightColor": "#bdc6cf",
-          "borderRightWidth": 1,
+          "borderRightWidth": 0,
         },
         false,
+        false,
         Object {
-          "borderBottomLeftRadius": 0,
-          "borderTopLeftRadius": 0,
+          "borderBottomLeftRadius": 3,
+          "borderTopLeftRadius": 3,
         },
         false,
       ]
@@ -441,6 +454,10 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
         Object {
           "borderRightColor": "#bdc6cf",
           "borderRightWidth": 1,
+        },
+        Object {
+          "borderLeftColor": "#bdc6cf",
+          "borderLeftWidth": 1,
         },
         false,
         false,
@@ -494,9 +511,10 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
           "flex": 1,
         },
         false,
+        false,
         Object {
-          "borderBottomRightRadius": 0,
-          "borderTopRightRadius": 0,
+          "borderBottomRightRadius": 3,
+          "borderTopRightRadius": 3,
         },
         false,
         false,
@@ -568,12 +586,13 @@ exports[`ButtonGroup Component should render with button.element 1`] = `
         },
         Object {
           "borderRightColor": "red",
-          "borderRightWidth": 300,
+          "borderRightWidth": 0,
         },
         false,
+        false,
         Object {
-          "borderBottomLeftRadius": 0,
-          "borderTopLeftRadius": 0,
+          "borderBottomLeftRadius": 3,
+          "borderTopLeftRadius": 3,
         },
         false,
       ]
@@ -605,8 +624,12 @@ exports[`ButtonGroup Component should render with button.element 1`] = `
         },
         false,
         Object {
-          "borderBottomRightRadius": 0,
-          "borderTopRightRadius": 0,
+          "borderLeftColor": "red",
+          "borderLeftWidth": 300,
+        },
+        Object {
+          "borderBottomRightRadius": 3,
+          "borderTopRightRadius": 3,
         },
         false,
         false,
@@ -663,12 +686,13 @@ exports[`ButtonGroup Component should render without issues 1`] = `
         },
         Object {
           "borderRightColor": "#bdc6cf",
-          "borderRightWidth": 1,
+          "borderRightWidth": 0,
         },
         false,
+        false,
         Object {
-          "borderBottomLeftRadius": 0,
-          "borderTopLeftRadius": 0,
+          "borderBottomLeftRadius": 3,
+          "borderTopLeftRadius": 3,
         },
         false,
       ]
@@ -717,6 +741,10 @@ exports[`ButtonGroup Component should render without issues 1`] = `
           "borderRightColor": "#bdc6cf",
           "borderRightWidth": 1,
         },
+        Object {
+          "borderLeftColor": "#bdc6cf",
+          "borderLeftWidth": 1,
+        },
         false,
         false,
         false,
@@ -763,9 +791,10 @@ exports[`ButtonGroup Component should render without issues 1`] = `
           "flex": 1,
         },
         false,
+        false,
         Object {
-          "borderBottomRightRadius": 0,
-          "borderTopRightRadius": 0,
+          "borderBottomRightRadius": 3,
+          "borderTopRightRadius": 3,
         },
         false,
         false,


### PR DESCRIPTION
ref: https://github.com/react-native-training/react-native-elements/issues/364

There is a bug left…
It’s only happen if you juste have 2 buttons on your buttonGroup, the border will still be missing.
Because the 2 buttons will have a borderRadius, so the border will not be displayed…

Or we can wait the fix by react-native ([issue](https://github.com/facebook/react-native/issues/8236))

(PS: I put the default radius of start & end buttons to 3, like the container radius)