### PR TITLE
Fix some example images not showing up in docs (Header, Slider, SwipeDeck)

### DIFF
--- a/docs/API/header.md
+++ b/docs/API/header.md
@@ -1,6 +1,4 @@
-#### Header Component
-
-<img src="../../docs/images/header.png" width="500" >
+![Header](https://raw.githubusercontent.com/react-native-training/react-native-elements/master/docs/images/header.png)
 
 ### Header with default components
 

--- a/docs/API/slider.md
+++ b/docs/API/slider.md
@@ -1,4 +1,4 @@
-<img alt="slider-component" src="../images/slider_screenshot.png" width="450">
+![Slider](https://raw.githubusercontent.com/react-native-training/react-native-elements/master/docs/images/slider_screenshot.png)
 
 A pure JavaScript <Slider> component for react-native. It is a drop-in replacement for Slider.
 

--- a/docs/API/swipedeck.md
+++ b/docs/API/swipedeck.md
@@ -4,7 +4,7 @@ An SwipeDeck component that provides [Tinder Cards](https://github.com/Monte9/re
 
 ### Demo
 
-![Demo gif](http://i.imgur.com/d8FxHk2.gifv)
+![SwipeDeck](https://i.imgur.com/d8FxHk2.gif)
 
 ```js
 import { SwipeDeck } from 'react-native-elements';


### PR DESCRIPTION
This fixes https://github.com/react-native-training/react-native-elements/issues/435 and also example images for Slider and SwipeDeck that weren't showing up.