### PR TITLE
Fixes invalid API doc which generates a RN warning

### DIFF
--- a/docs/API/header.md
+++ b/docs/API/header.md
@@ -8,9 +8,9 @@ For quick setup we provide default components, which are React Native Elements I
 
 ```js
 <Header
-  leftComponent={{ icon: 'menu', style: { color: '#fff'} }}
+  leftComponent={{ icon: 'menu', color: '#fff' }}
   centerComponent={{ text: 'MY TITLE', style: { color: '#fff' } }} 
-  rightComponent={{ icon: 'home', style: { color: '#fff'} }}
+  rightComponent={{ icon: 'home', color: '#fff' }}
 />
 ```
 


### PR DESCRIPTION
If you copy and paste the first example it will generate the follow warning: 

"Warning: Failed prop type: Invalid props.style key `color` supplied to `View`."

This minor fix corrects the issue.