### PR TITLE
Fix mix of import and module.exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ import Rating from './rating/Rating';
 import SwipeDeck from './swipedeck/SwipeDeck';
 import Header from './header/Header';
 
-const Elements = {
+export {
   Badge,
   Button,
   ButtonGroup,
@@ -63,5 +63,3 @@ const Elements = {
   SwipeDeck,
   Header,
 };
-
-module.exports = Elements; // eslint-disable-line no-undef


### PR DESCRIPTION
Build with webpack will raise `Cannot assign to read only property 'exports' of object '#<Object>' (mix require and export)`, see https://github.com/webpack/webpack/issues/4039#issuecomment-273804003.