### PR TITLE
fix autoresize for multiline text-inputs

### DIFF
--- a/src/form/FormInput.js
+++ b/src/form/FormInput.js
@@ -68,11 +68,11 @@ const styles = StyleSheet.create({
   input: {
     ...Platform.select({
       android: {
-        height: 46,
+        minHeight: 46,
         width: width - 30,
       },
       ios: {
-        height: 36,
+        minHeight: 36,
         width: width,
       },
     }),

--- a/src/form/__tests__/__snapshots__/FormInput.js.snap
+++ b/src/form/__tests__/__snapshots__/FormInput.js.snap
@@ -20,7 +20,7 @@ exports[`FormInput Component should render without issues 1`] = `
         Object {
           "color": "#86939e",
           "fontSize": 17.5,
-          "height": 36,
+          "minHeight": 36,
           "width": 750,
         },
         undefined,


### PR DESCRIPTION
I found bug with autoresize multiline text-input. Here is small fix for it.

Just try to write few lines of text in this input:
```js
<FormInput multiline />
```
You can see that it isn't resizing, when RN `<TextInput />` is.