### PR TITLE
fix for touchable swipedeck

### DIFF
--- a/src/swipedeck/SwipeDeck.js
+++ b/src/swipedeck/SwipeDeck.js
@@ -24,6 +24,10 @@ export default class SwipeDeck extends Component {
     const position = new Animated.ValueXY();
 
     const panResponder = PanResponder.create({
+      // ignore touch gestures to fix
+      onMoveShouldSetPanResponderCapture: (e, gesture) => {
+        return Math.abs(gesture.dx) > 50;
+      },
       onStartShouldSetPanResponder: () => true,
       onPanResponderMove: (event, gesture) => {
         position.setValue({ x: gesture.dx, y: gesture.dy });

--- a/src/swipedeck/SwipeDeck.js
+++ b/src/swipedeck/SwipeDeck.js
@@ -11,6 +11,7 @@ import {
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const SWIPE_THRESHOLD = 0.4 * SCREEN_WIDTH;
+const MOVE_THRESHOLD = 50;
 
 export default class SwipeDeck extends Component {
   static defaultProps = {
@@ -26,7 +27,7 @@ export default class SwipeDeck extends Component {
     const panResponder = PanResponder.create({
       // ignore touch and handle only move-gestures
       onMoveShouldSetPanResponderCapture: (e, gesture) => {
-        return Math.abs(gesture.dx) > 50;
+        return Math.abs(gesture.dx) > MOVE_THRESHOLD;
       },
       onStartShouldSetPanResponder: () => true,
       onPanResponderMove: (event, gesture) => {

--- a/src/swipedeck/SwipeDeck.js
+++ b/src/swipedeck/SwipeDeck.js
@@ -24,7 +24,7 @@ export default class SwipeDeck extends Component {
     const position = new Animated.ValueXY();
 
     const panResponder = PanResponder.create({
-      // ignore touch gestures to fix
+      // ignore touch and handle only move-gestures
       onMoveShouldSetPanResponderCapture: (e, gesture) => {
         return Math.abs(gesture.dx) > 50;
       },


### PR DESCRIPTION
I found one more bug: `<SwipeDeck />` ignores move-gestures if card is `<TouchableOpacity />`.

```
<SwipeDeck
  data={cards}
  renderCard={this.renderCard}
  onSwipeLeft={() => console.log('to repeat')}
  onSwipeRight={() => console.log('known')}
/>
```

```
// Card
<TouchableOpacity
  onPress={() => this.setState({
    isFlipped: !this.state.isFlipped
  })}
>
  <Text>{title}</Text>
  { isFlipped && <Text>{content}</Text> }
</TouchableOpacity>
```

Here is small fix:
![ezgif-1-f083c919a0](https://user-images.githubusercontent.com/1410106/27751557-92efaf6a-5de5-11e7-8fd6-4ab5dbe63d84.gif)

