### PR TITLE
Allow containerBorderRadius to equal zero for ButtonGroup

### DIFF
--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -40,6 +40,7 @@ const ButtonGroup = props => {
       {...attributes}
     >
       {buttons.map((button, i) => {
+        const containerRadius = !isNaN(containerBorderRadius) ? containerBorderRadius : 3;
         return (
           <Component
             activeOpacity={activeOpacity}
@@ -68,12 +69,12 @@ const ButtonGroup = props => {
               },
               i === buttons.length - 1 && {
                 ...lastBorderStyle,
-                borderTopRightRadius: containerBorderRadius || 3,
-                borderBottomRightRadius: containerBorderRadius || 3,
+                borderTopRightRadius: containerRadius,
+                borderBottomRightRadius: containerRadius,
               },
               i === 0 && {
-                borderTopLeftRadius: containerBorderRadius || 3,
-                borderBottomLeftRadius: containerBorderRadius || 3,
+                borderTopLeftRadius: containerRadius,
+                borderBottomLeftRadius: ccontainerRadius,
               },
               selectedIndex === i && {
                 backgroundColor: selectedBackgroundColor || 'white',

--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -74,7 +74,7 @@ const ButtonGroup = props => {
               },
               i === 0 && {
                 borderTopLeftRadius: containerRadius,
-                borderBottomLeftRadius: ccontainerRadius,
+                borderBottomLeftRadius: containerRadius,
               },
               selectedIndex === i && {
                 backgroundColor: selectedBackgroundColor || 'white',


### PR DESCRIPTION
Currently, a fix in ButtonGroup allows passing a containerBorderRadius prop. The current implementation uses this: `containerBorderRadius || 3`, which means that if containerBorderRadius is 0, then it will display 3, not 0.

This is important because displaying a border radius when the background is a different color causes a visual artifact (pictured below, notice the white triangles in the corner).

<img width="186" alt="screen shot 2017-07-12 at 10 29 52 am" src="https://user-images.githubusercontent.com/1566400/28122749-1dfc15f2-66ed-11e7-9fbf-19e3732ad1b7.png">
