### PR TITLE
WIP: pr/ButtonGroup-DisableSelected

### DIFF
--- a/docs/API/button_group.md
+++ b/docs/API/button_group.md
@@ -77,3 +77,4 @@ render () {
 | selectedTextStyle | inherited styling | object (style) | specify specific styling for text in the selected state (optional)|
 | innerBorderStyle | inherited styling | object { width, color } | update the styling of the interior border of the list of buttons (optional) |
 | underlayColor | white | string | specify underlayColor for TouchableHighlight (optional) |
+| disableSelected | false | boolean | disables the currently selected button if true |

--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -31,6 +31,7 @@ const ButtonGroup = props => {
     onShowUnderlay,
     setOpacityTo,
     containerBorderRadius,
+    disableSelected,
     ...attributes
   } = props;
 
@@ -49,6 +50,7 @@ const ButtonGroup = props => {
             onHideUnderlay={onHideUnderlay}
             onShowUnderlay={onShowUnderlay}
             underlayColor={underlayColor || '#ffffff'}
+            disabled={disableSelected && i === selectedIndex ? true : false}
             onPress={onPress ? () => onPress(i) : () => {}}
             key={i}
             style={[
@@ -162,6 +164,7 @@ ButtonGroup.propTypes = {
   buttonStyle: ViewPropTypes.style,
   selectedBackgroundColor: PropTypes.string,
   containerBorderRadius: PropTypes.number,
+  disableSelected: PropTypes.bool,
 };
 
 export default ButtonGroup;

--- a/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
+++ b/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
@@ -25,6 +25,7 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
 >
   <TouchableHighlight
     activeOpacity={0.85}
+    disabled={false}
     onPress={[Function]}
     style={
       Array [
@@ -80,6 +81,7 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
   </TouchableHighlight>
   <TouchableHighlight
     activeOpacity={0.85}
+    disabled={false}
     onPress={[Function]}
     style={
       Array [
@@ -135,6 +137,7 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
   </TouchableHighlight>
   <TouchableHighlight
     activeOpacity={0.85}
+    disabled={false}
     onPress={[Function]}
     style={
       Array [
@@ -211,6 +214,7 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
 >
   <TouchableHighlight
     activeOpacity={0.85}
+    disabled={false}
     onPress={[Function]}
     style={
       Array [
@@ -264,6 +268,7 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
   </TouchableHighlight>
   <TouchableHighlight
     activeOpacity={0.85}
+    disabled={false}
     onPress={[Function]}
     style={
       Array [
@@ -317,6 +322,7 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
   </TouchableHighlight>
   <TouchableHighlight
     activeOpacity={0.85}
+    disabled={false}
     onPress={[Function]}
     style={
       Array [
@@ -392,6 +398,7 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
 >
   <TouchableHighlight
     activeOpacity={0.85}
+    disabled={false}
     onPress={[Function]}
     style={
       Array [
@@ -445,6 +452,7 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
   </TouchableHighlight>
   <TouchableHighlight
     activeOpacity={0.85}
+    disabled={false}
     onPress={[Function]}
     style={
       Array [
@@ -504,6 +512,7 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
   </TouchableHighlight>
   <TouchableHighlight
     activeOpacity={0.85}
+    disabled={false}
     onPress={[Function]}
     style={
       Array [
@@ -578,6 +587,7 @@ exports[`ButtonGroup Component should render with button.element 1`] = `
 >
   <TouchableHighlight
     activeOpacity={0.85}
+    disabled={false}
     onPress={[Function]}
     style={
       Array [
@@ -616,6 +626,7 @@ exports[`ButtonGroup Component should render with button.element 1`] = `
   </TouchableHighlight>
   <TouchableHighlight
     activeOpacity={0.85}
+    disabled={false}
     onPress={[Function]}
     style={
       Array [
@@ -678,6 +689,7 @@ exports[`ButtonGroup Component should render without issues 1`] = `
 >
   <TouchableHighlight
     activeOpacity={0.85}
+    disabled={false}
     onPress={[Function]}
     style={
       Array [
@@ -731,6 +743,7 @@ exports[`ButtonGroup Component should render without issues 1`] = `
   </TouchableHighlight>
   <TouchableHighlight
     activeOpacity={0.85}
+    disabled={false}
     onPress={[Function]}
     style={
       Array [
@@ -784,6 +797,7 @@ exports[`ButtonGroup Component should render without issues 1`] = `
   </TouchableHighlight>
   <TouchableHighlight
     activeOpacity={0.85}
+    disabled={false}
     onPress={[Function]}
     style={
       Array [


### PR DESCRIPTION
As I wasn't sure what practices you follow for snapshots, PR does not include updated snapshots so 5 tests are failing. 

If update to snapshots is not desired, line 53 could be modified to not output "disabled={false}" by default. 

Happy to resubmit with updated snapshots or modified to avoid problem if preference is provided.



  ● ButtonGroup Component › should render without issues

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - Snapshot
    + Received
    
    @@ -18,10 +18,11 @@
         ]
       }
     >
       <TouchableHighlight
         activeOpacity={0.85}
    +    disabled={false}
         onPress={[Function]}
         style={
           Array [
             Object {
               "flex": 1,
    @@ -71,10 +72,11 @@
           </TextElement>
         </View>
       </TouchableHighlight>
       <TouchableHighlight
         activeOpacity={0.85}
    +    disabled={false}
         onPress={[Function]}
         style={
           Array [
             Object {
               "flex": 1,
    @@ -124,10 +126,11 @@
           </TextElement>
         </View>
       </TouchableHighlight>
       <TouchableHighlight
         activeOpacity={0.85}
    +    disabled={false}
         onPress={[Function]}
         style={
           Array [
             Object {
               "flex": 1,
      
      at Object.<anonymous> (src/buttons/__tests__/ButtonGroup.js:14:47)

  ● ButtonGroup Component › should have onPress event

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - Snapshot
    + Received
    
    @@ -20,10 +20,11 @@
         ]
       }
     >
       <TouchableHighlight
         activeOpacity={0.85}
    +    disabled={false}
         onPress={[Function]}
         style={
           Array [
             Object {
               "flex": 1,
    @@ -75,10 +76,11 @@
           </TextElement>
         </View>
       </TouchableHighlight>
       <TouchableHighlight
         activeOpacity={0.85}
    +    disabled={false}
         onPress={[Function]}
         style={
           Array [
             Object {
               "flex": 1,
    @@ -130,10 +132,11 @@
           </TextElement>
         </View>
       </TouchableHighlight>
       <TouchableHighlight
         activeOpacity={0.85}
    +    disabled={false}
         onPress={[Function]}
         style={
           Array [
             Object {
               "flex": 1,
      
      at Object.<anonymous> (src/buttons/__tests__/ButtonGroup.js:29:47)

  ● ButtonGroup Component › should render selectedIndex

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - Snapshot
    + Received
    
    @@ -18,10 +18,11 @@
         ]
       }
     >
       <TouchableHighlight
         activeOpacity={0.85}
    +    disabled={false}
         onPress={[Function]}
         style={
           Array [
             Object {
               "flex": 1,
    @@ -71,10 +72,11 @@
           </TextElement>
         </View>
       </TouchableHighlight>
       <TouchableHighlight
         activeOpacity={0.85}
    +    disabled={false}
         onPress={[Function]}
         style={
           Array [
             Object {
               "flex": 1,
    @@ -130,10 +132,11 @@
           </TextElement>
         </View>
       </TouchableHighlight>
       <TouchableHighlight
         activeOpacity={0.85}
    +    disabled={false}
         onPress={[Function]}
         style={
           Array [
             Object {
               "flex": 1,
      
      at Object.<anonymous> (src/buttons/__tests__/ButtonGroup.js:43:47)

  ● ButtonGroup Component › should render with button.element

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - Snapshot
    + Received
    
    @@ -18,10 +18,11 @@
         ]
       }
     >
       <TouchableHighlight
         activeOpacity={0.85}
    +    disabled={false}
         onPress={[Function]}
         style={
           Array [
             Object {
               "flex": 1,
    @@ -56,10 +57,11 @@
           <Text />
         </View>
       </TouchableHighlight>
       <TouchableHighlight
         activeOpacity={0.85}
    +    disabled={false}
         onPress={[Function]}
         style={
           Array [
             Object {
               "flex": 1,
      
      at Object.<anonymous> (src/buttons/__tests__/ButtonGroup.js:55:47)

  ● ButtonGroup Component › should render lastButtonStyle

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - Snapshot
    + Received
    
    @@ -18,10 +18,11 @@
         ]
       }
     >
       <TouchableHighlight
         activeOpacity={0.85}
    +    disabled={false}
         onPress={[Function]}
         style={
           Array [
             Object {
               "flex": 1,
    @@ -71,10 +72,11 @@
           </TextElement>
         </View>
       </TouchableHighlight>
       <TouchableHighlight
         activeOpacity={0.85}
    +    disabled={false}
         onPress={[Function]}
         style={
           Array [
             Object {
               "flex": 1,
    @@ -124,10 +126,11 @@
           </TextElement>
         </View>
       </TouchableHighlight>
       <TouchableHighlight
         activeOpacity={0.85}
    +    disabled={false}
         onPress={[Function]}
         style={
           Array [
             Object {
               "flex": 1,
      
      at Object.<anonymous> (src/buttons/__tests__/ButtonGroup.js:67:47)


Snapshot Summary
 › 5 snapshot tests failed in 1 test suite. Inspect your code changes or run with `npm test -- -u` to update them.

Test Suites: 1 failed, 28 passed, 29 total
Tests:       5 failed, 126 passed, 131 total
Snapshots:   5 failed, 78 passed, 83 total
Time:        6.768s, estimated 14s
Ran all test suites.
