### PR TITLE
Add shake animation to Input v1

### DIFF
--- a/example/src/views/login/screen3.js
+++ b/example/src/views/login/screen3.js
@@ -94,8 +94,8 @@ export default class LoginScreen2 extends Component {
       LayoutAnimation.easeInEaseOut();
       this.setState({
         isLoading: false,
-        isEmailValid: this.validateEmail(email),
-        isPasswordValid: password.length >= 8
+        isEmailValid: this.validateEmail(email) || this.emailInput.shake(),
+        isPasswordValid: password.length >= 8 || this.passwordInput.shake(),
       });
     }, 1500);
   }
@@ -112,9 +112,9 @@ export default class LoginScreen2 extends Component {
       LayoutAnimation.easeInEaseOut();
       this.setState({
         isLoading: false,
-        isEmailValid: this.validateEmail(email),
-        isPasswordValid: password.length >= 8,
-        isConfirmationValid: password == passwordConfirmation,
+        isEmailValid: this.validateEmail(email) || this.emailInput.shake(),
+        isPasswordValid: password.length >= 8 || this.passwordInput.shake(),
+        isConfirmationValid: password == passwordConfirmation || this.confirmationInput.shake(),
       });
     }, 1500);
   }
@@ -217,7 +217,7 @@ export default class LoginScreen2 extends Component {
                     inputStyle={{marginLeft: 10}}
                     placeholder={'Password'}
                     ref={input => this.passwordInput = input}
-                    onSubmitEditing={() => isSignUpPage ? this.passwordConfirmationInput.focus() : this.login()}
+                    onSubmitEditing={() => isSignUpPage ? this.confirmationInput.focus() : this.login()}
                     onChangeText={(password) => this.setState({password})}
                     displayError={!isPasswordValid}
                     errorMessage='Please enter at least 8 characters'
@@ -243,7 +243,7 @@ export default class LoginScreen2 extends Component {
                       containerStyle={{marginTop: 16, borderBottomColor: 'rgba(0, 0, 0, 0.38)'}}
                       inputStyle={{marginLeft: 10}}
                       placeholder={'Confirm password'}
-                      ref={input => this.passwordConfirmationInput = input}
+                      ref={input => this.confirmationInput = input}
                       onSubmitEditing={this.signUp}
                       onChangeText={passwordConfirmation => this.setState({ passwordConfirmation })}
                       displayError={!isConfirmationValid}

--- a/example/v1/input/Input.js
+++ b/example/v1/input/Input.js
@@ -37,7 +37,10 @@ class Input extends Component {
 
   shake() {
     const { shakeAnimationValue } = this;
+    
     shakeAnimationValue.setValue(0);
+    // Animation duration based on Material Design
+    // https://material.io/guidelines/motion/duration-easing.html#duration-easing-common-durations
     Animated.timing(shakeAnimationValue, {
       duration: 375,
       toValue: 3,

--- a/example/v1/input/Input.js
+++ b/example/v1/input/Input.js
@@ -1,13 +1,28 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
-import { StyleSheet, Text, View, TextInput, Dimensions } from 'react-native';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TextInput,
+  Dimensions,
+  Animated,
+  Easing,
+} from 'react-native';
 
 import ViewPropTypes from '../config/ViewPropTypes';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 
 class Input extends Component {
+
+  componentWillMount() {
+    this.shake = this.shake.bind(this);
+    this.shakeAnimationValue = new Animated.Value(0);
+    this.props.shake && this.shake();
+  }
+
   focus() {
     this.input.focus();
   }
@@ -18,6 +33,16 @@ class Input extends Component {
 
   clear() {
     this.input.clear();
+  }
+
+  shake() {
+    const { shakeAnimationValue } = this;
+    shakeAnimationValue.setValue(0);
+    Animated.timing(shakeAnimationValue, {
+      duration: 375,
+      toValue: 3,
+      ease: Easing.bounce,
+    }).start();
   }
 
   render() {
@@ -31,14 +56,19 @@ class Input extends Component {
       errorMessage,
       ...attributes
     } = this.props;
+    const translateX = this.shakeAnimationValue.interpolate({
+      inputRange: [0, 0.5, 1, 1.5, 2, 2.5, 3],
+      outputRange: [0, -15, 0, 15, 0, -15, 0],
+    });
 
     return (
       <View>
-        <View
+        <Animated.View
           style={[
             styles.container,
             { width: SCREEN_WIDTH - 100, height: 40 },
             containerStyle,
+            { transform: [{ translateX }] },
           ]}
         >
           {icon &&
@@ -57,7 +87,7 @@ class Input extends Component {
             ]}
             {...attributes}
           />
-        </View>
+        </Animated.View>
         {displayError &&
           <Text style={[styles.error, errorStyle && errorStyle]}>
             {errorMessage || 'Error!'}
@@ -75,6 +105,7 @@ Input.propTypes = {
 
   inputStyle: PropTypes.object,
 
+  shake: PropTypes.any,
   displayError: PropTypes.bool,
   errorStyle: PropTypes.object,
   errorMessage: PropTypes.string,


### PR DESCRIPTION
# Purpose

Hey !
Here is the shake input animation that @martinezguillaume did, but on the v1 input. 🔥 

I replicated the shake props logic, because I think using redux and stateless component it can be useful to pass directly the `error` object returned from an API call to the input, and it will shake itself if the `error` is `!==` from the previous one (and not falsy obviously).

I updated the `screen3`, as it is already animated it will fit perfectly.

Let me know if some changes are required ✌️ 

# Example

![juil -29-2017 10-38-57](https://user-images.githubusercontent.com/17592779/28743467-f3e59282-744a-11e7-9e80-6a95ce101cb9.gif)

(It is quite laggy on a gif tho...)