### PR TITLE
Update Tile.js: adding 'numberOfLines' prop

### DIFF
--- a/src/tile/Tile.js
+++ b/src/tile/Tile.js
@@ -31,6 +31,7 @@ const Tile = props => {
     imageContainerStyle,
     containerStyle,
     contentContainerStyle,
+    titleNumberOfLines,
     ...attributes
   } = props;
 
@@ -120,7 +121,7 @@ const Tile = props => {
           contentContainerStyle && contentContainerStyle,
         ]}
       >
-        <Text h4 style={[styles.text, titleStyle && titleStyle]}>
+        <Text h4 style={[styles.text, titleStyle && titleStyle]} numberOfLines={titleNumberOfLines>
           {title}
         </Text>
         {children}
@@ -147,6 +148,7 @@ Tile.propTypes = {
   featured: PropTypes.bool,
   children: PropTypes.any,
   contentContainerStyle: ViewPropTypes.style,
+  titleNumberOfLines: PropTypes.number,
 };
 
 export default Tile;

--- a/src/tile/Tile.js
+++ b/src/tile/Tile.js
@@ -121,7 +121,7 @@ const Tile = props => {
           contentContainerStyle && contentContainerStyle,
         ]}
       >
-        <Text h4 style={[styles.text, titleStyle && titleStyle]} numberOfLines={titleNumberOfLines>
+        <Text h4 style={[styles.text, titleStyle && titleStyle]} numberOfLines={titleNumberOfLines}>
           {title}
         </Text>
         {children}


### PR DESCRIPTION
Adding 'numberOfLines' prop for Text component (used to display title) in Tile.js.
So users can set numberOfLines for their 'title' text.

![image](https://user-images.githubusercontent.com/19988985/29650523-144ed690-88ce-11e7-908d-9a490045656d.png)
