### PR TITLE
fix(FormInput): follow the official doc with keyboardType

### DIFF
--- a/docs/API/lists.md
+++ b/docs/API/lists.md
@@ -251,7 +251,7 @@ styles = StyleSheet.create({
 | textInputAutoCorrect | | boolean | Can tell TextInput to automatically capitalize certain characters. |
 | textInputAutoFocus | | boolean | If true, focuses the input on componentDidMount. The default value is false. |
 | textInputEditable | | boolean | If false, text is not editable. The default value is true. |
-| textInputKeyboardType | | string | Can be one of the following: 'default', 'email-address', 'numeric', 'phone-pad', 'ascii-capable', 'numbers-and-punctuation', 'url', 'number-pad', 'name-phone-pad', 'decimal-pad', 'twitter', 'web-search' |
+| keyboardType | | string | Can be one of the following: 'default', 'email-address', 'numeric', 'phone-pad', 'ascii-capable', 'numbers-and-punctuation', 'url', 'number-pad', 'name-phone-pad', 'decimal-pad', 'twitter', 'web-search' |
 | textInputMaxLength | | number | Limits the maximum number of characters that can be entered. |
 | textInputMultiline | | boolean | If true, the text input can be multiple lines. The default value is false. |
 | textInputOnChangeText | | function | Callback that is called when the text input's text changes. Changed text is passed as an argument to the callback handler. |

--- a/src/list/ListItem.js
+++ b/src/list/ListItem.js
@@ -65,7 +65,7 @@ const ListItem = props => {
     textInputAutoCorrect,
     textInputAutoFocus,
     textInputEditable,
-    textInputKeyboardType,
+    keyboardType,
     textInputMaxLength,
     textInputMultiline,
     textInputOnChangeText,
@@ -201,7 +201,7 @@ const ListItem = props => {
               autoCorrect={textInputAutoCorrect}
               autoFocus={textInputAutoFocus}
               editable={textInputEditable}
-              keyboardType={textInputKeyboardType}
+              keyboardType={keyboardType}
               maxLength={textInputMaxLength}
               multiline={textInputMultiline}
               onChangeText={textInputOnChangeText}
@@ -300,7 +300,7 @@ ListItem.propTypes = {
   textInputAutoCorrect: PropTypes.bool,
   textInputAutoFocus: PropTypes.bool,
   textInputEditable: PropTypes.bool,
-  textInputKeyboardType: PropTypes.oneOf([
+  keyboardType: PropTypes.oneOf([
     'default',
     'email-address',
     'numeric',


### PR DESCRIPTION
According to the spec
https://facebook.github.io/react-native/docs/textinput.html#keyboardtype

Here is an example with a `keyboardType={'email-address'}`

__Before:__
![screen shot 2017-08-25 at 16 16 35](https://user-images.githubusercontent.com/360936/29720362-a8bfef74-89b1-11e7-9bfc-ff3717790a32.png)

__After:__
![screen shot 2017-08-25 at 16 16 46](https://user-images.githubusercontent.com/360936/29720396-c67e1d2e-89b1-11e7-95bc-f3194a676faa.png)

The email keyboard appears 🎉 