### PR TITLE
Fix(Button): Border Radius was not applied to view container.

### DIFF
--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -111,7 +111,8 @@ const Button = props => {
 
   const baseFont = {
     color: (textStyle && textStyle.color) || color || stylesObject.text.color,
-    size: (textStyle && textStyle.fontSize) ||
+    size:
+      (textStyle && textStyle.fontSize) ||
       fontSize ||
       (!large && stylesObject.smallFont.fontSize) ||
       stylesObject.text.fontSize,
@@ -127,7 +128,12 @@ const Button = props => {
 
   return (
     <View
-      style={[styles.container, raised && styles.raised, containerViewStyle]}
+      style={[
+        styles.container,
+        raised && styles.raised,
+        containerViewStyle,
+        borderRadius && { borderRadius },
+      ]}
     >
       <Component
         underlayColor={underlayColor || 'transparent'}

--- a/src/buttons/__tests__/__snapshots__/Button.js.snap
+++ b/src/buttons/__tests__/__snapshots__/Button.js.snap
@@ -11,6 +11,7 @@ exports[`Button Component should render with custom icon component 1`] = `
       },
       undefined,
       undefined,
+      undefined,
     ]
   }
 >
@@ -97,6 +98,7 @@ exports[`Button Component should render with default icon 1`] = `
         "marginLeft": 15,
         "marginRight": 15,
       },
+      undefined,
       undefined,
       undefined,
     ]
@@ -188,6 +190,7 @@ exports[`Button Component should render with icon type 1`] = `
       },
       undefined,
       undefined,
+      undefined,
     ]
   }
 >
@@ -273,6 +276,7 @@ exports[`Button Component should render without issues 1`] = `
         "marginLeft": 15,
         "marginRight": 15,
       },
+      undefined,
       undefined,
       undefined,
     ]


### PR DESCRIPTION
[issue #535](https://github.com/react-native-training/react-native-elements/issues/535), where to have a clean button you would also need to apply the
border radius value to the containerViewStyle prop so that the containing
view would wrap the rounded button. Test snapshots were updated to reflect
the change.