### PR TITLE
Rename iconLeft to leftIcon in button docs api

### DIFF
--- a/docs/API/buttons.md
+++ b/docs/API/buttons.md
@@ -46,7 +46,7 @@ import { Button } from 'react-native-elements'
 | large | false | boolean | makes button large |
 | fontFamily | System font (iOS), Sans Serif (android) | string | specify different font family |
 | fontWeight | none | string | specify font weight for title (optional) |
-| iconLeft or icon | {color: 'white'} | object {name: string, color: string, size: number, type: string (default is material, or choose one of material-community, simple-line-icon, zocial, font-awesome, octicon, ionicon, foundation, evilicon, or entypo), style: object(style)} | displays a centered icon (when no text) or to the left (with text). (can be used along with rightIcon as well) |
+| leftIcon or icon | {color: 'white'} | object {name: string, color: string, size: number, type: string (default is material, or choose one of material-community, simple-line-icon, zocial, font-awesome, octicon, ionicon, foundation, evilicon, or entypo), style: object(style)} | displays a centered icon (when no text) or to the left (with text). (can be used along with rightIcon as well) |
 | iconRight or rightIcon | none | object {name: string, color: string, size: number, type: string (default is material, or choose one of material-community, simple-line-icon, zocial, font-awesome, octicon, ionicon, foundation, evilicon, or entypo), style: object(style)} | displays a rightIcon (can be used along with leftIcon as well) |
 | iconComponent | MaterialIcon | React Native Component | Specify other icon component instead of default. The component will have all values from the icon prop |
 | onPress | none | function | onPress method (required) |


### PR DESCRIPTION
`iconLeft` is not a valid prop for Button. This should be `leftIcon`.