### PR TITLE
resizeMethod (Android) added to images

### DIFF
--- a/src/avatar/Avatar.js
+++ b/src/avatar/Avatar.js
@@ -40,6 +40,7 @@ const Avatar = props => {
     showEditButton,
     editButton,
     onEditPress,
+    resizeMethod,
     ...attributes
   } = props;
 
@@ -118,6 +119,7 @@ const Avatar = props => {
             styles.avatar,
             rounded && { borderRadius: width / 2 },
             avatarStyle && avatarStyle,
+            resizeMethod={resizeMethod}
           ]}
           source={source}
         />
@@ -220,6 +222,7 @@ const Avatar = props => {
 };
 
 const defaultProps = {
+  resizeMethod: 'auto',
   showEditButton: false,
   onEditPress: null,
   editButton: {
@@ -268,6 +271,7 @@ Avatar.propTypes = {
     underlayColor: PropTypes.string,
     style: ViewPropTypes.style,
   }),
+  resizeMethod: PropTypes.string
 };
 
 Avatar.defaultProps = defaultProps;

--- a/src/card/Card.js
+++ b/src/card/Card.js
@@ -33,6 +33,7 @@ const Card = props => {
     image,
     imageStyle,
     fontFamily,
+    resizeMethod,
     ...attributes
   } = props;
 
@@ -75,6 +76,7 @@ const Card = props => {
           <View style={imageWrapperStyle && imageWrapperStyle}>
             <BackgroundImage
               resizeMode="cover"
+              resizeMethod={resizeMethod}
               style={[{ width: null, height: 150 }, imageStyle && imageStyle]}
               source={image}
             >
@@ -128,6 +130,7 @@ Card.propTypes = {
   imageStyle: ViewPropTypes.style,
   imageWrapperStyle: ViewPropTypes.style,
   fontFamily: PropTypes.string,
+  resizeMethod: PropTypes.string,
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
**First of all, awesome work you guys are doing. Thank you!**

I have added a _resizeMethod_ prop to images on the Avatar and Card components as I don't think it is always necessary to handle image resizing straight away. My case is the user presses on the avatar which then lets the user choose a profile image. On success I replace the image on the avatar component.

If this image is quite large it causes a lag and then the app crashes. That is why i have added the _resizeMethod_ prop.

More details can be found here: https://facebook.github.io/react-native/docs/image.html#resizemethod 

Please note that this is **Android only** and it defaults to 'auto'.