### PR TITLE
fix(Tile): remove resizeMode warning message

### DIFF
--- a/src/tile/Tile.js
+++ b/src/tile/Tile.js
@@ -53,9 +53,11 @@ const Tile = props => {
     imageContainer: {
       alignItems: 'center',
       justifyContent: 'center',
-      resizeMode: 'cover',
       backgroundColor: '#ffffff',
       flex: 2,
+    },
+    imageStyle: {
+      resizeMode: 'cover',
     },
     text: {
       backgroundColor: 'rgba(0,0,0,0)',
@@ -105,6 +107,7 @@ const Tile = props => {
           styles.imageContainer,
           imageContainerStyle && imageContainerStyle,
         ]}
+        imageStyle={styles.imageStyle}
       >
         <View
           style={[
@@ -121,7 +124,11 @@ const Tile = props => {
           contentContainerStyle && contentContainerStyle,
         ]}
       >
-        <Text h4 style={[styles.text, titleStyle && titleStyle]} numberOfLines={titleNumberOfLines}>
+        <Text
+          h4
+          style={[styles.text, titleStyle && titleStyle]}
+          numberOfLines={titleNumberOfLines}
+        >
           {title}
         </Text>
         {children}

--- a/src/tile/__tests__/Tile.js
+++ b/src/tile/__tests__/Tile.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import Tile from '../Tile';
 
-describe('FeaturedTitle component', () => {
+describe('Tile component', () => {
   it('should render without issues', () => {
     const component = shallow(<Tile imageSrc={{ url: 'http://google.com' }} />);
 

--- a/src/tile/__tests__/__snapshots__/Tile.js.snap
+++ b/src/tile/__tests__/__snapshots__/Tile.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FeaturedTitle component should render featured tile 1`] = `
+exports[`Tile component should render featured tile 1`] = `
 <FeaturedTile
   caption="Some Caption Text"
   height={600}
@@ -14,7 +14,7 @@ exports[`FeaturedTitle component should render featured tile 1`] = `
 />
 `;
 
-exports[`FeaturedTitle component should render featured tile with icon 1`] = `
+exports[`Tile component should render featured tile with icon 1`] = `
 <FeaturedTile
   height={600}
   icon={
@@ -32,7 +32,7 @@ exports[`FeaturedTitle component should render featured tile with icon 1`] = `
 />
 `;
 
-exports[`FeaturedTitle component should render tile with icon 1`] = `
+exports[`Tile component should render tile with icon 1`] = `
 <TouchableOpacity
   activeOpacity={0.2}
   focusedOpacity={0.7}
@@ -49,6 +49,11 @@ exports[`FeaturedTitle component should render tile with icon 1`] = `
   }
 >
   <Image
+    imageStyle={
+      Object {
+        "resizeMode": "cover",
+      }
+    }
     source={
       Object {
         "url": "http://google.com",
@@ -61,7 +66,6 @@ exports[`FeaturedTitle component should render tile with icon 1`] = `
           "backgroundColor": "#ffffff",
           "flex": 2,
           "justifyContent": "center",
-          "resizeMode": "cover",
         },
         Object {
           "height": 70,
@@ -130,7 +134,7 @@ exports[`FeaturedTitle component should render tile with icon 1`] = `
 </TouchableOpacity>
 `;
 
-exports[`FeaturedTitle component should render without issues 1`] = `
+exports[`Tile component should render without issues 1`] = `
 <TouchableOpacity
   activeOpacity={0.2}
   focusedOpacity={0.7}
@@ -145,6 +149,11 @@ exports[`FeaturedTitle component should render without issues 1`] = `
   }
 >
   <Image
+    imageStyle={
+      Object {
+        "resizeMode": "cover",
+      }
+    }
     source={
       Object {
         "url": "http://google.com",
@@ -157,7 +166,6 @@ exports[`FeaturedTitle component should render without issues 1`] = `
           "backgroundColor": "#ffffff",
           "flex": 2,
           "justifyContent": "center",
-          "resizeMode": "cover",
         },
         undefined,
       ]


### PR DESCRIPTION
Closes #668 

Update Tile component to move the "resizeMode": "cover" from style to the new imageStyle prop so that there's no more warning message from ImageBackground