### PR TITLE
Fix horizontal alignment of ListItem elements

### DIFF
--- a/src/list/ListItem.js
+++ b/src/list/ListItem.js
@@ -112,7 +112,6 @@ const ListItem = props => {
               underlayColor={leftIconUnderlayColor}
               style={[
                 styles.iconStyle,
-                { flex: rightTitle && rightTitle !== '' ? 0.3 : 0.15 },
                 leftIconContainerStyle && leftIconContainerStyle,
               ]}
             >
@@ -398,12 +397,10 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   chevronContainer: {
-    flex: 0.15,
     alignItems: 'flex-end',
     justifyContent: 'center',
   },
   switchContainer: {
-    flex: 0.15,
     alignItems: 'flex-end',
     justifyContent: 'center',
     marginRight: 5,

--- a/src/list/__tests__/__snapshots__/ListItem.js.snap
+++ b/src/list/__tests__/__snapshots__/ListItem.js.snap
@@ -84,7 +84,6 @@ exports[`ListItem component should render with avatar 1`] = `
       style={
         Object {
           "alignItems": "flex-end",
-          "flex": 0.15,
           "justifyContent": "center",
         }
       }
@@ -140,9 +139,6 @@ exports[`ListItem component should render with left icon 1`] = `
             "alignItems": "center",
             "justifyContent": "center",
           },
-          Object {
-            "flex": 0.15,
-          },
           undefined,
         ]
       }
@@ -191,7 +187,6 @@ exports[`ListItem component should render with left icon 1`] = `
       style={
         Object {
           "alignItems": "flex-end",
-          "flex": 0.15,
           "justifyContent": "center",
         }
       }
@@ -269,7 +264,6 @@ exports[`ListItem component should render with left icon component 1`] = `
       style={
         Object {
           "alignItems": "flex-end",
-          "flex": 0.15,
           "justifyContent": "center",
         }
       }
@@ -421,7 +415,6 @@ exports[`ListItem component should render with textInput 1`] = `
       style={
         Object {
           "alignItems": "flex-end",
-          "flex": 0.15,
           "justifyContent": "center",
           "marginRight": 5,
         }
@@ -559,7 +552,6 @@ exports[`ListItem component should render with title and subtitle 1`] = `
       style={
         Object {
           "alignItems": "flex-end",
-          "flex": 0.15,
           "justifyContent": "center",
         }
       }
@@ -628,7 +620,6 @@ exports[`ListItem component should render without issues 1`] = `
       style={
         Object {
           "alignItems": "flex-end",
-          "flex": 0.15,
           "justifyContent": "center",
         }
       }


### PR DESCRIPTION
Associated Issue: #547 

This fixes an issue where lists with different types of list items (some with badges or switches, and some without) have titles that do not line up horizontally. 

As more elements are added to a `ListItem`, the `titleSubtitleContainer` (with flex: 1) changes size. This causes `LeftIconWrapper`, `chevronContainer`, and `switchContainer` (each with flex: 0.15) to scale to 0.15 the size of `titleSubtitleContainer` throwing off horizontal alignment of elements.

Removing these lines fixes title alignment issue as well as alignment of chevron or `rightIcon` when `rightTitle` or `textInput` is added.

Before:
![simulator screen shot - iphone 6 - 2017-10-26 at 15 51 36](https://user-images.githubusercontent.com/10087880/32058144-9198361a-ba69-11e7-875d-e043ad0537cc.png)

After:
![simulator screen shot - iphone 6 - 2017-10-26 at 15 52 21](https://user-images.githubusercontent.com/10087880/32058147-936d0c2c-ba69-11e7-829f-b096fadfbf6a.png)

The code I used to test: https://snack.expo.io/Skye7u10-