### PR TITLE
Corrected normalizeText for certain Android devices

### DIFF
--- a/src/helpers/normalizeText.js
+++ b/src/helpers/normalizeText.js
@@ -26,7 +26,7 @@ const deviceWidth = Dimensions.get('window').width;
 // console.log('normalizeText getPSFLS ->', layoutSize);
 
 const normalize = size => {
-  if (pixelRatio === 2) {
+  if (pixelRatio >= 2 && pixelRatio < 3) {
     // iphone 5s and older Androids
     if (deviceWidth < 360) {
       return size * 0.95;
@@ -40,8 +40,7 @@ const normalize = size => {
     }
     // older phablets
     return size * 1.25;
-  }
-  if (pixelRatio === 3) {
+  } else if (pixelRatio >= 3 && pixelRatio < 3.5) {
     // catch Android font scaling on small machines
     // where pixel ratio / font scale ratio => 3:3
     if (deviceWidth <= 360) {
@@ -59,8 +58,7 @@ const normalize = size => {
     // catch larger devices
     // ie iphone 6s plus / 7 plus / mi note 等等
     return size * 1.27;
-  }
-  if (pixelRatio === 3.5) {
+  } else if (pixelRatio >= 3.5) {
     // catch Android font scaling on small machines
     // where pixel ratio / font scale ratio => 3:3
     if (deviceWidth <= 360) {
@@ -77,9 +75,9 @@ const normalize = size => {
     }
     // catch larger phablet devices
     return size * 1.4;
-  }
-  // if older device ie pixelRatio !== 2 || 3 || 3.5
-  return size;
+  } else
+    // if older device ie pixelRatio !== 2 || 3 || 3.5
+    return size;
 };
 
 module.exports = normalize; // eslint-disable-line no-undef


### PR DESCRIPTION
As per [this issue](https://github.com/react-native-training/react-native-elements/issues/659), a bug was found in which certain devices will return the pixel ratio as a float, breaking the font size normalization function. This PR fixes that.