### PR TITLE
Fix ListItem flex alignment

### DIFF
--- a/src/list/ListItem.js
+++ b/src/list/ListItem.js
@@ -121,7 +121,6 @@ const ListItem = props => {
               underlayColor={leftIconUnderlayColor}
               style={[
                 styles.iconStyle,
-                { flex: rightTitle && rightTitle !== '' ? 0.3 : 0.15 },
                 leftIconContainerStyle && leftIconContainerStyle,
               ]}
             >

--- a/src/list/__tests__/__snapshots__/ListItem.js.snap
+++ b/src/list/__tests__/__snapshots__/ListItem.js.snap
@@ -137,9 +137,6 @@ exports[`ListItem component should render with left icon 1`] = `
             "alignItems": "center",
             "justifyContent": "center",
           },
-          Object {
-            "flex": 0.15,
-          },
           undefined,
         ]
       }


### PR DESCRIPTION
Removes line that sets a flex width for `leftIcon`. This fixes alignment when there are several list items and some have chevrons and/or right titles, and some do not.

This line was removed in #675 but re-introduced by mistake when #671 was merged.