### PR TITLE
Vertical slider hotfixes

### DIFF
--- a/docs/API/slider.md
+++ b/docs/API/slider.md
@@ -38,3 +38,4 @@ debugTouchArea        | bool     | Yes      | false                     | Set th
 animateTransitions    | bool     | Yes      | false                     | Set to true if you want to use the default 'spring' animation
 animationType         | string   | Yes      | 'timing'                  | Set to 'spring' or 'timing' to use one of those two types of animations with the default [animation properties](https://facebook.github.io/react-native/docs/animations.html).
 animationConfig       | object   | Yes      | undefined                 | Used to configure the animation parameters.  These are the same parameters in the [Animated library](https://facebook.github.io/react-native/docs/animations.html).
+orientation           | string   | Yes      | 'horizontal'              | Set the orientation of the slider.

--- a/src/slider/Slider.js
+++ b/src/slider/Slider.js
@@ -535,7 +535,13 @@ Slider.propTypes = {
   * Custom Animation type. 'spring' or 'timing'.
   */
   animationType: PropTypes.oneOf(['spring', 'timing']),
-
+  
+  /**
+  * Choose the orientation. 'horizontal' or 'vertical'.
+  */
+  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  
+      
   /**
   * Used to configure the animation parameters.  These are the same parameters in the Animated library.
   */
@@ -554,6 +560,7 @@ Slider.defaultProps = {
   thumbTouchSize: { width: 40, height: 40 },
   debugTouchArea: false,
   animationType: 'timing',
+  orientation: 'horizontal',
 };
 
 const styles = StyleSheet.create({

--- a/src/slider/Slider.js
+++ b/src/slider/Slider.js
@@ -260,7 +260,7 @@ export default class Slider extends Component {
 
   getValue(gestureState) {
     var length = this.state.containerSize.width - this.state.thumbSize.width;
-    var thumbLeft = this._previousLeft + gestureState.dx;
+    var thumbLeft = this._previousLeft + (this.props.orientation === 'vertical' ? gestureState.dy : gestureState.dx);
 
     var ratio = thumbLeft / length;
 
@@ -347,6 +347,7 @@ export default class Slider extends Component {
       trackStyle,
       thumbStyle,
       debugTouchArea,
+      orientation,
       ...other
     } = this.props;
 
@@ -382,7 +383,11 @@ export default class Slider extends Component {
     return (
       <View
         {...other}
-        style={[mainStyles.container, style]}
+        style={[
+          mainStyles.container,
+          orientation === 'vertical' && { transform: [{ rotate: '90deg' }] },
+          style,
+        ]}
         onLayout={this.measureContainer.bind(this)}
       >
         <View

--- a/src/slider/__tests__/Slider.js
+++ b/src/slider/__tests__/Slider.js
@@ -20,6 +20,13 @@ describe('Slider component', () => {
     expect(toJson(component)).toMatchSnapshot();
   });
 
+  it('should render vertically', () => {
+    const component = shallow(<Slider orientation="vertical" />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
   it('should call onValueChange', () => {
     const customFunction = jest.fn();
     const component = shallow(

--- a/src/slider/__tests__/__snapshots__/Slider.js.snap
+++ b/src/slider/__tests__/__snapshots__/Slider.js.snap
@@ -11,6 +11,7 @@ exports[`Slider component should render with ThumbTouchRect 1`] = `
         "height": 40,
         "justifyContent": "center",
       },
+      false,
       undefined,
     ]
   }
@@ -139,6 +140,128 @@ exports[`Slider component should render without issues 1`] = `
       Object {
         "height": 40,
         "justifyContent": "center",
+      },
+      false,
+      undefined,
+    ]
+  }
+  thumbTouchSize={
+    Object {
+      "height": 40,
+      "width": 40,
+    }
+  }
+  value={0}
+>
+  <View
+    onLayout={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#b3b3b3",
+        },
+        Object {
+          "borderRadius": 2,
+          "height": 4,
+        },
+        undefined,
+      ]
+    }
+  />
+  <AnimatedComponent
+    style={
+      Array [
+        Object {
+          "borderRadius": 2,
+          "height": 4,
+        },
+        undefined,
+        Object {
+          "backgroundColor": "#3f3f3f",
+          "marginTop": -0,
+          "opacity": 0,
+          "position": "absolute",
+          "width": 0,
+        },
+      ]
+    }
+  />
+  <AnimatedComponent
+    onLayout={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "red",
+        },
+        Object {
+          "borderRadius": 10,
+          "height": 20,
+          "position": "absolute",
+          "top": 22,
+          "width": 20,
+        },
+        undefined,
+        Object {
+          "opacity": 0,
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+            Object {
+              "translateY": -0,
+            },
+          ],
+        },
+      ]
+    }
+  />
+  <View
+    onMoveShouldSetResponder={[Function]}
+    onMoveShouldSetResponderCapture={[Function]}
+    onResponderEnd={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderReject={[Function]}
+    onResponderRelease={[Function]}
+    onResponderStart={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    onStartShouldSetResponderCapture={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        Object {},
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`Slider component should render vertically 1`] = `
+<View
+  animationType="timing"
+  onLayout={[Function]}
+  step={0}
+  style={
+    Array [
+      Object {
+        "height": 40,
+        "justifyContent": "center",
+      },
+      Object {
+        "transform": Array [
+          Object {
+            "rotate": "90deg",
+          },
+        ],
       },
       undefined,
     ]


### PR DESCRIPTION
## Purpose

This PR adds a `orientation` props to the `Slider` component, as suggested here #748 

|props|type|default|
|------|----|-------|
|`orientation`|`"horizontal"` or `"vertical"`|`"horizontal"`|

## Preview

|code|preview|
|-----|--------|
|`orientation="horizontal"`|`orientation="vertical"`|
|![dec-03-2017 13-40-46](https://user-images.githubusercontent.com/17592779/33525481-9d30fac2-d830-11e7-8799-275459e242f2.gif)|![dec-03-2017 13-40-03](https://user-images.githubusercontent.com/17592779/33525482-a44b5960-d830-11e7-9771-3bb75bd12e2e.gif)|