### PR TITLE
Adjusted Avatars Card and children Views

### DIFF
--- a/example/src/views/lists_home.js
+++ b/example/src/views/lists_home.js
@@ -303,13 +303,19 @@ class Icons extends Component {
             containerStyle={{
               marginTop: 15,
               marginBottom: 15,
-              height: 230,
               paddingLeft: 10,
             }}
             title="AVATARS"
           >
-            <View style={{margin: 40, flex: 1}}>
-              <View style={{ flexDirection: 'row', justifyContent: 'center', alignItems: 'center'}}>
+            <View
+              style={{
+                flex: 1,
+                margin: 40,
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <View style={{ flexDirection: 'row' }}>
                 <Avatar
                   small
                   rounded
@@ -346,7 +352,7 @@ class Icons extends Component {
                   activeOpacity={0.7}
                 />
               </View>
-              <View style={{ flexDirection: 'row', justifyContent: 'center', alignItems: 'center', marginTop: 80}}>
+              <View style={{ marginTop: 40, flexDirection: 'row' }}>
                 <Avatar
                   medium
                   rounded


### PR DESCRIPTION
The `height` prop in `Card` component were hiding the second View, limiting the View.
Style props in each child was also spared. This can be chest in the parent View.
This is more simple. I based of [Layout with flexbox](https://facebook.github.io/react-native/docs/flexbox.html)

emulator: `Genymotion`

before:

![image](https://user-images.githubusercontent.com/4691768/34064590-4670a164-e1e1-11e7-9c93-635f30eb70cf.png)


I just removed the `height` props and...

![image](https://user-images.githubusercontent.com/4691768/34064598-5ad2b430-e1e1-11e7-8556-92f259e59f0d.png)


So.. I improved the adjustments and... (I use background props to see this modifications better)

![image](https://user-images.githubusercontent.com/4691768/34064617-7d53e66e-e1e1-11e7-90f0-ded688992db6.png)
