### PR TITLE
imageProps declaration for Card component

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,6 +10,7 @@ import {
     ViewStyle,
     TextStyle,
     Image,
+    ImageProperties as RNImageProperties,
     ImageStyle,
     ImageURISource,
     TouchableWithoutFeedbackProps,
@@ -26,6 +27,13 @@ import {
     Animated,
     TransformsStyle
 } from 'react-native';
+
+/**
+ * Partial image property for imageProps support.
+ */
+interface ImageProperties extends Partial<RNImageProperties> {
+  
+}
 
 /**
  * Supports auto complete for most used types as well as any other string type.
@@ -506,6 +514,11 @@ export interface CardProps {
      * Add an image as the heading with the image prop
      */
     image?: ImageURISource;
+  
+    /**
+     * Optional properties to pass to the image if provided e.g "resizeMode"
+     */
+    imageProps?: ImageProperties;
 }
 
 /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,7 +10,7 @@ import {
     ViewStyle,
     TextStyle,
     Image,
-    ImageProperties as RNImageProperties,
+    ImageProperties,
     ImageStyle,
     ImageURISource,
     TouchableWithoutFeedbackProps,
@@ -27,13 +27,6 @@ import {
     Animated,
     TransformsStyle
 } from 'react-native';
-
-/**
- * Partial image property for imageProps support.
- */
-interface ImageProperties extends Partial<RNImageProperties> {
-  
-}
 
 /**
  * Supports auto complete for most used types as well as any other string type.
@@ -518,7 +511,7 @@ export interface CardProps {
     /**
      * Optional properties to pass to the image if provided e.g "resizeMode"
      */
-    imageProps?: ImageProperties;
+    imageProps?: Partial<ImageProperties>;
 }
 
 /**


### PR DESCRIPTION
Added missing Typescript `imageProps` declaration for `Card` component.