### PR TITLE
Allow specifying of selectedButtonStyle in button group

### DIFF
--- a/docs/API/button_group.md
+++ b/docs/API/button_group.md
@@ -78,7 +78,6 @@ render () {
 | containerStyle | inherited styling | object (style) | specify styling for main button container (optional) |
 | buttonStyle | inherited styling | object (style) | specify styling for button (optional) |
 | selectedButtonStyle | inherited styling | object (style) | specify styling for selected button (optional) |
-| selectedBackgroundColor | white | string | specify color for selected state of button (optional) |
 | containerBorderRadius | 3 | number | Set's the border radius for the first and last button in the button group |
 | textStyle | inherited styling | object (style) | specify specific styling for text (optional) |
 | selectedTextStyle | inherited styling | object (style) | specify specific styling for text in the selected state (optional)|

--- a/docs/API/button_group.md
+++ b/docs/API/button_group.md
@@ -77,6 +77,7 @@ render () {
 | component | TouchableHighlight | React Native Component | Choose other button component such as TouchableOpacity (optional) |
 | containerStyle | inherited styling | object (style) | specify styling for main button container (optional) |
 | buttonStyle | inherited styling | object (style) | specify styling for button (optional) |
+| selectedButtonStyle | inherited styling | object (style) | specify styling for selected button (optional) |
 | selectedBackgroundColor | white | string | specify color for selected state of button (optional) |
 | containerBorderRadius | 3 | number | Set's the border radius for the first and last button in the button group |
 | textStyle | inherited styling | object (style) | specify specific styling for text (optional) |

--- a/example/src/views/lists_home.js
+++ b/example/src/views/lists_home.js
@@ -303,13 +303,19 @@ class Icons extends Component {
             containerStyle={{
               marginTop: 15,
               marginBottom: 15,
-              height: 230,
               paddingLeft: 10,
             }}
             title="AVATARS"
           >
-            <View style={{margin: 40, flex: 1}}>
-              <View style={{ flexDirection: 'row', justifyContent: 'center', alignItems: 'center'}}>
+            <View
+              style={{
+                flex: 1,
+                margin: 40,
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <View style={{ flexDirection: 'row' }}>
                 <Avatar
                   small
                   rounded
@@ -346,7 +352,7 @@ class Icons extends Component {
                   activeOpacity={0.7}
                 />
               </View>
-              <View style={{ flexDirection: 'row', justifyContent: 'center', alignItems: 'center', marginTop: 80}}>
+              <View style={{ marginTop: 40, flexDirection: 'row' }}>
                 <Avatar
                   medium
                   rounded

--- a/example/src/views/lists_home.js
+++ b/example/src/views/lists_home.js
@@ -303,19 +303,13 @@ class Icons extends Component {
             containerStyle={{
               marginTop: 15,
               marginBottom: 15,
+              height: 230,
               paddingLeft: 10,
             }}
             title="AVATARS"
           >
-            <View
-              style={{
-                flex: 1,
-                margin: 40,
-                justifyContent: 'center',
-                alignItems: 'center',
-              }}
-            >
-              <View style={{ flexDirection: 'row' }}>
+            <View style={{margin: 40, flex: 1}}>
+              <View style={{ flexDirection: 'row', justifyContent: 'center', alignItems: 'center'}}>
                 <Avatar
                   small
                   rounded
@@ -352,7 +346,7 @@ class Icons extends Component {
                   activeOpacity={0.7}
                 />
               </View>
-              <View style={{ marginTop: 40, flexDirection: 'row' }}>
+              <View style={{ flexDirection: 'row', justifyContent: 'center', alignItems: 'center', marginTop: 80}}>
                 <Avatar
                   medium
                   rounded

--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -25,6 +25,7 @@ const ButtonGroup = props => {
     textStyle,
     selectedTextStyle,
     selectedBackgroundColor,
+    selectedButtonStyle,
     underlayColor,
     activeOpacity,
     onHideUnderlay,
@@ -87,19 +88,29 @@ const ButtonGroup = props => {
               },
             ]}
           >
-            <View style={[styles.textContainer, buttonStyle && buttonStyle]}>
-              {button.element
-                ? <button.element />
-                : <Text
-                    style={[
-                      styles.buttonText,
-                      textStyle && textStyle,
-                      selectedIndex === i && { color: colors.grey1 },
-                      selectedIndex === i && selectedTextStyle,
-                    ]}
-                  >
-                    {button}
-                  </Text>}
+            <View
+              style={[
+                styles.textContainer,
+                buttonStyle && buttonStyle,
+                selectedIndex === i &&
+                  selectedButtonStyle &&
+                  selectedButtonStyle,
+              ]}
+            >
+              {button.element ? (
+                <button.element />
+              ) : (
+                <Text
+                  style={[
+                    styles.buttonText,
+                    textStyle && textStyle,
+                    selectedIndex === i && { color: colors.grey1 },
+                    selectedIndex === i && selectedTextStyle,
+                  ]}
+                >
+                  {button}
+                </Text>
+              )}
             </View>
           </Component>
         );
@@ -149,6 +160,7 @@ ButtonGroup.propTypes = {
   containerStyle: ViewPropTypes.style,
   textStyle: NativeText.propTypes.style,
   selectedTextStyle: NativeText.propTypes.style,
+  selectedButtonStyle: ViewPropTypes.style,
   underlayColor: PropTypes.string,
   selectedIndex: PropTypes.number,
   activeOpacity: PropTypes.number,

--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -24,7 +24,6 @@ const ButtonGroup = props => {
     buttonStyle,
     textStyle,
     selectedTextStyle,
-    selectedBackgroundColor,
     selectedButtonStyle,
     underlayColor,
     activeOpacity,
@@ -84,7 +83,7 @@ const ButtonGroup = props => {
                 borderBottomLeftRadius: containerRadius,
               },
               selectedIndex === i && {
-                backgroundColor: selectedBackgroundColor || 'white',
+                backgroundColor: 'white',
               },
             ]}
           >
@@ -176,7 +175,6 @@ ButtonGroup.propTypes = {
     NativeText.propTypes.style,
   ]),
   buttonStyle: ViewPropTypes.style,
-  selectedBackgroundColor: PropTypes.string,
   containerBorderRadius: PropTypes.number,
   disableSelected: PropTypes.bool,
 };

--- a/src/buttons/__tests__/ButtonGroup.js
+++ b/src/buttons/__tests__/ButtonGroup.js
@@ -34,8 +34,7 @@ describe('ButtonGroup Component', () => {
       <ButtonGroup
         buttons={buttons}
         selectedIndex={1}
-        selectedBackgroundColor="red"
-        selectedButtonStyle={{ backgroundColor: '#dbedfc' }}
+        selectedButtonStyle={{ backgroundColor: 'red' }}
         selectedTextStyle={{ fontSize: 12 }}
       />
     );

--- a/src/buttons/__tests__/ButtonGroup.js
+++ b/src/buttons/__tests__/ButtonGroup.js
@@ -35,6 +35,7 @@ describe('ButtonGroup Component', () => {
         buttons={buttons}
         selectedIndex={1}
         selectedBackgroundColor="red"
+        selectedButtonStyle={{ backgroundColor: '#dbedfc' }}
         selectedTextStyle={{ fontSize: 12 }}
       />
     );

--- a/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
+++ b/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
@@ -477,7 +477,7 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
         false,
         false,
         Object {
-          "backgroundColor": "red",
+          "backgroundColor": "white",
         },
       ]
     }
@@ -493,7 +493,7 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
           },
           undefined,
           Object {
-            "backgroundColor": "#dbedfc",
+            "backgroundColor": "red",
           },
         ]
       }

--- a/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
+++ b/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
@@ -58,6 +58,7 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
           Object {
             "backgroundColor": "blue",
           },
+          false,
         ]
       }
     >
@@ -114,6 +115,7 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
           Object {
             "backgroundColor": "blue",
           },
+          false,
         ]
       }
     >
@@ -167,6 +169,7 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
           Object {
             "backgroundColor": "blue",
           },
+          false,
         ]
       }
     >
@@ -245,6 +248,7 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
             "justifyContent": "center",
           },
           undefined,
+          false,
         ]
       }
     >
@@ -299,6 +303,7 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
             "justifyContent": "center",
           },
           undefined,
+          false,
         ]
       }
     >
@@ -351,6 +356,7 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
             "justifyContent": "center",
           },
           undefined,
+          false,
         ]
       }
     >
@@ -429,6 +435,7 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
             "justifyContent": "center",
           },
           undefined,
+          false,
         ]
       }
     >
@@ -485,6 +492,9 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
             "justifyContent": "center",
           },
           undefined,
+          Object {
+            "backgroundColor": "#dbedfc",
+          },
         ]
       }
     >
@@ -540,6 +550,7 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
             "justifyContent": "center",
           },
           undefined,
+          false,
         ]
       }
     >
@@ -618,6 +629,7 @@ exports[`ButtonGroup Component should render with button.element 1`] = `
             "justifyContent": "center",
           },
           undefined,
+          false,
         ]
       }
     >
@@ -657,6 +669,7 @@ exports[`ButtonGroup Component should render with button.element 1`] = `
             "justifyContent": "center",
           },
           undefined,
+          false,
         ]
       }
     >
@@ -720,6 +733,7 @@ exports[`ButtonGroup Component should render without issues 1`] = `
             "justifyContent": "center",
           },
           undefined,
+          false,
         ]
       }
     >
@@ -774,6 +788,7 @@ exports[`ButtonGroup Component should render without issues 1`] = `
             "justifyContent": "center",
           },
           undefined,
+          false,
         ]
       }
     >
@@ -825,6 +840,7 @@ exports[`ButtonGroup Component should render without issues 1`] = `
             "justifyContent": "center",
           },
           undefined,
+          false,
         ]
       }
     >


### PR DESCRIPTION
Greetings from Bulgaria,
Firstly - Thanks for the great framework.

I've found an issue with the button group and styling.

Since we want to allow the overwriting of styles for selected
button without the need of custom logic. This commit
allows that behavior by introducing a new property -
selectedButtonStyle.

Also include the change in the docs