### PR TITLE
iconRight expects type `Object` not boolean

### DIFF
--- a/docs/API/buttons.md
+++ b/docs/API/buttons.md
@@ -17,14 +17,13 @@ import { Button } from 'react-native-elements'
 
 <Button
   large
-  iconRight
-  icon={{name: 'code'}}
+  iconRight={{name: 'code'}}
   title='LARGE WITH RIGHT ICON' />
 
 <Button
   large
   icon={{name: 'envira', type: 'font-awesome'}}
-  title='LARGE WITH RIGHT ICON' />
+  title='LARGE WITH ICON TYPE' />
 
 <Button
   large

--- a/example/src/views/lists_home.js
+++ b/example/src/views/lists_home.js
@@ -303,13 +303,19 @@ class Icons extends Component {
             containerStyle={{
               marginTop: 15,
               marginBottom: 15,
-              height: 230,
               paddingLeft: 10,
             }}
             title="AVATARS"
           >
-            <View style={{margin: 40, flex: 1}}>
-              <View style={{ flexDirection: 'row', justifyContent: 'center', alignItems: 'center'}}>
+            <View
+              style={{
+                flex: 1,
+                margin: 40,
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <View style={{ flexDirection: 'row' }}>
                 <Avatar
                   small
                   rounded
@@ -346,7 +352,7 @@ class Icons extends Component {
                   activeOpacity={0.7}
                 />
               </View>
-              <View style={{ flexDirection: 'row', justifyContent: 'center', alignItems: 'center', marginTop: 80}}>
+              <View style={{ marginTop: 40, flexDirection: 'row' }}>
                 <Avatar
                   medium
                   rounded

--- a/example/src/views/lists_home.js
+++ b/example/src/views/lists_home.js
@@ -303,19 +303,13 @@ class Icons extends Component {
             containerStyle={{
               marginTop: 15,
               marginBottom: 15,
+              height: 230,
               paddingLeft: 10,
             }}
             title="AVATARS"
           >
-            <View
-              style={{
-                flex: 1,
-                margin: 40,
-                justifyContent: 'center',
-                alignItems: 'center',
-              }}
-            >
-              <View style={{ flexDirection: 'row' }}>
+            <View style={{margin: 40, flex: 1}}>
+              <View style={{ flexDirection: 'row', justifyContent: 'center', alignItems: 'center'}}>
                 <Avatar
                   small
                   rounded
@@ -352,7 +346,7 @@ class Icons extends Component {
                   activeOpacity={0.7}
                 />
               </View>
-              <View style={{ marginTop: 40, flexDirection: 'row' }}>
+              <View style={{ flexDirection: 'row', justifyContent: 'center', alignItems: 'center', marginTop: 80}}>
                 <Avatar
                   medium
                   rounded


### PR DESCRIPTION
`iconRight` throws up error on Android due to Boolean values in the API example