### PR TITLE
fix(Button): add raised styles into the correct View

### DIFF
--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -157,7 +157,6 @@ const Button = props => {
     <View
       style={[
         styles.container,
-        raised && styles.raised,
         containerViewStyle,
         borderRadius && { borderRadius },
       ]}
@@ -172,6 +171,7 @@ const Button = props => {
           pointerEvents="box-only"
           style={[
             styles.button,
+            raised && styles.raised,
             secondary && { backgroundColor: colors.secondary },
             secondary2 && { backgroundColor: colors.secondary2 },
             secondary3 && { backgroundColor: colors.secondary3 },

--- a/src/buttons/__tests__/__snapshots__/Button.js.snap
+++ b/src/buttons/__tests__/__snapshots__/Button.js.snap
@@ -10,7 +10,6 @@ exports[`Button Component should render with custom icon component 1`] = `
       },
       undefined,
       undefined,
-      undefined,
     ]
   }
 >
@@ -31,6 +30,7 @@ exports[`Button Component should render with custom icon component 1`] = `
             "justifyContent": "center",
             "padding": 19,
           },
+          undefined,
           undefined,
           undefined,
           undefined,
@@ -100,7 +100,6 @@ exports[`Button Component should render with default icon 1`] = `
       },
       undefined,
       undefined,
-      undefined,
     ]
   }
 >
@@ -121,6 +120,7 @@ exports[`Button Component should render with default icon 1`] = `
             "justifyContent": "center",
             "padding": 19,
           },
+          undefined,
           undefined,
           undefined,
           undefined,
@@ -191,7 +191,6 @@ exports[`Button Component should render with icon type 1`] = `
       },
       undefined,
       undefined,
-      undefined,
     ]
   }
 >
@@ -212,6 +211,7 @@ exports[`Button Component should render with icon type 1`] = `
             "justifyContent": "center",
             "padding": 19,
           },
+          undefined,
           undefined,
           undefined,
           undefined,
@@ -280,7 +280,6 @@ exports[`Button Component should render without issues 1`] = `
       },
       undefined,
       undefined,
-      undefined,
     ]
   }
 >
@@ -301,6 +300,7 @@ exports[`Button Component should render without issues 1`] = `
             "justifyContent": "center",
             "padding": 19,
           },
+          undefined,
           undefined,
           undefined,
           undefined,


### PR DESCRIPTION
now the Styles added but the `raised` prop are added to the properly View inside Button. this avoids to have weird visuals when you apply some styles with `buttonStyle`.

solves #815 

here you can see the error: https://snack.expo.io/ryrxN0LVf

Visual Representation of the Solution:
![button change](https://user-images.githubusercontent.com/725120/34901692-dffd303a-f80d-11e7-978a-85653e1bcb7f.png)

