### PR TITLE
Separate checkbox single and checkbox with text styling

### DIFF
--- a/src/checkbox/CheckBox.js
+++ b/src/checkbox/CheckBox.js
@@ -53,7 +53,11 @@ const CheckBox = props => {
       {...attributes}
       onLongPress={onLongPress}
       onPress={onPress}
-      style={[styles.container, containerStyle && containerStyle]}
+      style={[
+        styles.container,
+        title && styles.containerHasTitle,
+        containerStyle && containerStyle,
+      ]}
     >
       <View
         style={[
@@ -62,35 +66,39 @@ const CheckBox = props => {
           center && { justifyContent: 'center' },
         ]}
       >
-        {!iconRight &&
+        {!iconRight && (
           <Icon
             color={checked ? checkedColor : uncheckedColor}
             name={iconName}
             size={size || 24}
             onLongPress={onLongIconPress}
             onPress={onIconPress}
-          />}
+          />
+        )}
 
         {React.isValidElement(title)
           ? title
-          : <TextElement
-              style={[
-                styles.text,
-                textStyle && textStyle,
-                fontFamily && { fontFamily },
-              ]}
-            >
-              {checked ? checkedTitle || title : title}
-            </TextElement>}
+          : title && (
+              <TextElement
+                style={[
+                  styles.text,
+                  textStyle && textStyle,
+                  fontFamily && { fontFamily },
+                ]}
+              >
+                {checked ? checkedTitle || title : title}
+              </TextElement>
+            )}
 
-        {iconRight &&
+        {iconRight && (
           <Icon
             color={checked ? checkedColor : uncheckedColor}
             name={iconName}
             size={size || 24}
             onLongPress={onLongIconPress}
             onPress={onIconPress}
-          />}
+          />
+        )}
       </View>
     </Component>
   );
@@ -140,11 +148,13 @@ const styles = StyleSheet.create({
     margin: 5,
     marginLeft: 10,
     marginRight: 10,
+    padding: 10,
+  },
+  containerHasTitle: {
+    borderWidth: 1,
+    borderRadius: 3,
     backgroundColor: '#fafafa',
     borderColor: '#ededed',
-    borderWidth: 1,
-    padding: 10,
-    borderRadius: 3,
   },
   text: {
     marginLeft: 10,

--- a/src/checkbox/__tests__/__snapshots__/CheckBox.js.snap
+++ b/src/checkbox/__tests__/__snapshots__/CheckBox.js.snap
@@ -7,15 +7,12 @@ exports[`CheckBox Component should render with icon and checked 1`] = `
   style={
     Array [
       Object {
-        "backgroundColor": "#fafafa",
-        "borderColor": "#ededed",
-        "borderRadius": 3,
-        "borderWidth": 1,
         "margin": 5,
         "marginLeft": 10,
         "marginRight": 10,
         "padding": 10,
       },
+      undefined,
       Object {
         "backgroundColor": "red",
       },
@@ -40,20 +37,6 @@ exports[`CheckBox Component should render with icon and checked 1`] = `
       name="square-o"
       size={24}
     />
-    <TextElement
-      style={
-        Array [
-          Object {
-            "color": "#43484d",
-            "fontWeight": "bold",
-            "marginLeft": 10,
-            "marginRight": 10,
-          },
-          undefined,
-          undefined,
-        ]
-      }
-    />
   </View>
 </TouchableOpacity>
 `;
@@ -66,15 +49,12 @@ exports[`CheckBox Component should render with icon and iconRight 1`] = `
   style={
     Array [
       Object {
-        "backgroundColor": "#fafafa",
-        "borderColor": "#ededed",
-        "borderRadius": 3,
-        "borderWidth": 1,
         "margin": 5,
         "marginLeft": 10,
         "marginRight": 10,
         "padding": 10,
       },
+      undefined,
       undefined,
     ]
   }
@@ -93,20 +73,6 @@ exports[`CheckBox Component should render with icon and iconRight 1`] = `
       ]
     }
   >
-    <TextElement
-      style={
-        Array [
-          Object {
-            "color": "#43484d",
-            "fontWeight": "bold",
-            "marginLeft": 10,
-            "marginRight": 10,
-          },
-          undefined,
-          undefined,
-        ]
-      }
-    />
     <Icon
       allowFontScaling={false}
       color="blue"
@@ -124,15 +90,12 @@ exports[`CheckBox Component should render without issues 1`] = `
   style={
     Array [
       Object {
-        "backgroundColor": "#fafafa",
-        "borderColor": "#ededed",
-        "borderRadius": 3,
-        "borderWidth": 1,
         "margin": 5,
         "marginLeft": 10,
         "marginRight": 10,
         "padding": 10,
       },
+      undefined,
       undefined,
     ]
   }
@@ -154,20 +117,6 @@ exports[`CheckBox Component should render without issues 1`] = `
       color="#bfbfbf"
       name="square-o"
       size={24}
-    />
-    <TextElement
-      style={
-        Array [
-          Object {
-            "color": "#43484d",
-            "fontWeight": "bold",
-            "marginLeft": 10,
-            "marginRight": 10,
-          },
-          undefined,
-          undefined,
-        ]
-      }
     />
   </View>
 </TouchableOpacity>


### PR DESCRIPTION
Currently right now making a checkbox without text produces an ugly spacing and border around the component. This is caused because the styling for the text style is being applied.

![screen shot 2018-01-26 at 12 44 03 pm](https://user-images.githubusercontent.com/5962998/35450500-99dffd2e-0296-11e8-979e-bc7b177e8230.png)

This PR allows the checkbox to be ~an independent grown man~ able to display differently depending on if there's a title.

![screen shot 2018-01-26 at 12 44 56 pm](https://user-images.githubusercontent.com/5962998/35450537-b9a73cb2-0296-11e8-8477-cf0ead504b74.png)
