### PR TITLE
Add `label` for the Input component

### DIFF
--- a/docs/input.md
+++ b/docs/input.md
@@ -15,7 +15,7 @@ import { Input } from 'react-native-elements';
 
 <Input
   placeholder='INPUT WITH ICON'
-  icon={
+  leftIcon={
     <Icon
       name='user'
       size={24}
@@ -31,7 +31,6 @@ import { Input } from 'react-native-elements';
 
 <Input
   placeholder='INPUT WITH ERROR MESSAGE'
-  displayError={true}
   errorStyle={{ color: 'red' }}
   errorMessage='ENTER A VALID ERROR HERE'
 />
@@ -50,6 +49,7 @@ import { Input } from 'react-native-elements';
 | leftIconContainerStyle  | none    | View style (object)    | styling for left Icon Component container        |
 | inputStyle              | none    | object                 | add styling to input component (optional)        |
 | shake                   | none    | any                    | add shaking effect to input component (optional) |
-| displayError            | none    | bool                   | displays error (optional)                        |
-| errorStyle              | none    | object                 | add styling to error message (optional)          |
-| errorMessage            | none    | string                 | adds error message (optional)                    |
+| label                   | none    | string                 | add a label on top of the input (optional)       |
+| labelStyle              | none    | object                 | styling for the error message (optional)         |
+| errorMessage            | none    | string                 | add error message (optional)                     |
+| errorStyle              | none    | object                 | styling for the error message (optional)         |

--- a/docs/input.md
+++ b/docs/input.md
@@ -50,6 +50,6 @@ import { Input } from 'react-native-elements';
 | inputStyle              | none    | object                 | add styling to input component (optional)        |
 | shake                   | none    | any                    | add shaking effect to input component (optional) |
 | label                   | none    | string                 | add a label on top of the input (optional)       |
-| labelStyle              | none    | object                 | styling for the error message (optional)         |
+| labelStyle              | none    | object                 | styling for the label (optional)         |
 | errorMessage            | none    | string                 | add error message (optional)                     |
 | errorStyle              | none    | object                 | styling for the error message (optional)         |

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -786,11 +786,6 @@ export interface InputProps extends TextInputProperties {
   shake?: any;
 
   /**
-   *  Displays error (optional)
-   */
-  displayError?: boolean;
-
-  /**
    * 	Add styling to error message (optional)
    */
   errorStyle?: StyleProp<TextStyle>;
@@ -801,6 +796,16 @@ export interface InputProps extends TextInputProperties {
    * @default 'Error!'
    */
   errorMessage?: string;
+
+  /**
+   * 	Add styling to label (optional)
+   */
+  labelStyle?: StyleProp<TextStyle>;
+
+  /**
+   * 	Adds label (optional)
+   */
+  label?: string;
 }
 
 export class Input extends React.Component<InputProps, any> {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -792,8 +792,6 @@ export interface InputProps extends TextInputProperties {
 
   /**
    * 	Adds error message (optional)
-   * *
-   * @default 'Error!'
    */
   errorMessage?: string;
 

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -74,10 +74,11 @@ class Input extends Component {
     return (
       <View>
         {
-          label != null &&
-          <Text style={[styles.label, labelStyle]}>
-            {label}
-          </Text>
+          label && (
+            <Text style={[styles.label, labelStyle]}>
+              {label}
+            </Text>
+          )
         }
         <Animated.View
           style={[
@@ -113,7 +114,7 @@ class Input extends Component {
             </View>
           )}
         </Animated.View>
-        {errorMessage != null && (
+        {errorMessage && (
           <Text style={[styles.error, errorStyle && errorStyle]}>
             {errorMessage}
           </Text>

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -60,7 +60,6 @@ class Input extends Component {
       rightIcon,
       rightIconContainerStyle,
       inputStyle,
-      displayError,
       errorStyle,
       errorMessage,
       labelStyle,
@@ -114,9 +113,9 @@ class Input extends Component {
             </View>
           )}
         </Animated.View>
-        {displayError && (
+        {errorMessage != null && (
           <Text style={[styles.error, errorStyle && errorStyle]}>
-            {errorMessage || 'Error!'}
+            {errorMessage}
           </Text>
         )}
       </View>
@@ -136,7 +135,6 @@ Input.propTypes = {
   inputStyle: Text.propTypes.style,
 
   shake: PropTypes.any,
-  displayError: PropTypes.bool,
   errorStyle: Text.propTypes.style,
   errorMessage: PropTypes.string,
 

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -9,9 +9,12 @@ import {
   Dimensions,
   Animated,
   Easing,
+  Platform,
 } from 'react-native';
 
 import ViewPropTypes from '../config/ViewPropTypes';
+import fonts from '../config/fonts';
+import colors from '../config/colors';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 
@@ -60,6 +63,8 @@ class Input extends Component {
       displayError,
       errorStyle,
       errorMessage,
+      labelStyle,
+      label,
       ...attributes
     } = this.props;
     const translateX = this.shakeAnimationValue.interpolate({
@@ -69,6 +74,12 @@ class Input extends Component {
 
     return (
       <View>
+        {
+          label != null &&
+          <Text style={[styles.label, labelStyle]}>
+            {label}
+          </Text>
+        }
         <Animated.View
           style={[
             styles.container,
@@ -128,13 +139,16 @@ Input.propTypes = {
   displayError: PropTypes.bool,
   errorStyle: Text.propTypes.style,
   errorMessage: PropTypes.string,
+
+  label: PropTypes.string,
+  labelStyle: Text.propTypes.style,
 };
 
 const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     borderBottomWidth: 1,
-    borderColor: 'rgba(171, 189, 219, 1)',
+    borderColor: colors.grey3,
     alignItems: 'center',
   },
   iconContainer: {
@@ -147,13 +161,25 @@ const styles = StyleSheet.create({
     color: 'black',
     fontSize: 18,
     marginLeft: 10,
-    width: '100%',
+    flex: 1,
     height: 40,
   },
   error: {
     color: '#FF2D00',
     margin: 5,
     fontSize: 12,
+  },
+  label: {
+    color: colors.grey3,
+    fontSize: 16,
+    ...Platform.select({
+      ios: {
+        fontWeight: 'bold',
+      },
+      android: {
+        ...fonts.android.bold,
+      },
+    }),
   },
 });
 

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -73,13 +73,11 @@ class Input extends Component {
 
     return (
       <View>
-        {
-          label && (
-            <Text style={[styles.label, labelStyle]}>
-              {label}
-            </Text>
-          )
-        }
+        {label && (
+          <Text style={[styles.label, labelStyle]}>
+            {label}
+          </Text>
+        )}
         <Animated.View
           style={[
             styles.container,


### PR DESCRIPTION
Refs #892 
Associated PR for the example app: https://github.com/react-native-training/react-native-elements-app/pull/48

## Props changes
* `label` adds a label on top of the Input
* `labelStyle` adds style to the label
* Remove useless `displayError` props. If the `errorMessage` is not null, I suppose there is an error to display…

I basically took back the style of the old `FormLabel`

## Result
![simulator screen shot - iphone x - 2018-03-12 at 23 26 28](https://user-images.githubusercontent.com/17592779/37313472-a72af01a-264f-11e8-9f71-50a3b8e42787.png)
