### PR TITLE
Included button missing properties

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -324,6 +324,25 @@ export interface ButtonProps extends TouchableWithoutFeedbackProps {
    * Style of the button when disabled
    */
   disabledStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * rounds the button (optional)
+   * 
+   * @default false
+   */
+  rounded?: boolean;
+
+  /**
+   * outlines the button (optional)
+   */
+  outline?: boolean;
+
+  /**
+   * makes the button transparent (optional)
+   * 
+   * @default false
+   */
+  transparent?: boolean;
 }
 
 /**


### PR DESCRIPTION
As indicated in the documentation, I could not find in the type definition the following properties:

> rounded, outline, transparent

Url to documentation:
https://react-native-training.github.io/react-native-elements/docs/0.19.0/button.html