### PR TITLE
Fix Button width (+ small refactor)

### DIFF
--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -41,7 +41,6 @@ class Button extends Component {
       loadingStyle,
       loadingProps,
       title,
-      titleStyle,
       titleProps,
       icon,
       iconContainerStyle,
@@ -55,6 +54,12 @@ class Button extends Component {
         : View,
       ...attributes
     } = this.props;
+
+    let { titleStyle = {} } = this.props;
+    titleStyle = {
+      width: buttonStyle && buttonStyle.width ? '100%' : null,
+      ...titleStyle,
+    };
 
     return (
       <View style={[styles.container, containerStyle]}>

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -176,7 +176,6 @@ Button.defaultProps = {
 
 const styles = StyleSheet.create({
   button: {
-    flex: 1,
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
@@ -190,10 +189,6 @@ const styles = StyleSheet.create({
     }),
   },
   disabled: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderRadius: 3,
     // grey from designmodo.github.io/Flat-UI/
     backgroundColor: '#D1D5D8',
     ...Platform.select({
@@ -204,6 +199,7 @@ const styles = StyleSheet.create({
     }),
   },
   title: {
+    backgroundColor: 'transparent',
     color: 'white',
     fontSize: 16,
     textAlign: 'center',

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -42,6 +42,7 @@ class Button extends Component {
       loadingProps,
       title,
       titleProps,
+      titleStyle,
       icon,
       iconContainerStyle,
       iconRight,
@@ -55,77 +56,73 @@ class Button extends Component {
       ...attributes
     } = this.props;
 
-    let { titleStyle = {} } = this.props;
-    titleStyle = {
-      width: buttonStyle && buttonStyle.width ? '100%' : null,
-      ...titleStyle,
-    };
-
     return (
-      <View style={[styles.container, containerStyle]}>
-        <TouchableComponent
-          {...attributes}
-          onPress={onPress}
-          underlayColor={clear ? 'transparent' : undefined}
-          activeOpacity={clear ? 0 : undefined}
-          style={{
-            borderRadius: buttonStyle.borderRadius,
-          }}
-          disabled={disabled}
+      <TouchableComponent
+        {...attributes}
+        style={[styles.container, containerStyle]}
+        onPress={onPress}
+        underlayColor={clear ? 'transparent' : undefined}
+        activeOpacity={clear ? 0 : undefined}
+        disabled={disabled}
+      >
+        <ViewComponent
+          {...linearGradientProps}
+          style={[
+            styles.button,
+            clear && { backgroundColor: 'transparent', elevation: 0 },
+            buttonStyle,
+            linearGradientProps && { backgroundColor: 'transparent' },
+            disabled && styles.disabled,
+            disabled && disabledStyle,
+          ]}
         >
-          <ViewComponent
-            {...linearGradientProps}
-            style={[
-              styles.button,
-              clear && { backgroundColor: 'transparent', elevation: 0 },
-              buttonStyle,
-              linearGradientProps && { backgroundColor: 'transparent' },
-              disabled && styles.disabled,
-              disabled && disabledStyle,
-            ]}
-          >
-            {loading && (
-              <ActivityIndicator
-                animating={true}
-                style={[styles.loading, loadingStyle]}
-                color={loadingProps.color}
-                size={loadingProps.size}
-                {...loadingProps}
-              />
+          {loading && (
+            <ActivityIndicator
+              animating={true}
+              style={[styles.loading, loadingStyle]}
+              color={loadingProps.color}
+              size={loadingProps.size}
+              {...loadingProps}
+            />
+          )}
+          {!loading &&
+            icon &&
+            !iconRight && (
+              <View style={[styles.iconContainer, iconContainerStyle]}>
+                {icon}
+              </View>
             )}
-            {!loading &&
-              icon &&
-              !iconRight && (
-                <View style={[styles.iconContainer, iconContainerStyle]}>
-                  {icon}
-                </View>
-              )}
-            {!loading && (
-              <Text
-                style={[
-                  styles.title,
-                  titleStyle,
-                  disabled && styles.disabledTitle,
-                  disabled && disabledTitleStyle,
-                ]}
-                {...titleProps}
-              >
-                {title}
-              </Text>
+          {!loading && (
+            <Text
+              style={[
+                styles.title,
+                titleStyle,
+                disabled && styles.disabledTitle,
+                disabled && disabledTitleStyle,
+              ]}
+              {...titleProps}
+            >
+              {title}
+            </Text>
+          )}
+          {!loading &&
+            icon &&
+            iconRight && (
+              <View style={[styles.iconContainer, iconContainerStyle]}>
+                {icon}
+              </View>
             )}
-            {!loading &&
-              icon &&
-              iconRight && (
-                <View style={[styles.iconContainer, iconContainerStyle]}>
-                  {icon}
-                </View>
-              )}
-          </ViewComponent>
-        </TouchableComponent>
-      </View>
+        </ViewComponent>
+      </TouchableComponent>
     );
   }
 }
+
+const TouchableNativeFeedbackContainer = ({ style, children, ...props }) => (
+  <View style={style}>
+    <TouchableNativeFeedback {...props}>{children}</TouchableNativeFeedback>
+  </View>
+);
 
 Button.propTypes = {
   title: PropTypes.string,
@@ -153,7 +150,7 @@ Button.defaultProps = {
   title: 'Welcome to\nReact Native Elements',
   iconRight: false,
   TouchableComponent:
-    Platform.OS === 'ios' ? TouchableOpacity : TouchableNativeFeedback,
+    Platform.OS === 'ios' ? TouchableOpacity : TouchableNativeFeedbackContainer,
   onPress: log,
   clear: false,
   loadingProps: {
@@ -167,12 +164,8 @@ Button.defaultProps = {
 };
 
 const styles = StyleSheet.create({
-  container: {
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderRadius: 30,
-  },
   button: {
+    flex: 1,
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
@@ -199,20 +192,6 @@ const styles = StyleSheet.create({
       },
     }),
   },
-  disabledTitle: {
-    color: '#F3F4F5',
-    fontSize: 16,
-    textAlign: 'center',
-    padding: 8,
-    ...Platform.select({
-      ios: {
-        fontSize: 18,
-      },
-      android: {
-        fontWeight: '500',
-      },
-    }),
-  },
   title: {
     color: 'white',
     fontSize: 16,
@@ -226,6 +205,9 @@ const styles = StyleSheet.create({
         fontWeight: '500',
       },
     }),
+  },
+  disabledTitle: {
+    color: '#F3F4F5',
   },
   iconContainer: {
     marginHorizontal: 5,

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -57,83 +57,67 @@ class Button extends Component {
     } = this.props;
 
     return (
-      <TouchableContainer
-        {...attributes}
-        Component={TouchableComponent}
-        style={[styles.container, containerStyle]}
-        onPress={onPress}
-        underlayColor={clear ? 'transparent' : undefined}
-        activeOpacity={clear ? 0 : undefined}
-        disabled={disabled}
-      >
-        <ViewComponent
-          {...linearGradientProps}
-          style={[
-            styles.button,
-            clear && { backgroundColor: 'transparent', elevation: 0 },
-            buttonStyle,
-            linearGradientProps && { backgroundColor: 'transparent' },
-            disabled && styles.disabled,
-            disabled && disabledStyle,
-          ]}
+      <View style={[styles.container, containerStyle]}>
+        <TouchableComponent
+          {...attributes}
+          onPress={onPress}
+          underlayColor={clear ? 'transparent' : undefined}
+          activeOpacity={clear ? 0 : undefined}
+          disabled={disabled}
         >
-          {loading && (
-            <ActivityIndicator
-              animating={true}
-              style={[styles.loading, loadingStyle]}
-              color={loadingProps.color}
-              size={loadingProps.size}
-              {...loadingProps}
-            />
-          )}
-          {!loading &&
-            icon &&
-            !iconRight && (
-              <View style={[styles.iconContainer, iconContainerStyle]}>
-                {icon}
-              </View>
+          <ViewComponent
+            {...linearGradientProps}
+            style={[
+              styles.button,
+              clear && { backgroundColor: 'transparent', elevation: 0 },
+              buttonStyle,
+              linearGradientProps && { backgroundColor: 'transparent' },
+              disabled && styles.disabled,
+              disabled && disabledStyle,
+            ]}
+          >
+            {loading && (
+              <ActivityIndicator
+                animating={true}
+                style={[styles.loading, loadingStyle]}
+                color={loadingProps.color}
+                size={loadingProps.size}
+                {...loadingProps}
+              />
             )}
-          {!loading && (
-            <Text
-              style={[
-                styles.title,
-                titleStyle,
-                disabled && styles.disabledTitle,
-                disabled && disabledTitleStyle,
-              ]}
-              {...titleProps}
-            >
-              {title}
-            </Text>
-          )}
-          {!loading &&
-            icon &&
-            iconRight && (
-              <View style={[styles.iconContainer, iconContainerStyle]}>
-                {icon}
-              </View>
+            {!loading &&
+              icon &&
+              !iconRight && (
+                <View style={[styles.iconContainer, iconContainerStyle]}>
+                  {icon}
+                </View>
+              )}
+            {!loading && (
+              <Text
+                style={[
+                  styles.title,
+                  titleStyle,
+                  disabled && styles.disabledTitle,
+                  disabled && disabledTitleStyle,
+                ]}
+                {...titleProps}
+              >
+                {title}
+              </Text>
             )}
-        </ViewComponent>
-      </TouchableContainer>
+            {!loading &&
+              icon &&
+              iconRight && (
+                <View style={[styles.iconContainer, iconContainerStyle]}>
+                  {icon}
+                </View>
+              )}
+          </ViewComponent>
+        </TouchableComponent>
+      </View>
     );
   }
 }
-
-// Because TouchableNativeFeedback and TouchableWithoutFeedback don't have style prop
-// issue: https://github.com/facebook/react-native/issues/8307
-const TouchableContainer = ({ style, children, Component, ...props }) => {
-  const { displayName } = Component;
-  return displayName === 'TouchableNativeFeedback' ||
-    displayName === 'TouchableWithoutFeedback' ? (
-    <View style={style}>
-      <Component {...props}>{children}</Component>
-    </View>
-  ) : (
-    <Component style={style} {...props}>
-      {children}
-    </Component>
-  );
-};
 
 Button.propTypes = {
   title: PropTypes.string,

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -56,14 +56,8 @@ class Button extends Component {
       ...attributes
     } = this.props;
 
-    let { titleStyle = {} } = this.props;
-    titleStyle = {
-      width: buttonStyle && buttonStyle.width ? '100%' : null,
-      ...titleStyle,
-    };
-
     return (
-      <View style={[styles.container, containerStyle]}>
+      <View style={containerStyle}>
         <TouchableComponent
           {...attributes}
           onPress={onPress}

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -57,8 +57,9 @@ class Button extends Component {
     } = this.props;
 
     return (
-      <TouchableComponent
+      <TouchableContainer
         {...attributes}
+        Component={TouchableComponent}
         style={[styles.container, containerStyle]}
         onPress={onPress}
         underlayColor={clear ? 'transparent' : undefined}
@@ -113,16 +114,26 @@ class Button extends Component {
               </View>
             )}
         </ViewComponent>
-      </TouchableComponent>
+      </TouchableContainer>
     );
   }
 }
 
-const TouchableNativeFeedbackContainer = ({ style, children, ...props }) => (
-  <View style={style}>
-    <TouchableNativeFeedback {...props}>{children}</TouchableNativeFeedback>
-  </View>
-);
+// Because TouchableNativeFeedback and TouchableWithoutFeedback don't have style prop
+// issue: https://github.com/facebook/react-native/issues/8307
+const TouchableContainer = ({ style, children, Component, ...props }) => {
+  const { displayName } = Component;
+  return displayName === 'TouchableNativeFeedback' ||
+    displayName === 'TouchableWithoutFeedback' ? (
+    <View style={style}>
+      <Component {...props}>{children}</Component>
+    </View>
+  ) : (
+    <Component style={style} {...props}>
+      {children}
+    </Component>
+  );
+};
 
 Button.propTypes = {
   title: PropTypes.string,
@@ -150,7 +161,7 @@ Button.defaultProps = {
   title: 'Welcome to\nReact Native Elements',
   iconRight: false,
   TouchableComponent:
-    Platform.OS === 'ios' ? TouchableOpacity : TouchableNativeFeedbackContainer,
+    Platform.OS === 'ios' ? TouchableOpacity : TouchableNativeFeedback,
   onPress: log,
   clear: false,
   loadingProps: {

--- a/website/versioned_docs/version-1.0.0-beta2/button.md
+++ b/website/versioned_docs/version-1.0.0-beta2/button.md
@@ -13,7 +13,7 @@ import { Button } from 'react-native-elements';
 import Icon from 'react-native-vector-icons/FontAwesome';
 
 <Button
-  title='BUTTON'
+  text='BUTTON'
 />
 
 <Button
@@ -24,7 +24,7 @@ import Icon from 'react-native-vector-icons/FontAwesome';
       color='white'
     />
   }
-  title='BUTTON WITH ICON'
+  text='BUTTON WITH ICON'
 />
 
 <Button
@@ -36,14 +36,14 @@ import Icon from 'react-native-vector-icons/FontAwesome';
     />
   }
   iconRight
-  title='BUTTON WITH RIGHT ICON'
+  text='BUTTON WITH RIGHT ICON'
 />
 
 <Button
-  title="LOADING BUTTON"
+  text="LOADING BUTTON"
   loading
   loadingProps={{ size: "large", color: "rgba(111, 202, 186, 1)" }}
-  titleStyle={{ fontWeight: "700" }}
+  textStyle={{ fontWeight: "700" }}
   buttonStyle={{
     backgroundColor: "rgba(92, 99,216, 1)",
     width: 300,
@@ -62,9 +62,9 @@ import Icon from 'react-native-vector-icons/FontAwesome';
 
 | prop | default | type | description |
 | ---- | ---- | ----| ---- |
-| title | none | string | button title (optional) |
-| titleStyle | none | Text style (object) | add additional styling for text component (optional) |
-| titleProps | none | object (style) | add additional props for Text component (optional) |
+| text | none | string | button title (optional) |
+| textStyle | none | Text style (object) | add additional styling for text component (optional) |
+| textProps | none | object (style) | add additional props for Text component (optional) |
 | buttonStyle | none | object (style) | add additional styling for button component (optional) |
 | clear | none | boolean | makes the button transparent (optional) |
 | loading | none | boolean | prop to display a loading spinner (optional) |


### PR DESCRIPTION
Now, the button is just limited to the "button" and not the container around it:
**Before :**
<img width="255" alt="capture d ecran 2018-03-14 a 22 27 04" src="https://user-images.githubusercontent.com/17292331/37431959-0460c268-27d7-11e8-80b5-f9a0125f13e9.png">
**After :**
<img width="254" alt="capture d ecran 2018-03-14 a 22 25 37" src="https://user-images.githubusercontent.com/17292331/37431969-0ed8df50-27d7-11e8-838e-14bab363a8be.png">
It's more simple to use it

So, it's preferable to set the dimensions of the button in the `containerStyle` like the rest of our components: 
**Before :**
```js
          <Button
            title='LOG IN'
            buttonStyle={{ height: 50, width: 250, backgroundColor: 'black' }}
            containerStyle={{ marginVertical: 10 }}
          />
```
**After :**
```js
          <Button
            title='LOG IN'
            buttonStyle={{ backgroundColor: 'black' }}
            containerStyle={{ marginVertical: 10, height: 50, width: 250 }}
          />
```
(1000e pr 🎉)