### PR TITLE
Update typings to match button title prop

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -243,7 +243,7 @@ export interface ButtonProps extends TouchableWithoutFeedbackProps {
    *
    * @default 'Welcome to\nReact Native Elements'
    */
-  text?: string;
+  title?: string;
 
   /**
    * If to show the icon on the right


### PR DESCRIPTION
* One liner - seems the `title` prop became `text` and was then reverted?