### PR TITLE
Remove Text from Button if title is empty

### DIFF
--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -101,7 +101,7 @@ class Button extends Component {
                 </View>
               )}
             {!loading &&
-              title && (
+              !!title && (
               <Text
                 style={[
                   styles.title,

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -100,7 +100,8 @@ class Button extends Component {
                   {icon}
                 </View>
               )}
-            {!loading && (
+            {!loading &&
+              title && (
               <Text
                 style={[
                   styles.title,


### PR DESCRIPTION
Fixes (#639 , #771 , #901) by not adding redundant `<Text/>` component with `styles.title.padding = 8` if title is empty.