### PR TITLE
Avoid changing ref function to the inner text input on every render (input sometimes becomes null, otherwise)

### DIFF
--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -46,6 +46,8 @@ class Input extends Component {
       ease: Easing.bounce,
     }).start();
   }
+  
+  _inputRef = input => (this.input = input)
 
   render() {
     const {
@@ -88,7 +90,7 @@ class Input extends Component {
           )}
           <TextInput
             {...attributes}
-            ref={input => (this.input = input)}
+            ref={this._inputRef}
             underlineColorAndroid="transparent"
             style={[
               styles.input,


### PR DESCRIPTION
fix(Input): avoid changing ref to text-input on every render

create `_inputRef` for Input object, pass it to the child text-input as ref, instead of creating a new ref function in every render.
Otherwise, in each render `this.input` becomes null for a while and that gets set again with the new ref function. 
That is due to the fact that React calls old-ref with null and new-ref with component when the ref function changes. Since, the ref function were being created in the render function, it used to change on every render.

Closes the following problem: input.focus() sometimes give the error `Cannot read the property of 'focus' of null`