### PR TITLE
Solving imgSource propType undefined in Tiles

### DIFF
--- a/src/tile/FeaturedTile.js
+++ b/src/tile/FeaturedTile.js
@@ -121,7 +121,7 @@ FeaturedTile.propTypes = {
   title: PropTypes.string,
   icon: PropTypes.object,
   caption: PropTypes.string,
-  imageSrc: Image.propTypes.source.isRequired,
+  imageSrc: Image.propTypes.source,
   onPress: PropTypes.func,
   containerStyle: ViewPropTypes.style,
   iconContainerStyle: ViewPropTypes.style,

--- a/src/tile/Tile.js
+++ b/src/tile/Tile.js
@@ -138,7 +138,7 @@ Tile.propTypes = {
   title: PropTypes.string,
   icon: PropTypes.object,
   caption: PropTypes.string,
-  imageSrc: Image.propTypes.source.isRequired,
+  imageSrc: Image.propTypes.source,
   onPress: PropTypes.func,
   activeOpacity: PropTypes.number,
   containerStyle: ViewPropTypes.style,


### PR DESCRIPTION
As stated in the title and from the discussion on slack, we're trying to solve an error showing up inside production builds for web.

Should be implemented a null check on the component as written in the attached issue #960
haven't got much time right now. 
This should also resolve problems to people that are using react styleguidist like me. Here the other related issue that I opened there: https://github.com/styleguidist/react-styleguidist/issues/913 