### PR TITLE
Added Possibility of Custom Component in Button.

### DIFF
--- a/docs/button.md
+++ b/docs/button.md
@@ -53,6 +53,13 @@ import Icon from 'react-native-vector-icons/FontAwesome';
   }}
   containerStyle={{ marginTop: 20 }}
 />
+
+
+<Button>
+	<View style={{ width: 200, height: 40, backgroundColor: "rgba(92, 99,216, 1)", justifyContent: 'center' }} >
+		<Text style={{ color: 'white', textAlign: 'center', fontWeight: '800' }}>CUSTOM COMPONENT</Text>
+	</View>
+</Button>
 ```
 
 ---

--- a/docs/listitem.md
+++ b/docs/listitem.md
@@ -281,6 +281,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `component`
 
+replace element with custom element (optional)
+
 |                             Type                              |  Default  |
 | :-----------------------------------------------------------: | :-------: |
 | View or TouchableHighlight if onPress method is added as prop | component |
@@ -288,6 +290,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `containerStyle`
+
+additional main container styling (optional)
 
 |      Type      | Default |
 | :------------: | :-----: |
@@ -297,6 +301,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `contentContainerStyle`
 
+additional wrapper styling (title and subtitle container)
+
 |      Type      | Default |
 | :------------: | :-----: |
 | object (style) |  none   |
@@ -304,6 +310,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `rightContentContainerStyle`
+
+additional wrapper styling (right title and subtitle container)
 
 |      Type      | Default |
 | :------------: | :-----: |
@@ -313,6 +321,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `chevron`
 
+set it to true if you want a chevron (optional)
+
 |  Type   | Default |
 | :-----: | :-----: |
 | boolean |  false  |
@@ -320,6 +330,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `chevronColor`
+
+set chevron color
 
 |  Type  | Default |
 | :----: | :-----: |
@@ -329,6 +341,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `checkmark`
 
+set it to true if you want a checkmark (optional)
+
 |  Type   | Default |
 | :-----: | :-----: |
 | boolean |  false  |
@@ -336,6 +350,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `checkmarkColor`
+
+set checkmark color
 
 |  Type  | Default |
 | :----: | :-----: |
@@ -345,6 +361,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `onPress`
 
+onPress method for link (optional)
+
 |   Type   | Default |
 | :------: | :-----: |
 | function |  none   |
@@ -352,6 +370,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `onLongPress`
+
+onLongPress method for link (optional)
 
 |   Type   | Default |
 | :------: | :-----: |
@@ -361,6 +381,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `title`
 
+Main title of list item
+
 |            Type             | Default |
 | :-------------------------: | :-----: |
 | string **OR** React element |  none   |
@@ -368,6 +390,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `titleStyle`
+
+Add additional styling
 
 |    Type    | Default |
 | :--------: | :-----: |
@@ -377,6 +401,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `titleProps`
 
+provide all props from react-native Text component
+
 |                                      Type                                       | Default |
 | :-----------------------------------------------------------------------------: | :-----: |
 | {[...Text props](https://facebook.github.io/react-native/docs/text.html#props)} |  none   |
@@ -384,6 +410,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `subtitle`
+
+subtitle text or custom view (optional)
 
 |            Type             | Default |
 | :-------------------------: | :-----: |
@@ -393,6 +421,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `subtitleStyle`
 
+Add additional styling
+
 |    Type    | Default |
 | :--------: | :-----: |
 | Text style |  none   |
@@ -400,6 +430,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `subtitleProps`
+
+provide all props from react-native Text component
 
 |                                      Type                                       | Default |
 | :-----------------------------------------------------------------------------: | :-----: |
@@ -409,6 +441,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `rightTitle`
 
+Show up a title on the right side of the list item
+
 |            Type             | Default |
 | :-------------------------: | :-----: |
 | string **OR** React element |  none   |
@@ -416,6 +450,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `rightTitleStyle`
+
+add additional styling
 
 |    Type    | Default |
 | :--------: | :-----: |
@@ -425,6 +461,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `rightTitleProps`
 
+provide all props from react-native Text component
+
 |                                      Type                                       | Default |
 | :-----------------------------------------------------------------------------: | :-----: |
 | {[...Text props](https://facebook.github.io/react-native/docs/text.html#props)} |  none   |
@@ -432,6 +470,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `rightSubtitle`
+
+Show up a subtitle on the right side of the list item
 
 |            Type             | Default |
 | :-------------------------: | :-----: |
@@ -441,6 +481,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `rightSubtitleStyle`
 
+Add additional styling
+
 |    Type    | Default |
 | :--------: | :-----: |
 | Text style |  none   |
@@ -448,6 +490,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `rightSubtitleProps`
+
+provide all props from react-native Text component
 
 |                                      Type                                       | Default |
 | :-----------------------------------------------------------------------------: | :-----: |
@@ -457,6 +501,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `leftIcon`
 
+displays an icon on the left (optional)
+
 |                                             Type                                              | Default |
 | :-------------------------------------------------------------------------------------------: | :-----: |
 | {[...Icon props](/react-native-elements/docs/icon.html#icon-props)}<br/>**OR**<br/> component |  none   |
@@ -464,6 +510,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `rightIcon`
+
+displays an icon on the right (optional)
 
 |                                             Type                                              | Default |
 | :-------------------------------------------------------------------------------------------: | :-----: |
@@ -473,6 +521,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `leftAvatar`
 
+displays an Avatar on the left (optional)
+
 |                                                Type                                                 | Default |
 | :-------------------------------------------------------------------------------------------------: | :-----: |
 | {[...Avatar props](/react-native-elements/docs/avatar.html#avatar-props)}<br/>**OR**<br/> component |  none   |
@@ -480,6 +530,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `rightAvatar`
+
+displays an Avatar on the right (optional)
 
 |                                                          Type                                                          | Default |
 | :--------------------------------------------------------------------------------------------------------------------: | :-----: |
@@ -489,6 +541,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `leftElement`
 
+Add any element on the left side of the list item
+
 |     Type      | Default |
 | :-----------: | :-----: |
 | React element |  none   |
@@ -496,6 +550,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `rightElement`
+
+Add any element on the right side of the list item
 
 |     Type      | Default |
 | :-----------: | :-----: |
@@ -505,6 +561,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `switch`
 
+add a switch to the right side. (object with the props of the react-native `Switch` component)
+
 |                                        Type                                         | Default |
 | :---------------------------------------------------------------------------------: | :-----: |
 | {[...Switch props](https://facebook.github.io/react-native/docs/switch.html#props)} |  none   |
@@ -512,6 +570,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `input`
+
+add an Input on the right side (object with the props of the React Native Elements `Input` component)
 
 |                                  Type                                  | Default |
 | :--------------------------------------------------------------------: | :-----: |
@@ -521,6 +581,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `buttonGroup`
 
+add a button group on the right side (object with the props of the React Native Elements `ButtonGroup` component)
+
 |                                           Type                                            | Default |
 | :---------------------------------------------------------------------------------------: | :-----: |
 | {[...ButtonGroup props](/react-native-elements/docs/button_group.html#buttongroup-props)} |  none   |
@@ -528,6 +590,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `checkbox`
+
+add a checkbox on the right side (object with the props of the React Native Elements `CheckBox` component)
 
 |                                      Type                                       | Default |
 | :-----------------------------------------------------------------------------: | :-----: |
@@ -537,6 +601,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `badge`
 
+add a badge on the right side (object with the props of the React Native Elements `Badge` component)
+
 |                                  Type                                  | Default |
 | :--------------------------------------------------------------------: | :-----: |
 | {[...Badge props](/react-native-elements/docs/badge.html#badge-props)} |  none   |
@@ -544,6 +610,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `disabled`
+
+If true the user won't be able to perform any action on the list item.
 
 |  Type   | Default |
 | :-----: | :-----: |
@@ -553,6 +621,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `disabledStyle`
 
+Specific styling to be used when list item is disabled.
+
 |      Type      | Default |
 | :------------: | :-----: |
 | object (style) |  none   |
@@ -560,6 +630,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `topDivider`
+
+Add divider at the top of the list item
 
 |  Type   | Default |
 | :-----: | :-----: |
@@ -569,6 +641,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `bottomDivider`
 
+Add divider at the bottom of the list item
+
 |  Type   | Default |
 | :-----: | :-----: |
 | boolean |  false  |
@@ -577,6 +651,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 ### `scaleProps`
 
+Provide all props for scale feedback
+
 |                                    Type                                    | Default |
 | :------------------------------------------------------------------------: | :-----: |
 | {[...Scale props](https://github.com/kohver/react-native-touchable-scale)} |  none   |
@@ -584,6 +660,8 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 ---
 
 ### `ViewComponent`
+
+Container for linear gradient (for non-expo user)
 
 |   Type    | Default |
 | :-------: | :-----: |

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -2,216 +2,216 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import {
-	StyleSheet,
-	View,
-	Text,
-	TouchableNativeFeedback,
-	TouchableOpacity,
-	ActivityIndicator,
-	Platform,
+  StyleSheet,
+  View,
+  Text,
+  TouchableNativeFeedback,
+  TouchableOpacity,
+  ActivityIndicator,
+  Platform,
 } from 'react-native';
 import colors from '../config/colors';
 
 import ViewPropTypes from '../config/ViewPropTypes';
 
 const log = () => {
-	/* eslint-disable no-console */
-	console.log('Please attach a method to this component');
+  /* eslint-disable no-console */
+  console.log('Please attach a method to this component');
 };
 
 class Button extends Component {
-	componentDidMount() {
-		const { linearGradientProps, ViewComponent } = this.props;
-		if (linearGradientProps && !global.Expo && !ViewComponent) {
-			/* eslint-disable no-console */
-			console.error(
-				`You need to pass a ViewComponent to use linearGradientProps !\nExample: ViewComponent={require('react-native-linear-gradient')}`
-			);
-		}
-	}
+  componentDidMount() {
+    const { linearGradientProps, ViewComponent } = this.props;
+    if (linearGradientProps && !global.Expo && !ViewComponent) {
+      /* eslint-disable no-console */
+      console.error(
+        `You need to pass a ViewComponent to use linearGradientProps !\nExample: ViewComponent={require('react-native-linear-gradient')}`
+      );
+    }
+  }
 
-	render() {
-		const {
-			children,
-			TouchableComponent,
-			containerStyle,
-			onPress,
-			buttonStyle,
-			clear,
-			loading,
-			loadingStyle,
-			loadingProps,
-			title,
-			titleProps,
-			titleStyle,
-			icon,
-			iconContainerStyle,
-			iconRight,
-			disabled,
-			disabledStyle,
-			disabledTitleStyle,
-			linearGradientProps,
-			ViewComponent = linearGradientProps && global.Expo
-				? global.Expo.LinearGradient
-				: View,
-			...attributes
-		} = this.props;
+  render() {
+    const {
+      children,
+      TouchableComponent,
+      containerStyle,
+      onPress,
+      buttonStyle,
+      clear,
+      loading,
+      loadingStyle,
+      loadingProps,
+      title,
+      titleProps,
+      titleStyle,
+      icon,
+      iconContainerStyle,
+      iconRight,
+      disabled,
+      disabledStyle,
+      disabledTitleStyle,
+      linearGradientProps,
+      ViewComponent = linearGradientProps && global.Expo
+        ? global.Expo.LinearGradient
+        : View,
+      ...attributes
+    } = this.props;
 
-		return (
-			<View style={containerStyle}>
-				<TouchableComponent
-					{...attributes}
-					onPress={onPress}
-					underlayColor={clear ? 'transparent' : undefined}
-					activeOpacity={clear ? 0 : undefined}
-					disabled={disabled}
-				>
-					{(children) &&
-						children
-						||
-						(
-							<ViewComponent
-								{...linearGradientProps}
-								style={[
-									styles.button,
-									buttonStyle,
-									disabled && styles.disabled,
-									disabled && disabledStyle,
-									clear && { backgroundColor: 'transparent', elevation: 0 },
-									linearGradientProps && { backgroundColor: 'transparent' },
-								]}
-							>
-								{loading && (
-									<ActivityIndicator
-										animating={true}
-										style={[styles.loading, loadingStyle]}
-										color={loadingProps.color}
-										size={loadingProps.size}
-										{...loadingProps}
-									/>
-								)}
-								{!loading &&
-									icon &&
-									!iconRight && (
-										<View style={[styles.iconContainer, iconContainerStyle]}>
-											{icon}
-										</View>
-									)}
-								{!loading &&
-									!!title && (
-										<Text
-											style={[
-												styles.title,
-												titleStyle,
-												disabled && styles.disabledTitle,
-												disabled && disabledTitleStyle,
-											]}
-											{...titleProps}
-										>
-											{title}
-										</Text>
-									)}
-								{!loading &&
-									icon &&
-									iconRight && (
-										<View style={[styles.iconContainer, iconContainerStyle]}>
-											{icon}
-										</View>
-									)}
-							</ViewComponent>
-						)
-					}
+    return (
+      <View style={containerStyle}>
+        <TouchableComponent
+          {...attributes}
+          onPress={onPress}
+          underlayColor={clear ? 'transparent' : undefined}
+          activeOpacity={clear ? 0 : undefined}
+          disabled={disabled}
+        >
+          {(children) &&
+            children
+            ||
+            (
+              <ViewComponent
+                {...linearGradientProps}
+                style={[
+                  styles.button,
+                  buttonStyle,
+                  disabled && styles.disabled,
+                  disabled && disabledStyle,
+                  clear && { backgroundColor: 'transparent', elevation: 0 },
+                  linearGradientProps && { backgroundColor: 'transparent' },
+                ]}
+              >
+                {loading && (
+                  <ActivityIndicator
+                    animating={true}
+                    style={[styles.loading, loadingStyle]}
+                    color={loadingProps.color}
+                    size={loadingProps.size}
+                    {...loadingProps}
+                  />
+                )}
+                {!loading &&
+                  icon &&
+                  !iconRight && (
+                    <View style={[styles.iconContainer, iconContainerStyle]}>
+                      {icon}
+                    </View>
+                  )}
+                {!loading &&
+                  !!title && (
+                    <Text
+                      style={[
+                        styles.title,
+                        titleStyle,
+                        disabled && styles.disabledTitle,
+                        disabled && disabledTitleStyle,
+                      ]}
+                      {...titleProps}
+                    >
+                      {title}
+                    </Text>
+                  )}
+                {!loading &&
+                  icon &&
+                  iconRight && (
+                    <View style={[styles.iconContainer, iconContainerStyle]}>
+                      {icon}
+                    </View>
+                  )}
+              </ViewComponent>
+            )
+          }
 
-				</TouchableComponent>
-			</View>
-		);
-	}
+        </TouchableComponent>
+      </View>
+    );
+  }
 }
 
 Button.propTypes = {
-	title: PropTypes.string,
-	titleStyle: Text.propTypes.style,
-	titleProps: PropTypes.object,
-	buttonStyle: ViewPropTypes.style,
-	clear: PropTypes.bool,
-	loading: PropTypes.bool,
-	loadingStyle: ViewPropTypes.style,
-	loadingProps: PropTypes.object,
-	onPress: PropTypes.any,
-	containerStyle: ViewPropTypes.style,
-	icon: PropTypes.element,
-	iconContainerStyle: ViewPropTypes.style,
-	iconRight: PropTypes.bool,
-	linearGradientProps: PropTypes.object,
-	TouchableComponent: PropTypes.any,
-	ViewComponent: PropTypes.any,
-	disabled: PropTypes.bool,
-	disabledStyle: ViewPropTypes.style,
-	disabledTitleStyle: Text.propTypes.style,
+  title: PropTypes.string,
+  titleStyle: Text.propTypes.style,
+  titleProps: PropTypes.object,
+  buttonStyle: ViewPropTypes.style,
+  clear: PropTypes.bool,
+  loading: PropTypes.bool,
+  loadingStyle: ViewPropTypes.style,
+  loadingProps: PropTypes.object,
+  onPress: PropTypes.any,
+  containerStyle: ViewPropTypes.style,
+  icon: PropTypes.element,
+  iconContainerStyle: ViewPropTypes.style,
+  iconRight: PropTypes.bool,
+  linearGradientProps: PropTypes.object,
+  TouchableComponent: PropTypes.any,
+  ViewComponent: PropTypes.any,
+  disabled: PropTypes.bool,
+  disabledStyle: ViewPropTypes.style,
+  disabledTitleStyle: Text.propTypes.style,
 };
 
 Button.defaultProps = {
-	title: 'Welcome to\nReact Native Elements',
-	iconRight: false,
-	TouchableComponent:
-		Platform.OS === 'ios' ? TouchableOpacity : TouchableNativeFeedback,
-	onPress: log,
-	clear: false,
-	loadingProps: {
-		color: 'white',
-		size: 'small',
-	},
-	buttonStyle: {
-		borderRadius: 3,
-	},
-	disabled: false,
+  title: 'Welcome to\nReact Native Elements',
+  iconRight: false,
+  TouchableComponent:
+    Platform.OS === 'ios' ? TouchableOpacity : TouchableNativeFeedback,
+  onPress: log,
+  clear: false,
+  loadingProps: {
+    color: 'white',
+    size: 'small',
+  },
+  buttonStyle: {
+    borderRadius: 3,
+  },
+  disabled: false,
 };
 
 const styles = StyleSheet.create({
-	button: {
-		flexDirection: 'row',
-		justifyContent: 'center',
-		alignItems: 'center',
-		borderRadius: 3,
-		backgroundColor: colors.primary,
-		...Platform.select({
-			android: {
-				elevation: 4,
-				borderRadius: 2,
-			},
-		}),
-	},
-	disabled: {
-		// grey from designmodo.github.io/Flat-UI/
-		backgroundColor: '#D1D5D8',
-		...Platform.select({
-			android: {
-				//no elevation
-				borderRadius: 2,
-			},
-		}),
-	},
-	title: {
-		backgroundColor: 'transparent',
-		color: 'white',
-		fontSize: 16,
-		textAlign: 'center',
-		padding: 8,
-		...Platform.select({
-			ios: {
-				fontSize: 18,
-			},
-			android: {
-				fontWeight: '500',
-			},
-		}),
-	},
-	disabledTitle: {
-		color: '#F3F4F5',
-	},
-	iconContainer: {
-		marginHorizontal: 5,
-	},
+  button: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 3,
+    backgroundColor: colors.primary,
+    ...Platform.select({
+      android: {
+        elevation: 4,
+        borderRadius: 2,
+      },
+    }),
+  },
+  disabled: {
+    // grey from designmodo.github.io/Flat-UI/
+    backgroundColor: '#D1D5D8',
+    ...Platform.select({
+      android: {
+        //no elevation
+        borderRadius: 2,
+      },
+    }),
+  },
+  title: {
+    backgroundColor: 'transparent',
+    color: 'white',
+    fontSize: 16,
+    textAlign: 'center',
+    padding: 8,
+    ...Platform.select({
+      ios: {
+        fontSize: 18,
+      },
+      android: {
+        fontWeight: '500',
+      },
+    }),
+  },
+  disabledTitle: {
+    color: '#F3F4F5',
+  },
+  iconContainer: {
+    marginHorizontal: 5,
+  },
 });
 
 export default Button;

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -32,6 +32,7 @@ class Button extends Component {
 
   render() {
     const {
+      children,
       TouchableComponent,
       containerStyle,
       onPress,
@@ -65,55 +66,63 @@ class Button extends Component {
           activeOpacity={clear ? 0 : undefined}
           disabled={disabled}
         >
-          <ViewComponent
-            {...linearGradientProps}
-            style={[
-              styles.button,
-              disabled && styles.disabled,
-              clear && { backgroundColor: 'transparent', elevation: 0 },
-              buttonStyle,
-              disabled && disabledStyle,
-              linearGradientProps && { backgroundColor: 'transparent' },
-            ]}
-          >
-            {loading && (
-              <ActivityIndicator
-                animating={true}
-                style={[styles.loading, loadingStyle]}
-                color={loadingProps.color}
-                size={loadingProps.size}
-                {...loadingProps}
-              />
-            )}
-            {!loading &&
-              icon &&
-              !iconRight && (
-                <View style={[styles.iconContainer, iconContainerStyle]}>
-                  {icon}
-                </View>
-              )}
-            {!loading &&
-              !!title && (
-                <Text
-                  style={[
-                    styles.title,
-                    titleStyle,
-                    disabled && styles.disabledTitle,
-                    disabled && disabledTitleStyle,
-                  ]}
-                  {...titleProps}
-                >
-                  {title}
-                </Text>
-              )}
-            {!loading &&
-              icon &&
-              iconRight && (
-                <View style={[styles.iconContainer, iconContainerStyle]}>
-                  {icon}
-                </View>
-              )}
-          </ViewComponent>
+
+          {(children) &&
+            children
+            ||
+            (
+              <ViewComponent
+                {...linearGradientProps}
+                style={[
+                  styles.button,
+                  disabled && styles.disabled,
+                  clear && { backgroundColor: 'transparent', elevation: 0 },
+                  buttonStyle,
+                  disabled && disabledStyle,
+                  linearGradientProps && { backgroundColor: 'transparent' },
+                ]}
+              >
+                {loading && (
+                  <ActivityIndicator
+                    animating={true}
+                    style={[styles.loading, loadingStyle]}
+                    color={loadingProps.color}
+                    size={loadingProps.size}
+                    {...loadingProps}
+                  />
+                )}
+                {!loading &&
+                  icon &&
+                  !iconRight && (
+                    <View style={[styles.iconContainer, iconContainerStyle]}>
+                      {icon}
+                    </View>
+                  )}
+                {!loading &&
+                  !!title && (
+                    <Text
+                      style={[
+                        styles.title,
+                        titleStyle,
+                        disabled && styles.disabledTitle,
+                        disabled && disabledTitleStyle,
+                      ]}
+                      {...titleProps}
+                    >
+                      {title}
+                    </Text>
+                  )}
+                {!loading &&
+                  icon &&
+                  iconRight && (
+                    <View style={[styles.iconContainer, iconContainerStyle]}>
+                      {icon}
+                    </View>
+                  )}
+              </ViewComponent>
+            )
+          }
+
         </TouchableComponent>
       </View>
     );

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -2,217 +2,217 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import {
-  StyleSheet,
-  View,
-  Text,
-  TouchableNativeFeedback,
-  TouchableOpacity,
-  ActivityIndicator,
-  Platform,
+	StyleSheet,
+	View,
+	Text,
+	TouchableNativeFeedback,
+	TouchableOpacity,
+	ActivityIndicator,
+	Platform,
 } from 'react-native';
 import colors from '../config/colors';
 
 import ViewPropTypes from '../config/ViewPropTypes';
 
 const log = () => {
-  /* eslint-disable no-console */
-  console.log('Please attach a method to this component');
+	/* eslint-disable no-console */
+	console.log('Please attach a method to this component');
 };
 
 class Button extends Component {
-  componentDidMount() {
-    const { linearGradientProps, ViewComponent } = this.props;
-    if (linearGradientProps && !global.Expo && !ViewComponent) {
-      /* eslint-disable no-console */
-      console.error(
-        `You need to pass a ViewComponent to use linearGradientProps !\nExample: ViewComponent={require('react-native-linear-gradient')}`
-      );
-    }
-  }
+	componentDidMount() {
+		const { linearGradientProps, ViewComponent } = this.props;
+		if (linearGradientProps && !global.Expo && !ViewComponent) {
+			/* eslint-disable no-console */
+			console.error(
+				`You need to pass a ViewComponent to use linearGradientProps !\nExample: ViewComponent={require('react-native-linear-gradient')}`
+			);
+		}
+	}
 
-  render() {
-    const {
-      children,
-      TouchableComponent,
-      containerStyle,
-      onPress,
-      buttonStyle,
-      clear,
-      loading,
-      loadingStyle,
-      loadingProps,
-      title,
-      titleProps,
-      titleStyle,
-      icon,
-      iconContainerStyle,
-      iconRight,
-      disabled,
-      disabledStyle,
-      disabledTitleStyle,
-      linearGradientProps,
-      ViewComponent = linearGradientProps && global.Expo
-        ? global.Expo.LinearGradient
-        : View,
-      ...attributes
-    } = this.props;
+	render() {
+		const {
+			children,
+			TouchableComponent,
+			containerStyle,
+			onPress,
+			buttonStyle,
+			clear,
+			loading,
+			loadingStyle,
+			loadingProps,
+			title,
+			titleProps,
+			titleStyle,
+			icon,
+			iconContainerStyle,
+			iconRight,
+			disabled,
+			disabledStyle,
+			disabledTitleStyle,
+			linearGradientProps,
+			ViewComponent = linearGradientProps && global.Expo
+				? global.Expo.LinearGradient
+				: View,
+			...attributes
+		} = this.props;
 
-    return (
-      <View style={containerStyle}>
-        <TouchableComponent
-          {...attributes}
-          onPress={onPress}
-          underlayColor={clear ? 'transparent' : undefined}
-          activeOpacity={clear ? 0 : undefined}
-          disabled={disabled}
-        >
+		return (
+			<View style={containerStyle}>
+				<TouchableComponent
+					{...attributes}
+					onPress={onPress}
+					underlayColor={clear ? 'transparent' : undefined}
+					activeOpacity={clear ? 0 : undefined}
+					disabled={disabled}
+				>
 
-          {(children) &&
-            children
-            ||
-            (
-              <ViewComponent
-                {...linearGradientProps}
-                style={[
-                  styles.button,
-                  disabled && styles.disabled,
-                  clear && { backgroundColor: 'transparent', elevation: 0 },
-                  buttonStyle,
-                  disabled && disabledStyle,
-                  linearGradientProps && { backgroundColor: 'transparent' },
-                ]}
-              >
-                {loading && (
-                  <ActivityIndicator
-                    animating={true}
-                    style={[styles.loading, loadingStyle]}
-                    color={loadingProps.color}
-                    size={loadingProps.size}
-                    {...loadingProps}
-                  />
-                )}
-                {!loading &&
-                  icon &&
-                  !iconRight && (
-                    <View style={[styles.iconContainer, iconContainerStyle]}>
-                      {icon}
-                    </View>
-                  )}
-                {!loading &&
-                  !!title && (
-                    <Text
-                      style={[
-                        styles.title,
-                        titleStyle,
-                        disabled && styles.disabledTitle,
-                        disabled && disabledTitleStyle,
-                      ]}
-                      {...titleProps}
-                    >
-                      {title}
-                    </Text>
-                  )}
-                {!loading &&
-                  icon &&
-                  iconRight && (
-                    <View style={[styles.iconContainer, iconContainerStyle]}>
-                      {icon}
-                    </View>
-                  )}
-              </ViewComponent>
-            )
-          }
+					{(children) &&
+						children
+						||
+						(
+							<ViewComponent
+								{...linearGradientProps}
+								style={[
+									styles.button,
+									disabled && styles.disabled,
+									clear && { backgroundColor: 'transparent', elevation: 0 },
+									buttonStyle,
+									disabled && disabledStyle,
+									linearGradientProps && { backgroundColor: 'transparent' },
+								]}
+							>
+								{loading && (
+									<ActivityIndicator
+										animating={true}
+										style={[styles.loading, loadingStyle]}
+										color={loadingProps.color}
+										size={loadingProps.size}
+										{...loadingProps}
+									/>
+								)}
+								{!loading &&
+									icon &&
+									!iconRight && (
+										<View style={[styles.iconContainer, iconContainerStyle]}>
+											{icon}
+										</View>
+									)}
+								{!loading &&
+									!!title && (
+										<Text
+											style={[
+												styles.title,
+												titleStyle,
+												disabled && styles.disabledTitle,
+												disabled && disabledTitleStyle,
+											]}
+											{...titleProps}
+										>
+											{title}
+										</Text>
+									)}
+								{!loading &&
+									icon &&
+									iconRight && (
+										<View style={[styles.iconContainer, iconContainerStyle]}>
+											{icon}
+										</View>
+									)}
+							</ViewComponent>
+						)
+					}
 
-        </TouchableComponent>
-      </View>
-    );
-  }
+				</TouchableComponent>
+			</View>
+		);
+	}
 }
 
 Button.propTypes = {
-  title: PropTypes.string,
-  titleStyle: Text.propTypes.style,
-  titleProps: PropTypes.object,
-  buttonStyle: ViewPropTypes.style,
-  clear: PropTypes.bool,
-  loading: PropTypes.bool,
-  loadingStyle: ViewPropTypes.style,
-  loadingProps: PropTypes.object,
-  onPress: PropTypes.any,
-  containerStyle: ViewPropTypes.style,
-  icon: PropTypes.element,
-  iconContainerStyle: ViewPropTypes.style,
-  iconRight: PropTypes.bool,
-  linearGradientProps: PropTypes.object,
-  TouchableComponent: PropTypes.any,
-  ViewComponent: PropTypes.any,
-  disabled: PropTypes.bool,
-  disabledStyle: ViewPropTypes.style,
-  disabledTitleStyle: Text.propTypes.style,
+	title: PropTypes.string,
+	titleStyle: Text.propTypes.style,
+	titleProps: PropTypes.object,
+	buttonStyle: ViewPropTypes.style,
+	clear: PropTypes.bool,
+	loading: PropTypes.bool,
+	loadingStyle: ViewPropTypes.style,
+	loadingProps: PropTypes.object,
+	onPress: PropTypes.any,
+	containerStyle: ViewPropTypes.style,
+	icon: PropTypes.element,
+	iconContainerStyle: ViewPropTypes.style,
+	iconRight: PropTypes.bool,
+	linearGradientProps: PropTypes.object,
+	TouchableComponent: PropTypes.any,
+	ViewComponent: PropTypes.any,
+	disabled: PropTypes.bool,
+	disabledStyle: ViewPropTypes.style,
+	disabledTitleStyle: Text.propTypes.style,
 };
 
 Button.defaultProps = {
-  title: 'Welcome to\nReact Native Elements',
-  iconRight: false,
-  TouchableComponent:
-    Platform.OS === 'ios' ? TouchableOpacity : TouchableNativeFeedback,
-  onPress: log,
-  clear: false,
-  loadingProps: {
-    color: 'white',
-    size: 'small',
-  },
-  buttonStyle: {
-    borderRadius: 3,
-  },
-  disabled: false,
+	title: 'Welcome to\nReact Native Elements',
+	iconRight: false,
+	TouchableComponent:
+		Platform.OS === 'ios' ? TouchableOpacity : TouchableNativeFeedback,
+	onPress: log,
+	clear: false,
+	loadingProps: {
+		color: 'white',
+		size: 'small',
+	},
+	buttonStyle: {
+		borderRadius: 3,
+	},
+	disabled: false,
 };
 
 const styles = StyleSheet.create({
-  button: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderRadius: 3,
-    backgroundColor: colors.primary,
-    ...Platform.select({
-      android: {
-        elevation: 4,
-        borderRadius: 2,
-      },
-    }),
-  },
-  disabled: {
-    // grey from designmodo.github.io/Flat-UI/
-    backgroundColor: '#D1D5D8',
-    ...Platform.select({
-      android: {
-        //no elevation
-        borderRadius: 2,
-      },
-    }),
-  },
-  title: {
-    backgroundColor: 'transparent',
-    color: 'white',
-    fontSize: 16,
-    textAlign: 'center',
-    padding: 8,
-    ...Platform.select({
-      ios: {
-        fontSize: 18,
-      },
-      android: {
-        fontWeight: '500',
-      },
-    }),
-  },
-  disabledTitle: {
-    color: '#F3F4F5',
-  },
-  iconContainer: {
-    marginHorizontal: 5,
-  },
+	button: {
+		flexDirection: 'row',
+		justifyContent: 'center',
+		alignItems: 'center',
+		borderRadius: 3,
+		backgroundColor: colors.primary,
+		...Platform.select({
+			android: {
+				elevation: 4,
+				borderRadius: 2,
+			},
+		}),
+	},
+	disabled: {
+		// grey from designmodo.github.io/Flat-UI/
+		backgroundColor: '#D1D5D8',
+		...Platform.select({
+			android: {
+				//no elevation
+				borderRadius: 2,
+			},
+		}),
+	},
+	title: {
+		backgroundColor: 'transparent',
+		color: 'white',
+		fontSize: 16,
+		textAlign: 'center',
+		padding: 8,
+		...Platform.select({
+			ios: {
+				fontSize: 18,
+			},
+			android: {
+				fontWeight: '500',
+			},
+		}),
+	},
+	disabledTitle: {
+		color: '#F3F4F5',
+	},
+	iconContainer: {
+		marginHorizontal: 5,
+	},
 });
 
 export default Button;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -96,7 +96,7 @@ export interface TextProps extends TextProperties {
  * HTML Style Headings
  *
  */
-export class Text extends React.Component<TextProps, any> {}
+export class Text extends React.Component<TextProps, any> { }
 
 export interface AvatarProps {
   /**
@@ -209,7 +209,7 @@ export interface AvatarProps {
  * Avatar Component
  *
  */
-export class Avatar extends React.Component<AvatarProps, any> {}
+export class Avatar extends React.Component<AvatarProps, any> { }
 
 export interface ButtonIcon extends IconObject {
   buttonStyle?: StyleProp<TextStyle>;
@@ -324,13 +324,19 @@ export interface ButtonProps extends TouchableWithoutFeedbackProps {
    * Style of the button when disabled
    */
   disabledStyle?: StyleProp<ViewStyle>;
+  
+  /**
+   * Override the default contents of the Button.
+   * @default false
+   */
+  children?: JSX.Element;
 }
 
 /**
  * Button component
  *
  */
-export class Button extends React.Component<ButtonProps, any> {}
+export class Button extends React.Component<ButtonProps, any> { }
 
 export interface BadgeProps {
   /**
@@ -377,7 +383,7 @@ export interface BadgeProps {
  * Badge component
  *
  */
-export class Badge extends React.Component<BadgeProps, any> {}
+export class Badge extends React.Component<BadgeProps, any> { }
 
 export interface CardProps {
   /**
@@ -467,7 +473,7 @@ export interface CardProps {
  * Card component
  *
  */
-export class Card extends React.Component<CardProps, any> {}
+export class Card extends React.Component<CardProps, any> { }
 
 /**
  * Set the buttons within a Group.
@@ -599,7 +605,7 @@ export interface ButtonGroupProps {
   setOpacityTo?(value: number): void;
 }
 
-export class ButtonGroup extends React.Component<ButtonGroupProps, any> {}
+export class ButtonGroup extends React.Component<ButtonGroupProps, any> { }
 
 export interface CheckBoxProps {
   /**
@@ -715,7 +721,7 @@ export interface CheckBoxProps {
    */
   fontFamily?: string;
 }
-export class CheckBox extends React.Component<CheckBoxProps, any> {}
+export class CheckBox extends React.Component<CheckBoxProps, any> { }
 
 export interface DividerProps {
   /**
@@ -726,7 +732,7 @@ export interface DividerProps {
   style?: StyleProp<ViewStyle>;
 }
 
-export class Divider extends React.Component<DividerProps, any> {}
+export class Divider extends React.Component<DividerProps, any> { }
 
 export interface FormValidationMessageProps extends ViewProperties {
   /**
@@ -748,7 +754,7 @@ export interface FormValidationMessageProps extends ViewProperties {
 export class FormValidationMessage extends React.Component<
   FormValidationMessageProps,
   any
-> {}
+  > { }
 
 export interface InputProps extends TextInputProperties {
   /**
@@ -914,7 +920,7 @@ export interface FormLabelProps extends ViewProperties {
   fontFamily?: string;
 }
 
-export class FormLabel extends React.Component<FormLabelProps, any> {}
+export class FormLabel extends React.Component<FormLabelProps, any> { }
 
 export interface HeaderIcon extends IconObject {
   icon?: string;
@@ -983,7 +989,7 @@ export interface HeaderProps extends ViewProperties {
 /**
  * Header component
  */
-export class Header extends React.Component<HeaderProps, any> {}
+export class Header extends React.Component<HeaderProps, any> { }
 
 export interface IconProps {
   /**
@@ -1065,7 +1071,7 @@ export interface IconProps {
 /**
  * Icon component
  */
-export class Icon extends React.Component<IconProps, any> {}
+export class Icon extends React.Component<IconProps, any> { }
 
 export interface ScaleProps extends TouchableWithoutFeedbackProps {
   style?: StyleProp<ViewStyle>;
@@ -1125,7 +1131,7 @@ export interface ListItemProps {
 /**
  * ListItem component
  */
-export class ListItem extends React.Component<ListItemProps, any> {}
+export class ListItem extends React.Component<ListItemProps, any> { }
 
 export interface OverlayProps {
   /**
@@ -1191,7 +1197,7 @@ export interface OverlayProps {
   fullScreen?: boolean;
 }
 
-export class Overlay extends React.Component<OverlayProps> {}
+export class Overlay extends React.Component<OverlayProps> { }
 
 export interface ButtonInformation {
   title: string;
@@ -1277,7 +1283,7 @@ export interface PricingCardProps {
 /**
  * PricingCard component
  */
-export class PricingCard extends React.Component<PricingCardProps, any> {}
+export class PricingCard extends React.Component<PricingCardProps, any> { }
 
 export interface RatingProps {
   /**
@@ -1358,7 +1364,7 @@ export interface RatingProps {
 /**
  * Rating component
  */
-export class Rating extends React.Component<RatingProps, any> {}
+export class Rating extends React.Component<RatingProps, any> { }
 
 export interface SearchBarWrapperProps {
   /**
@@ -1702,14 +1708,14 @@ export interface SliderProps {
    * @default undefined
    */
   animationConfig?:
-    | Animated.TimingAnimationConfig
-    | Animated.SpringAnimationConfig;
+  | Animated.TimingAnimationConfig
+  | Animated.SpringAnimationConfig;
 }
 
 /**
  * Slider component
  */
-export class Slider extends React.Component<SliderProps, any> {}
+export class Slider extends React.Component<SliderProps, any> { }
 
 export type SocialMediaType =
   | 'facebook'
@@ -1842,7 +1848,7 @@ export interface SocialIconProps {
 /**
  * SocialIcon component
  */
-export class SocialIcon extends React.Component<SocialIconProps, any> {}
+export class SocialIcon extends React.Component<SocialIconProps, any> { }
 
 export interface TileProps {
   /**
@@ -1930,7 +1936,7 @@ export interface TileProps {
 /**
  * Tile component
  */
-export class Tile extends React.Component<TileProps, any> {}
+export class Tile extends React.Component<TileProps, any> { }
 
 /**
  * Colors


### PR DESCRIPTION
Added possibility of Custom Component in Button that replace the typical Title/Icon.
This way you can configure the content of a button in any way that you want.

Usage:
Just Add Children to the Button  Like the example:
```
<Button>
	<View style={{ width: 200, height: 40, backgroundColor: "rgba(92, 99,216, 1)", justifyContent: 'center' }} >
		<Text style={{ color: 'white', textAlign: 'center', fontWeight: '800' }}>CUSTOM COMPONENT</Text>
	</View>
</Button>
```

Reason:
I don't know if anyone as the same problem as I do but I need to be able to customize the way my designer want the buttons and in the current button I was limited to title and icon.

@iRoachie  @martinezguillaume @xavier-villelegier @Monte9 