### PR TITLE
Refactor and make uniform all SearchBars

### DIFF
--- a/docs/input.md
+++ b/docs/input.md
@@ -15,6 +15,11 @@ import { Input } from 'react-native-elements';
 
 <Input
   placeholder='INPUT WITH ICON'
+  leftIcon={{ type: 'font-awesome', name: 'chevron-left' }}
+/>
+
+<Input
+  placeholder='INPUT WITH CUSTOM ICON'
   leftIcon={
     <Icon
       name='user'
@@ -131,11 +136,11 @@ styling for the label (optional)
 
 ### `leftIcon`
 
-displays an icon to the left (optional)
+displays an icon on the left (optional)
 
-|          Type          | Default |
-| :--------------------: | :-----: |
-| React Native Component |  none   |
+|                                             Type                                              | Default |
+| :-------------------------------------------------------------------------------------------: | :-----: |
+| {[...Icon props](/react-native-elements/docs/icon.html#icon-props)}<br/>**OR**<br/> component |  none   |
 
 ---
 
@@ -151,11 +156,11 @@ styling for left Icon Component container
 
 ### `rightIcon`
 
-displays an icon to the right (optional)
+displays an icon on the right (optional)
 
-|          Type          | Default |
-| :--------------------: | :-----: |
-| React Native Component |  none   |
+|                                             Type                                              | Default |
+| :-------------------------------------------------------------------------------------------: | :-----: |
+| {[...Icon props](/react-native-elements/docs/icon.html#icon-props)}<br/>**OR**<br/> component |  none   |
 
 ---
 
@@ -181,6 +186,6 @@ add shaking effect to input component (optional)
 
 #### Styles explanation
 
-| Input with a label and an error message                                 | Styles explanation                                                  |
-| ----------------------------------------------------------------------- | ------------------------------------------------------------------- |
-|<img src="/react-native-elements/img/input_without_explanation.png" />   | <img src="/react-native-elements/img/input_with_explanation.png" /> |
+| Input with a label and an error message                                | Styles explanation                                                  |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| <img src="/react-native-elements/img/input_without_explanation.png" /> | <img src="/react-native-elements/img/input_with_explanation.png" /> |

--- a/docs/searchbar.md
+++ b/docs/searchbar.md
@@ -27,7 +27,7 @@ import { SearchBar } from 'react-native-elements'
 
 <SearchBar
   clearIcon={{ color: 'red' }}
-  searchIcon={null} // You could have passed `false` too
+  searchIcon={false} // You could have passed `null` too
   onChangeText={someMethod}
   onClear={someMethod}
   placeholder='Type Here...' />

--- a/docs/searchbar.md
+++ b/docs/searchbar.md
@@ -26,13 +26,22 @@ import { SearchBar } from 'react-native-elements'
   placeholder='Type Here...' />
 
 <SearchBar
-  noIcon
+  clearIcon={{ color: 'red' }}
+  searchIcon={null} // You could have passed `false` too
   onChangeText={someMethod}
   onClear={someMethod}
   placeholder='Type Here...' />
 
 <SearchBar
   round
+  searchIcon={{ size: 24 }}
+  onChangeText={someMethod}
+  onClear={someMethod}
+  placeholder='Type Here...' />
+
+<SearchBar
+  lightTheme
+  searchIcon={<CustomComponent />}
   onChangeText={someMethod}
   onClear={someMethod}
   placeholder='Type Here...' />
@@ -41,13 +50,6 @@ import { SearchBar } from 'react-native-elements'
   lightTheme
   onChangeText={someMethod}
   onClear={someMethod}
-  placeholder='Type Here...' />
-
-<SearchBar
-  lightTheme
-  onChangeText={someMethod}
-  onClear={someMethod}
-  icon={{ type: 'font-awesome', name: 'search' }}
   placeholder='Type Here...' />
 
 <SearchBar
@@ -60,41 +62,81 @@ import { SearchBar } from 'react-native-elements'
   showLoading
   platform="android"
   placeholder='Search' />
+
+<SearchBar
+  showLoading
+  platform="android"
+  cancelIcon={{ type: 'font-awesome', name: 'chevron-left' }}
+  placeholder='Search' />
 ```
 
 ### Props
 
-> This component inherits [all native TextInput props that come with a standard React Native TextInput element](https://facebook.github.io/react-native/docs/textinput.html), along with the following:
+> This component inherits all React Native Elements props, which means [all native TextInput props that come with a standard React Native TextInput element](https://facebook.github.io/react-native/docs/textinput.html), along with the following:
 
+* [`platform`](#platform)
 * [`clearIcon`](#clearicon)
+* [`searchIcon`](#searchIcon)
+* [`cancelIcon`](#cancelIcon) (**`platform="android"` only**)
 * [`containerStyle`](#containerstyle)
-* [`icon`](#icon)
 * [`inputStyle`](#inputstyle)
-* [`lightTheme`](#lighttheme)
+* [`lightTheme`](#lighttheme) (**`platform="default"` only**)
 * [`loadingProps`](#loadingprops)
 * [`noIcon`](#noicon)
 * [`onChangeText`](#onchangetext)
 * [`onClear`](#onclear)
 * [`placeholder`](#placeholder)
 * [`placeholderTextColor`](#placeholdertextcolor)
-* [`round`](#round)
+* [`round`](#round) (**`platform="default"` only**)
 * [`showLoading`](#showloading)
 * [`underlineColorAndroid`](#underlinecolorandroid)
 * [`cancelButtonTitle`](#cancelbuttontitle)
 * [`onCancel`](#oncancel)
-* [`platform`](#platform)
 
 ---
 
 # Reference
 
+### `platform`
+
+choose the look and feel of the search bar. One of "default", "ios", "android"
+
+|  Type  |  Default  |
+| :----: | :-------: |
+| string | "default" |
+
+---
+
 ### `clearIcon`
 
-specify color, styling, or another [Material Icon Name](https://design.google.com/icons/) (Note: pressing on this icon clears text inside the searchbar)
+This props allows to override the `Icon` props or use a custom component.
+Use `null` or `false` to hide the icon.
 
-|                          Type                          |               Default               |
-| :----------------------------------------------------: | :---------------------------------: |
-| object {name (string), color (string), style (object)} | { color: '#86939e', name: 'close' } |
+|                                             Type                                              | Default |
+| :-------------------------------------------------------------------------------------------: | :-----: |
+| {[...Icon props](/react-native-elements/docs/icon.html#icon-props)}<br/>**OR**<br/> component |  none   |
+
+---
+
+### `searchIcon`
+
+This props allows to override the `Icon` props or use a custom component.
+Use `null` or `false` to hide the icon.
+
+|                                             Type                                              | Default |
+| :-------------------------------------------------------------------------------------------: | :-----: |
+| {[...Icon props](/react-native-elements/docs/icon.html#icon-props)}<br/>**OR**<br/> component |  none   |
+
+---
+
+### `cancelIcon` (**`platform="android"` only**)
+
+This props allows to override the `Icon` props or use a custom component.
+Use `null` or `false` to hide the icon.
+
+|                                             Type                                              | Default |
+| :-------------------------------------------------------------------------------------------: | :-----: |
+| {[...Icon props](/react-native-elements/docs/icon.html#icon-props)}<br/>**OR**<br/> component |  none   |
 
 ---
 
@@ -108,16 +150,6 @@ style the container of the TextInput
 
 ---
 
-### `icon`
-
-specify type, name, color, and styling of the icon
-
-|                                 Type                                  |                        Default                         |
-| :-------------------------------------------------------------------: | :----------------------------------------------------: |
-| object {type (string), name (string), color (string), style (object)} | { type: 'material', color: '#86939e', name: 'search' } |
-
----
-
 ### `inputStyle`
 
 style the TextInput
@@ -128,7 +160,7 @@ style the TextInput
 
 ---
 
-### `lightTheme`
+### `lightTheme` (**`platform="default"` only**)
 
 change theme to light theme
 
@@ -145,16 +177,6 @@ props passed to ActivityIndicator
 |  Type  | Default |
 | :----: | :-----: |
 | object |   { }   |
-
----
-
-### `noIcon`
-
-remove icon from textinput
-
-|  Type   | Default |
-| :-----: | :-----: |
-| boolean |  false  |
 
 ---
 
@@ -198,7 +220,7 @@ set the color of the placeholder text
 
 ---
 
-### `round`
+### `round` (**`platform="default"` only**)
 
 change TextInput styling to rounded corners
 
@@ -245,16 +267,6 @@ callback fired when pressing the cancel button (iOS) or the back icon (Android)
 |   Type   | Default |
 | :------: | :-----: |
 | function |  null   |
-
----
-
-### `platform`
-
-choose the look and feel of the search bar. One of "default", "ios", "android"
-
-|  Type  |  Default  |
-| :----: | :-------: |
-| string | "default" |
 
 ---
 

--- a/docs/searchbar.md
+++ b/docs/searchbar.md
@@ -72,7 +72,7 @@ import { SearchBar } from 'react-native-elements'
 
 ### Props
 
-> This component inherits all React Native Elements props, which means [all native TextInput props that come with a standard React Native TextInput element](https://facebook.github.io/react-native/docs/textinput.html), along with the following:
+> This component inherits all [React Native Elements Input props](/react-native-elements/docs/input.html#props), which means [all native TextInput props that come with a standard React Native TextInput element](https://facebook.github.io/react-native/docs/textinput.html), along with the following:
 
 * [`platform`](#platform)
 * [`clearIcon`](#clearicon)

--- a/src/helpers/nodeType.js
+++ b/src/helpers/nodeType.js
@@ -1,0 +1,7 @@
+import PropTypes from 'prop-types';
+
+export default PropTypes.oneOfType([
+  PropTypes.element,
+  PropTypes.object,
+  PropTypes.bool,
+]);

--- a/src/helpers/renderIcon.js
+++ b/src/helpers/renderIcon.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import Icon from '../icons/Icon';
+
+export default (content, defaultIconProps) => {
+  if (content === null || content === false) {
+    return null;
+  }
+  if (React.isValidElement(content)) {
+    return content;
+  }
+  const iconProps = { ...defaultIconProps, ...content };
+  return <Icon {...iconProps} />;
+};

--- a/src/helpers/renderIcon.js
+++ b/src/helpers/renderIcon.js
@@ -9,6 +9,11 @@ export default (content, defaultIconProps) => {
   if (React.isValidElement(content)) {
     return content;
   }
+  // Just in case
+  if (content === true) {
+    return <Icon {...defaultIconProps} />;
+  }
+  // if `content` is undefined the icon will be only defined by defaultIconProps
   const iconProps = { ...defaultIconProps, ...content };
   return <Icon {...iconProps} />;
 };

--- a/src/helpers/renderNode.js
+++ b/src/helpers/renderNode.js
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import Icon from '../icons/Icon';
-
-export default (content, defaultIconProps) => {
+export default (Component, content, defaultIconProps) => {
   if (content === null || content === false) {
     return null;
   }
@@ -11,9 +9,8 @@ export default (content, defaultIconProps) => {
   }
   // Just in case
   if (content === true) {
-    return <Icon {...defaultIconProps} />;
+    return <Component {...defaultIconProps} />;
   }
   // if `content` is undefined the icon will be only defined by defaultIconProps
-  const iconProps = { ...defaultIconProps, ...content };
-  return <Icon {...iconProps} />;
+  return <Component {...defaultIconProps} {...content} />;
 };

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -81,24 +81,28 @@ class Input extends Component {
             { transform: [{ translateX }] },
           ]}
         >
-          {leftIcon &&
-            renderIcon(leftIcon, {
-              containerStyle: [
+          {leftIcon && (
+            <View
+              style={[
                 styles.iconContainer,
                 { marginLeft: 15 },
                 leftIconContainerStyle,
-              ],
-            })}
+              ]}
+            >
+              {renderIcon(leftIcon)}
+            </View>
+          )}
           <TextInput
             {...attributes}
             ref={this._inputRef}
             underlineColorAndroid="transparent"
             style={[styles.input, inputStyle]}
           />
-          {rightIcon &&
-            renderIcon(rightIcon, {
-              containerStyle: [styles.iconContainer, rightIconContainerStyle],
-            })}
+          {rightIcon && (
+            <View style={[styles.iconContainer, rightIconContainerStyle]}>
+              {renderIcon(rightIcon)}
+            </View>
+          )}
         </Animated.View>
         {errorMessage && (
           <Text style={[styles.error, errorStyle && errorStyle]}>

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -15,8 +15,7 @@ import {
 import ViewPropTypes from '../config/ViewPropTypes';
 import fonts from '../config/fonts';
 import colors from '../config/colors';
-
-const SCREEN_WIDTH = Dimensions.get('window').width;
+import renderIcon from '../helpers/renderIcon';
 
 class Input extends Component {
   componentWillMount() {
@@ -82,28 +81,24 @@ class Input extends Component {
             { transform: [{ translateX }] },
           ]}
         >
-          {leftIcon && (
-            <View
-              style={[
+          {leftIcon &&
+            renderIcon(leftIcon, {
+              containerStyle: [
                 styles.iconContainer,
                 { marginLeft: 15 },
                 leftIconContainerStyle,
-              ]}
-            >
-              {leftIcon}
-            </View>
-          )}
+              ],
+            })}
           <TextInput
             {...attributes}
             ref={this._inputRef}
             underlineColorAndroid="transparent"
             style={[styles.input, inputStyle]}
           />
-          {rightIcon && (
-            <View style={[styles.iconContainer, rightIconContainerStyle]}>
-              {rightIcon}
-            </View>
-          )}
+          {rightIcon &&
+            renderIcon(rightIcon, {
+              containerStyle: [styles.iconContainer, rightIconContainerStyle],
+            })}
         </Animated.View>
         {errorMessage && (
           <Text style={[styles.error, errorStyle && errorStyle]}>
@@ -115,14 +110,18 @@ class Input extends Component {
   }
 }
 
+const elementOrObject = PropTypes.oneOfType([
+  PropTypes.element,
+  PropTypes.object,
+]);
 Input.propTypes = {
   containerStyle: ViewPropTypes.style,
   inputContainerStyle: ViewPropTypes.style,
 
-  leftIcon: PropTypes.node,
+  leftIcon: elementOrObject,
   leftIconContainerStyle: ViewPropTypes.style,
 
-  rightIcon: PropTypes.node,
+  rightIcon: elementOrObject,
   rightIconContainerStyle: ViewPropTypes.style,
 
   inputStyle: Text.propTypes.style,

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -13,9 +13,11 @@ import {
 } from 'react-native';
 
 import ViewPropTypes from '../config/ViewPropTypes';
+import nodeType from '../helpers/nodeType';
 import fonts from '../config/fonts';
 import colors from '../config/colors';
-import renderIcon from '../helpers/renderIcon';
+import renderNode from '../helpers/renderNode';
+import Icon from '../icons/Icon'
 
 class Input extends Component {
   componentWillMount() {
@@ -89,7 +91,7 @@ class Input extends Component {
                 leftIconContainerStyle,
               ]}
             >
-              {renderIcon(leftIcon)}
+              {renderNode(Icon, leftIcon)}
             </View>
           )}
           <TextInput
@@ -100,7 +102,7 @@ class Input extends Component {
           />
           {rightIcon && (
             <View style={[styles.iconContainer, rightIconContainerStyle]}>
-              {renderIcon(rightIcon)}
+              {renderNode(Icon, rightIcon)}
             </View>
           )}
         </Animated.View>
@@ -114,18 +116,14 @@ class Input extends Component {
   }
 }
 
-const elementOrObject = PropTypes.oneOfType([
-  PropTypes.element,
-  PropTypes.object,
-]);
 Input.propTypes = {
   containerStyle: ViewPropTypes.style,
   inputContainerStyle: ViewPropTypes.style,
 
-  leftIcon: elementOrObject,
+  leftIcon: nodeType,
   leftIconContainerStyle: ViewPropTypes.style,
 
-  rightIcon: elementOrObject,
+  rightIcon: nodeType,
   rightIconContainerStyle: ViewPropTypes.style,
 
   inputStyle: Text.propTypes.style,

--- a/src/searchbar/SearchBar-android.js
+++ b/src/searchbar/SearchBar-android.js
@@ -93,7 +93,7 @@ class SearchBar extends Component {
       name: 'close',
       size: 25,
       color: ANDROID_GRAY,
-      onPress: () => this.clear(),
+      onPress: this.clear,
     };
     return (
       <View style={[styles.container, containerStyle]}>

--- a/src/searchbar/SearchBar-android.js
+++ b/src/searchbar/SearchBar-android.js
@@ -167,7 +167,6 @@ const styles = StyleSheet.create({
     paddingBottom: 8,
   },
   input: {
-    flex: 1,
     marginLeft: 24,
     marginRight: 8,
   },

--- a/src/searchbar/SearchBar-android.js
+++ b/src/searchbar/SearchBar-android.js
@@ -7,13 +7,19 @@ import {
   ActivityIndicator,
   Text,
 } from 'react-native';
-import MaterialIcon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import ViewPropTypes from '../config/ViewPropTypes';
 import Input from '../input/Input';
+import renderIcon from '../helpers/renderIcon';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const ANDROID_GRAY = 'rgba(0, 0, 0, 0.54)';
+const defaultSearchIcon = {
+  type: 'material-community',
+  size: 25,
+  color: ANDROID_GRAY,
+  name: 'magnify',
+};
 
 class SearchBar extends Component {
   focus = () => {
@@ -62,26 +68,33 @@ class SearchBar extends Component {
     const {
       clearIcon,
       containerStyle,
-      leftIcon,
       leftIconContainerStyle,
       rightIconContainerStyle,
       inputContainerStyle,
       inputStyle,
-      noIcon,
+      searchIcon,
+      cancelIcon,
       showLoading,
       loadingProps,
       ...attributes
     } = this.props;
     const { hasFocus, isEmpty } = this.state;
     const { style: loadingStyle, ...otherLoadingProps } = loadingProps;
-    const searchIcon = (
-      <MaterialIcon
-        size={25}
-        color={ANDROID_GRAY}
-        name={hasFocus ? 'arrow-left' : 'magnify'}
-        onPress={hasFocus ? this.cancel : null}
-      />
-    );
+
+    const defaultCancelIcon = {
+      type: 'material-community',
+      size: 25,
+      color: ANDROID_GRAY,
+      name: 'arrow-left',
+      onPress: this.cancel,
+    };
+    const defaultClearIcon = {
+      type: 'material-community',
+      name: 'close',
+      size: 25,
+      color: ANDROID_GRAY,
+      onPress: () => this.clear(),
+    };
     return (
       <View style={[styles.container, containerStyle]}>
         <Input
@@ -92,7 +105,11 @@ class SearchBar extends Component {
           ref={input => (this.input = input)}
           inputStyle={[styles.input, inputStyle]}
           inputContainerStyle={[styles.inputContainer, inputContainerStyle]}
-          leftIcon={noIcon ? undefined : leftIcon ? leftIcon : searchIcon}
+          leftIcon={
+            hasFocus
+              ? renderIcon(cancelIcon, defaultCancelIcon)
+              : renderIcon(searchIcon, defaultSearchIcon)
+          }
           leftIconContainerStyle={[
             styles.leftIconContainerStyle,
             leftIconContainerStyle,
@@ -101,22 +118,11 @@ class SearchBar extends Component {
             <View style={{ flexDirection: 'row' }}>
               {showLoading && (
                 <ActivityIndicator
-                  style={[
-                    clearIcon && !isEmpty && { marginRight: 10 },
-                    loadingStyle,
-                  ]}
+                  style={[{ marginRight: 5 }, loadingStyle]}
                   {...otherLoadingProps}
                 />
               )}
-              {clearIcon &&
-                !isEmpty && (
-                  <MaterialIcon
-                    name={'close'}
-                    size={25}
-                    color={ANDROID_GRAY}
-                    onPress={() => this.clear()}
-                  />
-                )}
+              {!isEmpty && renderIcon(clearIcon, defaultClearIcon)}
             </View>
           }
           rightIconContainerStyle={[
@@ -129,13 +135,17 @@ class SearchBar extends Component {
   }
 }
 
+const elementOrObject = PropTypes.oneOfType([
+  PropTypes.element,
+  PropTypes.object,
+]);
 SearchBar.propTypes = {
-  clearIcon: PropTypes.bool,
+  clearIcon: elementOrObject,
+  searchIcon: elementOrObject,
+  cancelIcon: elementOrObject,
   loadingProps: PropTypes.object,
-  noIcon: PropTypes.bool,
   showLoading: PropTypes.bool,
   containerStyle: ViewPropTypes.style,
-  leftIcon: PropTypes.object,
   leftIconContainerStyle: ViewPropTypes.style,
   rightIconContainerStyle: ViewPropTypes.style,
   inputContainerStyle: ViewPropTypes.style,
@@ -148,9 +158,7 @@ SearchBar.propTypes = {
 };
 
 SearchBar.defaultProps = {
-  clearIcon: true,
   loadingProps: {},
-  noIcon: false,
   showLoading: false,
   onClear: () => null,
   onCancel: () => null,

--- a/src/searchbar/SearchBar-android.js
+++ b/src/searchbar/SearchBar-android.js
@@ -9,8 +9,10 @@ import {
 } from 'react-native';
 
 import ViewPropTypes from '../config/ViewPropTypes';
+import nodeType from '../helpers/nodeType';
 import Input from '../input/Input';
-import renderIcon from '../helpers/renderIcon';
+import Icon from '../icons/Icon';
+import renderNode from '../helpers/renderNode';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const ANDROID_GRAY = 'rgba(0, 0, 0, 0.54)';
@@ -107,8 +109,8 @@ class SearchBar extends Component {
           inputContainerStyle={[styles.inputContainer, inputContainerStyle]}
           leftIcon={
             hasFocus
-              ? renderIcon(cancelIcon, defaultCancelIcon)
-              : renderIcon(searchIcon, defaultSearchIcon)
+              ? renderNode(Icon, cancelIcon, defaultCancelIcon)
+              : renderNode(Icon, searchIcon, defaultSearchIcon)
           }
           leftIconContainerStyle={[
             styles.leftIconContainerStyle,
@@ -122,7 +124,7 @@ class SearchBar extends Component {
                   {...otherLoadingProps}
                 />
               )}
-              {!isEmpty && renderIcon(clearIcon, defaultClearIcon)}
+              {!isEmpty && renderNode(Icon, clearIcon, defaultClearIcon)}
             </View>
           }
           rightIconContainerStyle={[
@@ -135,14 +137,10 @@ class SearchBar extends Component {
   }
 }
 
-const elementOrObject = PropTypes.oneOfType([
-  PropTypes.element,
-  PropTypes.object,
-]);
 SearchBar.propTypes = {
-  clearIcon: elementOrObject,
-  searchIcon: elementOrObject,
-  cancelIcon: elementOrObject,
+  clearIcon: nodeType,
+  searchIcon: nodeType,
+  cancelIcon: nodeType,
   loadingProps: PropTypes.object,
   showLoading: PropTypes.bool,
   containerStyle: ViewPropTypes.style,

--- a/src/searchbar/SearchBar-default.js
+++ b/src/searchbar/SearchBar-default.js
@@ -42,11 +42,6 @@ class SearchBar extends Component {
     this.props.onClear();
   };
 
-  cancel = () => {
-    this.blur();
-    this.props.onCancel();
-  };
-
   onFocus = () => {
     this.props.onFocus();
     this.setState({ hasFocus: true });
@@ -152,7 +147,6 @@ SearchBar.propTypes = {
   inputContainerStyle: ViewPropTypes.style,
   inputStyle: Text.propTypes.style,
   onClear: PropTypes.func,
-  onCancel: PropTypes.func,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
   onChangeText: PropTypes.func,
@@ -168,7 +162,6 @@ SearchBar.defaultProps = {
   round: false,
   placeholderTextColor: colors.grey3,
   onClear: () => null,
-  onCancel: () => null,
   onFocus: () => null,
   onBlur: () => null,
   onChangeText: () => null,

--- a/src/searchbar/SearchBar-default.js
+++ b/src/searchbar/SearchBar-default.js
@@ -4,162 +4,173 @@ import {
   ActivityIndicator,
   View,
   StyleSheet,
-  TextInput,
-  Platform,
-  Text as NativeText,
+  Dimensions,
+  Text,
 } from 'react-native';
+import MaterialIcon from 'react-native-vector-icons/MaterialCommunityIcons';
 import colors from '../config/colors';
 import normalize from '../helpers/normalizeText';
 import ViewPropTypes from '../config/ViewPropTypes';
 import getIconType from '../helpers/getIconType';
 
-class Search extends Component {
-  getRef = () => {
-    return this.input || this.refs[this.props.textInputRef];
+import Input from '../input/Input';
+
+const SCREEN_WIDTH = Dimensions.get('window').width;
+
+class SearchBar extends Component {
+  focus = () => {
+    this.input.focus();
   };
 
-  getRefHandler = () => {
-    if (this.props.textInputRef) {
-      if (typeof this.props.textInputRef === 'function') {
-        return input => {
-          this.input = input;
-          this.props.textInputRef(input);
-        };
-      } else {
-        return this.props.textInputRef;
-      }
-    } else {
-      return input => (this.input = input);
-    }
+  blur = () => {
+    this.input.blur();
   };
 
-  focus() {
-    this.getRef() && this.getRef().focus();
-  }
-
-  blur() {
-    this.getRef() && this.getRef().blur();
-  }
-
-  clear() {
-    this.getRef() && this.getRef().clear();
-    this.props.onChangeText('');
+  clear = () => {
+    this.input.clear();
+    this.onChangeText('');
     this.props.onClear();
+  };
+
+  cancel = () => {
+    this.blur();
+    this.props.onCancel();
+  };
+
+  onFocus = () => {
+    this.props.onFocus();
+    this.setState({ hasFocus: true });
+  };
+
+  onBlur = () => {
+    this.props.onBlur();
+    this.setState({ hasFocus: false });
+  };
+
+  onChangeText = text => {
+    this.props.onChangeText(text);
+    this.setState({ isEmpty: text === '' });
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasFocus: false,
+      isEmpty: true,
+    };
   }
 
   render() {
     const {
-      containerStyle,
-      inputStyle,
-      icon,
-      noIcon,
       lightTheme,
       round,
+      clearIcon,
+      containerStyle,
+      leftIcon,
+      leftIconContainerStyle,
+      rightIconContainerStyle,
+      inputContainerStyle,
+      inputStyle,
+      noIcon,
       showLoading,
       loadingProps,
-      clearIcon,
-      containerRef,
-      underlineColorAndroid,
+      placeholderTextColor,
       ...attributes
     } = this.props;
-
+    const { isEmpty } = this.state;
     const { style: loadingStyle, ...otherLoadingProps } = loadingProps;
-
-    //returns materialicon or customIcon as default
-    let Icon = getIconType(icon.type);
-
+    const searchIcon = (
+      <MaterialIcon size={18} name="magnify" color={colors.grey3} />
+    );
     return (
       <View
-        ref={containerRef}
         style={[
           styles.container,
+          containerStyle,
           lightTheme && styles.containerLight,
-          containerStyle && containerStyle,
         ]}
       >
-        <TextInput
+        <Input
           {...attributes}
-          ref={this.getRefHandler()}
-          underlineColorAndroid={
-            underlineColorAndroid ? underlineColorAndroid : 'transparent'
-          }
-          style={[
-            styles.input,
+          onFocus={this.onFocus}
+          onBlur={this.onBlur}
+          onChangeText={this.onChangeText}
+          ref={input => (this.input = input)}
+          placeholderTextColor={placeholderTextColor}
+          inputStyle={[styles.input, inputStyle]}
+          inputContainerStyle={[
+            styles.inputContentContainer,
+            inputContainerStyle,
             lightTheme && styles.inputLight,
-            noIcon && { paddingLeft: 9 },
-            round && { borderRadius: Platform.OS === 'ios' ? 15 : 20 },
-            inputStyle && inputStyle,
-            clearIcon && showLoading && { paddingRight: 50 },
-            ((clearIcon && !showLoading) || (!clearIcon && showLoading)) && {
-              paddingRight: 30,
-            },
+            round && styles.round,
+          ]}
+          containerStyle={styles.inputContainer}
+          leftIcon={noIcon ? undefined : leftIcon ? leftIcon : searchIcon}
+          leftIconContainerStyle={[
+            styles.leftIconContainerStyle,
+            leftIconContainerStyle,
+          ]}
+          rightIcon={
+            <View style={{ flexDirection: 'row' }}>
+              {showLoading && (
+                <ActivityIndicator
+                  style={[
+                    clearIcon && !isEmpty && { marginRight: 10 },
+                    loadingStyle,
+                  ]}
+                  {...otherLoadingProps}
+                />
+              )}
+              {clearIcon &&
+                !isEmpty && (
+                  <MaterialIcon
+                    size={18}
+                    name="close"
+                    onPress={() => this.clear()}
+                    color={colors.grey3}
+                  />
+                )}
+            </View>
+          }
+          rightIconContainerStyle={[
+            styles.rightIconContainerStyle,
+            rightIconContainerStyle,
           ]}
         />
-        {!noIcon && (
-          <Icon
-            size={icon.size || 16}
-            style={[styles.icon, styles.searchIcon, icon.style && icon.style]}
-            name={icon.name || 'search'}
-            color={icon.color || colors.grey3}
-          />
-        )}
-        {clearIcon && (
-          <Icon
-            size={clearIcon.size || 16}
-            style={[
-              styles.icon,
-              styles.clearIcon,
-              clearIcon.style && clearIcon.style,
-            ]}
-            name={clearIcon.name || 'close'}
-            onPress={this.clear.bind(this)}
-            color={clearIcon.color || colors.grey3}
-          />
-        )}
-        {showLoading && (
-          <ActivityIndicator
-            style={[
-              styles.loadingIcon,
-              loadingStyle && loadingStyle,
-              clearIcon && { right: 35 },
-            ]}
-            color={icon.color || colors.grey3}
-            {...otherLoadingProps}
-          />
-        )}
       </View>
     );
   }
 }
 
-Search.propTypes = {
-  icon: PropTypes.object,
-  noIcon: PropTypes.bool,
-  lightTheme: PropTypes.bool,
-  containerStyle: ViewPropTypes.style,
-  inputStyle: NativeText.propTypes.style,
-  round: PropTypes.bool,
-  showLoading: PropTypes.bool,
+SearchBar.propTypes = {
+  clearIcon: PropTypes.bool,
   loadingProps: PropTypes.object,
-  clearIcon: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
-  // Deprecated
-  textInputRef: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-  // Deprecated
-  containerRef: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-  underlineColorAndroid: PropTypes.string,
-  onChangeText: PropTypes.func,
+  noIcon: PropTypes.bool,
+  showLoading: PropTypes.bool,
+  containerStyle: ViewPropTypes.style,
+  leftIcon: PropTypes.object,
+  leftIconContainerStyle: ViewPropTypes.style,
+  rightIconContainerStyle: ViewPropTypes.style,
+  inputContainerStyle: ViewPropTypes.style,
+  inputStyle: Text.propTypes.style,
   onClear: PropTypes.func,
+  onCancel: PropTypes.func,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+  onChangeText: PropTypes.func,
+  placeholderTextColor: PropTypes.string,
 };
 
-Search.defaultProps = {
-  placeholderTextColor: colors.grey3,
-  lightTheme: false,
-  noIcon: false,
-  round: false,
-  icon: {},
-  showLoading: false,
+SearchBar.defaultProps = {
+  clearIcon: true,
   loadingProps: {},
+  noIcon: false,
+  showLoading: false,
+  placeholderTextColor: colors.grey3,
   onClear: () => null,
+  onCancel: () => null,
+  onFocus: () => null,
+  onBlur: () => null,
   onChangeText: () => null,
 };
 
@@ -170,61 +181,40 @@ const styles = StyleSheet.create({
     borderBottomColor: '#000',
     borderTopColor: '#000',
     backgroundColor: colors.grey0,
+    padding: 8,
+  },
+  rightIconContainerStyle: {
+    marginRight: 8,
+  },
+  leftIconContainerStyle: {
+    marginLeft: 8,
   },
   containerLight: {
     backgroundColor: colors.grey5,
     borderTopColor: '#e1e1e1',
     borderBottomColor: '#e1e1e1',
   },
-  icon: {
-    backgroundColor: 'transparent',
-    position: 'absolute',
-    top: 15.5,
-    ...Platform.select({
-      android: {
-        top: 20,
-      },
-    }),
-  },
-  loadingIcon: {
-    backgroundColor: 'transparent',
-    position: 'absolute',
-    right: 16,
-    top: 13,
-    ...Platform.select({
-      android: {
-        top: 18,
-      },
-    }),
+  inputContainer: {
+    width: '100%',
   },
   input: {
-    paddingLeft: 26,
-    paddingRight: 19,
-    margin: 8,
+    color: colors.grey3,
+  },
+  inputContentContainer: {
+    borderBottomWidth: 0,
     borderRadius: 3,
     overflow: 'hidden',
     backgroundColor: colors.searchBg,
     fontSize: normalize(14),
     color: colors.grey3,
-    height: 40,
-    ...Platform.select({
-      ios: {
-        height: 30,
-      },
-      android: {
-        borderWidth: 0,
-      },
-    }),
+    height: 30,
   },
   inputLight: {
     backgroundColor: colors.grey4,
   },
-  searchIcon: {
-    left: 16,
-  },
-  clearIcon: {
-    right: 16,
+  round: {
+    borderRadius: 15,
   },
 });
 
-export default Search;
+export default SearchBar;

--- a/src/searchbar/SearchBar-default.js
+++ b/src/searchbar/SearchBar-default.js
@@ -7,7 +7,6 @@ import {
   Dimensions,
   Text,
 } from 'react-native';
-import MaterialIcon from 'react-native-vector-icons/MaterialCommunityIcons';
 import colors from '../config/colors';
 import renderIcon from '../helpers/renderIcon';
 import ViewPropTypes from '../config/ViewPropTypes';
@@ -82,7 +81,6 @@ class SearchBar extends Component {
       rightIconContainerStyle,
       inputContainerStyle,
       inputStyle,
-      noIcon,
       showLoading,
       loadingProps,
       placeholderTextColor,
@@ -122,10 +120,7 @@ class SearchBar extends Component {
             <View style={{ flexDirection: 'row' }}>
               {showLoading && (
                 <ActivityIndicator
-                  style={[
-                    clearIcon && !isEmpty && { marginRight: 10 },
-                    loadingStyle,
-                  ]}
+                  style={[{ marginRight: 5 }, loadingStyle]}
                   {...otherLoadingProps}
                 />
               )}

--- a/src/searchbar/SearchBar-default.js
+++ b/src/searchbar/SearchBar-default.js
@@ -8,10 +8,12 @@ import {
   Text,
 } from 'react-native';
 import colors from '../config/colors';
-import renderIcon from '../helpers/renderIcon';
+import renderNode from '../helpers/renderNode';
 import ViewPropTypes from '../config/ViewPropTypes';
+import nodeType from '../helpers/nodeType';
 
 import Input from '../input/Input';
+import Icon from '../icons/Icon';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const defaultSearchIcon = {
@@ -103,7 +105,7 @@ class SearchBar extends Component {
             round && styles.round,
           ]}
           containerStyle={styles.inputContainer}
-          leftIcon={renderIcon(searchIcon, defaultSearchIcon)}
+          leftIcon={renderNode(Icon, searchIcon, defaultSearchIcon)}
           leftIconContainerStyle={[
             styles.leftIconContainerStyle,
             leftIconContainerStyle,
@@ -116,7 +118,7 @@ class SearchBar extends Component {
                   {...otherLoadingProps}
                 />
               )}
-              {!isEmpty && renderIcon(clearIcon, defaultClearIcon)}
+              {!isEmpty && renderNode(Icon, clearIcon, defaultClearIcon)}
             </View>
           }
           rightIconContainerStyle={[
@@ -129,13 +131,9 @@ class SearchBar extends Component {
   }
 }
 
-const elementOrObject = PropTypes.oneOfType([
-  PropTypes.element,
-  PropTypes.object,
-]);
 SearchBar.propTypes = {
-  clearIcon: elementOrObject,
-  searchIcon: elementOrObject,
+  clearIcon: nodeType,
+  searchIcon: nodeType,
   loadingProps: PropTypes.object,
   showLoading: PropTypes.bool,
   containerStyle: ViewPropTypes.style,

--- a/src/searchbar/SearchBar-default.js
+++ b/src/searchbar/SearchBar-default.js
@@ -9,13 +9,24 @@ import {
 } from 'react-native';
 import MaterialIcon from 'react-native-vector-icons/MaterialCommunityIcons';
 import colors from '../config/colors';
-import normalize from '../helpers/normalizeText';
+import renderIcon from '../helpers/renderIcon';
 import ViewPropTypes from '../config/ViewPropTypes';
-import getIconType from '../helpers/getIconType';
 
 import Input from '../input/Input';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
+const defaultSearchIcon = {
+  type: 'material-community',
+  size: 18,
+  name: 'magnify',
+  color: colors.grey3,
+};
+const defaultClearIcon = {
+  type: 'material-community',
+  size: 18,
+  name: 'close',
+  color: colors.grey3,
+};
 
 class SearchBar extends Component {
   focus = () => {
@@ -66,7 +77,7 @@ class SearchBar extends Component {
       round,
       clearIcon,
       containerStyle,
-      leftIcon,
+      searchIcon,
       leftIconContainerStyle,
       rightIconContainerStyle,
       inputContainerStyle,
@@ -79,9 +90,6 @@ class SearchBar extends Component {
     } = this.props;
     const { isEmpty } = this.state;
     const { style: loadingStyle, ...otherLoadingProps } = loadingProps;
-    const searchIcon = (
-      <MaterialIcon size={18} name="magnify" color={colors.grey3} />
-    );
     return (
       <View
         style={[
@@ -105,7 +113,7 @@ class SearchBar extends Component {
             round && styles.round,
           ]}
           containerStyle={styles.inputContainer}
-          leftIcon={noIcon ? undefined : leftIcon ? leftIcon : searchIcon}
+          leftIcon={renderIcon(searchIcon, defaultSearchIcon)}
           leftIconContainerStyle={[
             styles.leftIconContainerStyle,
             leftIconContainerStyle,
@@ -121,15 +129,7 @@ class SearchBar extends Component {
                   {...otherLoadingProps}
                 />
               )}
-              {clearIcon &&
-                !isEmpty && (
-                  <MaterialIcon
-                    size={18}
-                    name="close"
-                    onPress={() => this.clear()}
-                    color={colors.grey3}
-                  />
-                )}
+              {!isEmpty && renderIcon(clearIcon, defaultClearIcon)}
             </View>
           }
           rightIconContainerStyle={[
@@ -142,13 +142,16 @@ class SearchBar extends Component {
   }
 }
 
+const elementOrObject = PropTypes.oneOfType([
+  PropTypes.element,
+  PropTypes.object,
+]);
 SearchBar.propTypes = {
-  clearIcon: PropTypes.bool,
+  clearIcon: elementOrObject,
+  searchIcon: elementOrObject,
   loadingProps: PropTypes.object,
-  noIcon: PropTypes.bool,
   showLoading: PropTypes.bool,
   containerStyle: ViewPropTypes.style,
-  leftIcon: PropTypes.object,
   leftIconContainerStyle: ViewPropTypes.style,
   rightIconContainerStyle: ViewPropTypes.style,
   inputContainerStyle: ViewPropTypes.style,
@@ -159,13 +162,15 @@ SearchBar.propTypes = {
   onBlur: PropTypes.func,
   onChangeText: PropTypes.func,
   placeholderTextColor: PropTypes.string,
+  lightTheme: PropTypes.bool,
+  round: PropTypes.bool,
 };
 
 SearchBar.defaultProps = {
-  clearIcon: true,
   loadingProps: {},
-  noIcon: false,
   showLoading: false,
+  lightTheme: false,
+  round: false,
   placeholderTextColor: colors.grey3,
   onClear: () => null,
   onCancel: () => null,
@@ -205,8 +210,6 @@ const styles = StyleSheet.create({
     borderRadius: 3,
     overflow: 'hidden',
     backgroundColor: colors.searchBg,
-    fontSize: normalize(14),
-    color: colors.grey3,
     height: 30,
   },
   inputLight: {

--- a/src/searchbar/SearchBar-default.js
+++ b/src/searchbar/SearchBar-default.js
@@ -44,12 +44,10 @@ class SearchBar extends Component {
 
   onFocus = () => {
     this.props.onFocus();
-    this.setState({ hasFocus: true });
   };
 
   onBlur = () => {
     this.props.onBlur();
-    this.setState({ hasFocus: false });
   };
 
   onChangeText = text => {
@@ -60,7 +58,6 @@ class SearchBar extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      hasFocus: false,
       isEmpty: true,
     };
   }

--- a/src/searchbar/SearchBar-ios.js
+++ b/src/searchbar/SearchBar-ios.js
@@ -91,7 +91,7 @@ class SearchBar extends Component {
       name: 'ios-close-circle',
       size: 20,
       color: IOS_GRAY,
-      onPress: () => this.clear(),
+      onPress: this.clear,
     };
     return (
       <View style={[styles.container, containerStyle]}>

--- a/src/searchbar/SearchBar-ios.js
+++ b/src/searchbar/SearchBar-ios.js
@@ -14,10 +14,16 @@ import Ionicon from 'react-native-vector-icons/Ionicons';
 
 import ViewPropTypes from '../config/ViewPropTypes';
 import Input from '../input/Input';
+import renderIcon from 'react-native-elements/src/helpers/renderIcon';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const IOS_GRAY = '#7d7d7d';
-
+const defaultSearchIcon = {
+  type: 'ionicon',
+  size: 20,
+  name: 'ios-search',
+  color: IOS_GRAY,
+};
 class SearchBar extends Component {
   focus = () => {
     this.input.focus();
@@ -68,22 +74,25 @@ class SearchBar extends Component {
       cancelButtonTitle,
       clearIcon,
       containerStyle,
-      leftIcon,
       leftIconContainerStyle,
       rightIconContainerStyle,
       inputContainerStyle,
       inputStyle,
-      noIcon,
       placeholderTextColor,
       showLoading,
       loadingProps,
+      searchIcon,
       ...attributes
     } = this.props;
     const { hasFocus, isEmpty } = this.state;
     const { style: loadingStyle, ...otherLoadingProps } = loadingProps;
-    const searchIcon = (
-      <Ionicon size={20} name={'ios-search'} color={IOS_GRAY} />
-    );
+    const defaultClearIcon = {
+      type: 'ionicon',
+      name: 'ios-close-circle',
+      size: 20,
+      color: IOS_GRAY,
+      onPress: () => this.clear(),
+    };
     return (
       <View style={[styles.container, containerStyle]}>
         <Input
@@ -102,7 +111,7 @@ class SearchBar extends Component {
             !hasFocus && { width: SCREEN_WIDTH - 32, marginRight: 15 },
             inputContainerStyle,
           ]}
-          leftIcon={noIcon ? undefined : leftIcon ? leftIcon : searchIcon}
+          leftIcon={renderIcon(searchIcon, defaultSearchIcon)}
           leftIconContainerStyle={[
             styles.leftIconContainerStyle,
             leftIconContainerStyle,
@@ -112,22 +121,11 @@ class SearchBar extends Component {
             <View style={{ flexDirection: 'row' }}>
               {showLoading && (
                 <ActivityIndicator
-                  style={[
-                    clearIcon && !isEmpty && { marginRight: 10 },
-                    loadingStyle,
-                  ]}
+                  style={[{ marginRight: 5 }, loadingStyle]}
                   {...otherLoadingProps}
                 />
               )}
-              {clearIcon &&
-                !isEmpty && (
-                  <Ionicon
-                    name={'ios-close-circle'}
-                    size={20}
-                    color={IOS_GRAY}
-                    onPress={() => this.clear()}
-                  />
-                )}
+              {!isEmpty && renderIcon(clearIcon, defaultClearIcon)}
             </View>
           }
           rightIconContainerStyle={[
@@ -141,11 +139,15 @@ class SearchBar extends Component {
   }
 }
 
+const elementOrObject = PropTypes.oneOfType([
+  PropTypes.element,
+  PropTypes.object,
+]);
 SearchBar.propTypes = {
   cancelButtonTitle: PropTypes.string,
-  clearIcon: PropTypes.bool,
+  clearIcon: elementOrObject,
+  searchIcon: elementOrObject,
   loadingProps: PropTypes.object,
-  noIcon: PropTypes.bool,
   showLoading: PropTypes.bool,
   onClear: PropTypes.func,
   onCancel: PropTypes.func,
@@ -153,7 +155,6 @@ SearchBar.propTypes = {
   onBlur: PropTypes.func,
   onChangeText: PropTypes.func,
   containerStyle: ViewPropTypes.style,
-  leftIcon: PropTypes.object,
   leftIconContainerStyle: ViewPropTypes.style,
   rightIconContainerStyle: ViewPropTypes.style,
   inputContainerStyle: ViewPropTypes.style,
@@ -163,9 +164,7 @@ SearchBar.propTypes = {
 
 SearchBar.defaultProps = {
   cancelButtonTitle: 'Cancel',
-  clearIcon: true,
   loadingProps: {},
-  noIcon: false,
   showLoading: false,
   onClear: () => null,
   onCancel: () => null,

--- a/src/searchbar/SearchBar-ios.js
+++ b/src/searchbar/SearchBar-ios.js
@@ -14,7 +14,9 @@ import Ionicon from 'react-native-vector-icons/Ionicons';
 
 import ViewPropTypes from '../config/ViewPropTypes';
 import Input from '../input/Input';
-import renderIcon from 'react-native-elements/src/helpers/renderIcon';
+import Icon from '../icons/Icon';
+import renderNode from 'react-native-elements/src/helpers/renderNode';
+import nodeType from 'react-native-elements/src/helpers/nodeType';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const IOS_GRAY = '#7d7d7d';
@@ -111,7 +113,7 @@ class SearchBar extends Component {
             !hasFocus && { width: SCREEN_WIDTH - 32, marginRight: 15 },
             inputContainerStyle,
           ]}
-          leftIcon={renderIcon(searchIcon, defaultSearchIcon)}
+          leftIcon={renderNode(Icon, searchIcon, defaultSearchIcon)}
           leftIconContainerStyle={[
             styles.leftIconContainerStyle,
             leftIconContainerStyle,
@@ -125,7 +127,7 @@ class SearchBar extends Component {
                   {...otherLoadingProps}
                 />
               )}
-              {!isEmpty && renderIcon(clearIcon, defaultClearIcon)}
+              {!isEmpty && renderNode(Icon, clearIcon, defaultClearIcon)}
             </View>
           }
           rightIconContainerStyle={[
@@ -139,14 +141,10 @@ class SearchBar extends Component {
   }
 }
 
-const elementOrObject = PropTypes.oneOfType([
-  PropTypes.element,
-  PropTypes.object,
-]);
 SearchBar.propTypes = {
   cancelButtonTitle: PropTypes.string,
-  clearIcon: elementOrObject,
-  searchIcon: elementOrObject,
+  clearIcon: nodeType,
+  searchIcon: nodeType,
   loadingProps: PropTypes.object,
   showLoading: PropTypes.bool,
   onClear: PropTypes.func,

--- a/src/searchbar/SearchBar-ios.js
+++ b/src/searchbar/SearchBar-ios.js
@@ -184,7 +184,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
   input: {
-    flex: 1,
     marginLeft: 6,
   },
   inputContainer: {

--- a/src/searchbar/__tests__/SearchBar-android.js
+++ b/src/searchbar/__tests__/SearchBar-android.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { View } from 'react-native';
 import toJson from 'enzyme-to-json';
 import SearchBar from '../SearchBar-android';
 
@@ -25,8 +26,36 @@ describe('Android SearchBar component', () => {
     expect(toJson(component)).toMatchSnapshot();
   });
 
+  it('should render with a custom search icon component', () => {
+    const component = shallow(<SearchBar searchIcon={<View />} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should render with a custom search icon', () => {
+    const component = shallow(<SearchBar searchIcon={{ size: 50 }} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
   it('should render without search icon', () => {
-    const component = shallow(<SearchBar noIcon />);
+    const component = shallow(<SearchBar searchIcon={false} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should render with a custom clear icon', () => {
+    const component = shallow(<SearchBar clearIcon={{ color: 'black' }} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should render with a custom clear icon component', () => {
+    const component = shallow(<SearchBar clearIcon={<View />} />);
 
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();
@@ -34,6 +63,27 @@ describe('Android SearchBar component', () => {
 
   it('should render without clear icon', () => {
     const component = shallow(<SearchBar clearIcon={false} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should render with a custom cancel icon', () => {
+    const component = shallow(<SearchBar cancelIcon={{ color: 'black' }} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should render with a custom cancel icon component', () => {
+    const component = shallow(<SearchBar cancelIcon={<View />} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should render without cancel icon', () => {
+    const component = shallow(<SearchBar cancelIcon={false} />);
 
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();

--- a/src/searchbar/__tests__/SearchBar-default.js
+++ b/src/searchbar/__tests__/SearchBar-default.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { View } from 'react-native';
 import toJson from 'enzyme-to-json';
 import SearchBar from '../SearchBar-default';
 
@@ -30,28 +31,66 @@ describe('Default SearchBar component', () => {
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();
   });
-  it('should call onChangeText when close icon is touched', () => {
-    const onChangeTextMock = jest.fn();
-    const component = shallow(
-      <SearchBar textInputRef="ti" clearIcon onChangeText={onChangeTextMock} />
-    );
-    component.find('Icon[name="close"]').simulate('press');
-    expect(onChangeTextMock).toBeCalled();
+
+  it('should call onFocus when input is focused', () => {
+    const onFocusMock = jest.fn();
+    const component = shallow(<SearchBar onFocus={onFocusMock} />);
+    component.find('Input').simulate('focus');
+    expect(onFocusMock).toBeCalled();
   });
 
-  it('should render without icon', () => {
-    const component = shallow(
-      <SearchBar underlineColorAndroid="red" noIcon round />
-    );
+  it('should call onBlur when input is blured', () => {
+    const onBlurMock = jest.fn();
+    const component = shallow(<SearchBar onFocus={onBlurMock} />);
+    component.find('Input').simulate('focus');
+    component.find('Input').simulate('blur');
+    expect(onBlurMock).toBeCalled();
+  });
+
+  it('should call onChangeText when input is changed', () => {
+    const onChangeMock = jest.fn();
+    const component = shallow(<SearchBar onChangeText={onChangeMock} />);
+    component.find('Input').simulate('changeText', 'test');
+    expect(onChangeMock).toBeCalled();
+  });
+
+  it('should render with a custom search icon component', () => {
+    const component = shallow(<SearchBar searchIcon={<View />} round />);
 
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();
   });
 
-  it('should render with a custom icon', () => {
-    const component = shallow(
-      <SearchBar icon={{ type: 'font-awesome', name: 'glass' }} />
-    );
+  it('should render with a custom search icon', () => {
+    const component = shallow(<SearchBar searchIcon={{ size: 50 }} lightTheme />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should render without search icon', () => {
+    const component = shallow(<SearchBar searchIcon={false} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should render with a custom clear icon', () => {
+    const component = shallow(<SearchBar clearIcon={{ color: 'black' }} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should render with a custom clear icon component', () => {
+    const component = shallow(<SearchBar clearIcon={<View />} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should render without clear icon', () => {
+    const component = shallow(<SearchBar clearIcon={false} />);
 
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();

--- a/src/searchbar/__tests__/SearchBar-ios.js
+++ b/src/searchbar/__tests__/SearchBar-ios.js
@@ -27,15 +27,36 @@ describe('iOS SearchBar component', () => {
     expect(toJson(component)).toMatchSnapshot();
   });
 
+  it('should render with a custom search icon component', () => {
+    const component = shallow(<SearchBar searchIcon={<View />} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
   it('should render with a custom search icon', () => {
-    const component = shallow(<SearchBar leftIcon={<View />} />);
+    const component = shallow(<SearchBar searchIcon={{ size: 50 }} />);
 
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();
   });
 
   it('should render without search icon', () => {
-    const component = shallow(<SearchBar noIcon />);
+    const component = shallow(<SearchBar searchIcon={false} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should render with a custom clear icon', () => {
+    const component = shallow(<SearchBar clearIcon={{ color: 'black' }} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should render with a custom clear icon component', () => {
+    const component = shallow(<SearchBar clearIcon={<View />} />);
 
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();

--- a/src/searchbar/__tests__/__snapshots__/SearchBar-android.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar-android.js.snap
@@ -27,7 +27,6 @@ exports[`Android SearchBar component should render with a custom methods 1`] = `
     inputStyle={
       Array [
         Object {
-          "flex": 1,
           "marginLeft": 24,
           "marginRight": 8,
         },
@@ -36,11 +35,14 @@ exports[`Android SearchBar component should render with a custom methods 1`] = `
     }
     leftIcon={
       <Icon
-        allowFontScaling={false}
         color="rgba(0, 0, 0, 0.54)"
         name="magnify"
-        onPress={null}
+        raised={false}
+        reverse={false}
+        reverseColor="white"
         size={25}
+        type="material-community"
+        underlayColor="white"
       />
     }
     leftIconContainerStyle={
@@ -104,7 +106,6 @@ exports[`Android SearchBar component should render with loading 1`] = `
     inputStyle={
       Array [
         Object {
-          "flex": 1,
           "marginLeft": 24,
           "marginRight": 8,
         },
@@ -113,11 +114,14 @@ exports[`Android SearchBar component should render with loading 1`] = `
     }
     leftIcon={
       <Icon
-        allowFontScaling={false}
         color="rgba(0, 0, 0, 0.54)"
         name="magnify"
-        onPress={null}
+        raised={false}
+        reverse={false}
+        reverseColor="white"
         size={25}
+        type="material-community"
+        underlayColor="white"
       />
     }
     leftIconContainerStyle={
@@ -148,7 +152,9 @@ exports[`Android SearchBar component should render with loading 1`] = `
           size="small"
           style={
             Array [
-              false,
+              Object {
+                "marginRight": 5,
+              },
               Object {
                 "flex": 1,
               },
@@ -196,7 +202,6 @@ exports[`Android SearchBar component should render without clear icon 1`] = `
     inputStyle={
       Array [
         Object {
-          "flex": 1,
           "marginLeft": 24,
           "marginRight": 8,
         },
@@ -205,11 +210,14 @@ exports[`Android SearchBar component should render without clear icon 1`] = `
     }
     leftIcon={
       <Icon
-        allowFontScaling={false}
         color="rgba(0, 0, 0, 0.54)"
         name="magnify"
-        onPress={null}
+        raised={false}
+        reverse={false}
+        reverseColor="white"
         size={25}
+        type="material-community"
+        underlayColor="white"
       />
     }
     leftIconContainerStyle={
@@ -273,7 +281,6 @@ exports[`Android SearchBar component should render without issues 1`] = `
     inputStyle={
       Array [
         Object {
-          "flex": 1,
           "marginLeft": 24,
           "marginRight": 8,
         },
@@ -282,11 +289,14 @@ exports[`Android SearchBar component should render without issues 1`] = `
     }
     leftIcon={
       <Icon
-        allowFontScaling={false}
         color="rgba(0, 0, 0, 0.54)"
         name="magnify"
-        onPress={null}
+        raised={false}
+        reverse={false}
+        reverseColor="white"
         size={25}
+        type="material-community"
+        underlayColor="white"
       />
     }
     leftIconContainerStyle={
@@ -350,12 +360,23 @@ exports[`Android SearchBar component should render without search icon 1`] = `
     inputStyle={
       Array [
         Object {
-          "flex": 1,
           "marginLeft": 24,
           "marginRight": 8,
         },
         undefined,
       ]
+    }
+    leftIcon={
+      <Icon
+        color="rgba(0, 0, 0, 0.54)"
+        name="magnify"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={25}
+        type="material-community"
+        underlayColor="white"
+      />
     }
     leftIconContainerStyle={
       Array [
@@ -365,6 +386,7 @@ exports[`Android SearchBar component should render without search icon 1`] = `
         undefined,
       ]
     }
+    noIcon={true}
     onBlur={[Function]}
     onCancel={[Function]}
     onChangeText={[Function]}

--- a/src/searchbar/__tests__/__snapshots__/SearchBar-android.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar-android.js.snap
@@ -1,5 +1,321 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Android SearchBar component should render with a custom cancel icon 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "white",
+        "paddingBottom": 8,
+        "paddingTop": 8,
+        "width": 750,
+      },
+      undefined,
+    ]
+  }
+>
+  <Input
+    inputContainerStyle={
+      Array [
+        Object {
+          "borderBottomWidth": 0,
+          "width": 750,
+        },
+        undefined,
+      ]
+    }
+    inputStyle={
+      Array [
+        Object {
+          "marginLeft": 24,
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+    leftIcon={
+      <Icon
+        color="rgba(0, 0, 0, 0.54)"
+        name="magnify"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={25}
+        type="material-community"
+        underlayColor="white"
+      />
+    }
+    leftIconContainerStyle={
+      Array [
+        Object {
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onCancel={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`Android SearchBar component should render with a custom cancel icon component 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "white",
+        "paddingBottom": 8,
+        "paddingTop": 8,
+        "width": 750,
+      },
+      undefined,
+    ]
+  }
+>
+  <Input
+    inputContainerStyle={
+      Array [
+        Object {
+          "borderBottomWidth": 0,
+          "width": 750,
+        },
+        undefined,
+      ]
+    }
+    inputStyle={
+      Array [
+        Object {
+          "marginLeft": 24,
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+    leftIcon={
+      <Icon
+        color="rgba(0, 0, 0, 0.54)"
+        name="magnify"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={25}
+        type="material-community"
+        underlayColor="white"
+      />
+    }
+    leftIconContainerStyle={
+      Array [
+        Object {
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onCancel={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`Android SearchBar component should render with a custom clear icon 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "white",
+        "paddingBottom": 8,
+        "paddingTop": 8,
+        "width": 750,
+      },
+      undefined,
+    ]
+  }
+>
+  <Input
+    inputContainerStyle={
+      Array [
+        Object {
+          "borderBottomWidth": 0,
+          "width": 750,
+        },
+        undefined,
+      ]
+    }
+    inputStyle={
+      Array [
+        Object {
+          "marginLeft": 24,
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+    leftIcon={
+      <Icon
+        color="rgba(0, 0, 0, 0.54)"
+        name="magnify"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={25}
+        type="material-community"
+        underlayColor="white"
+      />
+    }
+    leftIconContainerStyle={
+      Array [
+        Object {
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onCancel={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`Android SearchBar component should render with a custom clear icon component 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "white",
+        "paddingBottom": 8,
+        "paddingTop": 8,
+        "width": 750,
+      },
+      undefined,
+    ]
+  }
+>
+  <Input
+    inputContainerStyle={
+      Array [
+        Object {
+          "borderBottomWidth": 0,
+          "width": 750,
+        },
+        undefined,
+      ]
+    }
+    inputStyle={
+      Array [
+        Object {
+          "marginLeft": 24,
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+    leftIcon={
+      <Icon
+        color="rgba(0, 0, 0, 0.54)"
+        name="magnify"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={25}
+        type="material-community"
+        underlayColor="white"
+      />
+    }
+    leftIconContainerStyle={
+      Array [
+        Object {
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onCancel={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
 exports[`Android SearchBar component should render with a custom methods 1`] = `
 <View
   style={
@@ -57,6 +373,153 @@ exports[`Android SearchBar component should render with a custom methods 1`] = `
     onCancel={[MockFunction]}
     onChangeText={[Function]}
     onClear={[MockFunction]}
+    onFocus={[Function]}
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`Android SearchBar component should render with a custom search icon 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "white",
+        "paddingBottom": 8,
+        "paddingTop": 8,
+        "width": 750,
+      },
+      undefined,
+    ]
+  }
+>
+  <Input
+    inputContainerStyle={
+      Array [
+        Object {
+          "borderBottomWidth": 0,
+          "width": 750,
+        },
+        undefined,
+      ]
+    }
+    inputStyle={
+      Array [
+        Object {
+          "marginLeft": 24,
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+    leftIcon={
+      <Icon
+        color="rgba(0, 0, 0, 0.54)"
+        name="magnify"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={50}
+        type="material-community"
+        underlayColor="white"
+      />
+    }
+    leftIconContainerStyle={
+      Array [
+        Object {
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onCancel={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`Android SearchBar component should render with a custom search icon component 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "white",
+        "paddingBottom": 8,
+        "paddingTop": 8,
+        "width": 750,
+      },
+      undefined,
+    ]
+  }
+>
+  <Input
+    inputContainerStyle={
+      Array [
+        Object {
+          "borderBottomWidth": 0,
+          "width": 750,
+        },
+        undefined,
+      ]
+    }
+    inputStyle={
+      Array [
+        Object {
+          "marginLeft": 24,
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+    leftIcon={<View />}
+    leftIconContainerStyle={
+      Array [
+        Object {
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onCancel={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
     onFocus={[Function]}
     rightIcon={
       <View
@@ -162,6 +625,85 @@ exports[`Android SearchBar component should render with loading 1`] = `
           }
         />
       </View>
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`Android SearchBar component should render without cancel icon 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "white",
+        "paddingBottom": 8,
+        "paddingTop": 8,
+        "width": 750,
+      },
+      undefined,
+    ]
+  }
+>
+  <Input
+    inputContainerStyle={
+      Array [
+        Object {
+          "borderBottomWidth": 0,
+          "width": 750,
+        },
+        undefined,
+      ]
+    }
+    inputStyle={
+      Array [
+        Object {
+          "marginLeft": 24,
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+    leftIcon={
+      <Icon
+        color="rgba(0, 0, 0, 0.54)"
+        name="magnify"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={25}
+        type="material-community"
+        underlayColor="white"
+      />
+    }
+    leftIconContainerStyle={
+      Array [
+        Object {
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onCancel={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
     }
     rightIconContainerStyle={
       Array [
@@ -366,18 +908,7 @@ exports[`Android SearchBar component should render without search icon 1`] = `
         undefined,
       ]
     }
-    leftIcon={
-      <Icon
-        color="rgba(0, 0, 0, 0.54)"
-        name="magnify"
-        raised={false}
-        reverse={false}
-        reverseColor="white"
-        size={25}
-        type="material-community"
-        underlayColor="white"
-      />
-    }
+    leftIcon={null}
     leftIconContainerStyle={
       Array [
         Object {
@@ -386,7 +917,6 @@ exports[`Android SearchBar component should render without search icon 1`] = `
         undefined,
       ]
     }
-    noIcon={true}
     onBlur={[Function]}
     onCancel={[Function]}
     onChangeText={[Function]}

--- a/src/searchbar/__tests__/__snapshots__/SearchBar-default.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar-default.js.snap
@@ -10,54 +10,85 @@ exports[`Default SearchBar component should render with a custom icon 1`] = `
         "borderBottomWidth": 1,
         "borderTopColor": "#000",
         "borderTopWidth": 1,
+        "padding": 8,
       },
-      false,
       undefined,
+      false,
     ]
   }
 >
-  <TextInput
-    allowFontScaling={true}
-    onChangeText={[Function]}
-    onClear={[Function]}
-    placeholderTextColor="#86939e"
-    style={
+  <Input
+    containerStyle={
+      Object {
+        "width": "100%",
+      }
+    }
+    icon={
+      Object {
+        "name": "glass",
+        "type": "font-awesome",
+      }
+    }
+    inputContainerStyle={
       Array [
         Object {
           "backgroundColor": "#303337",
+          "borderBottomWidth": 0,
           "borderRadius": 3,
-          "color": "#86939e",
-          "fontSize": 17.5,
           "height": 30,
-          "margin": 8,
           "overflow": "hidden",
-          "paddingLeft": 26,
-          "paddingRight": 19,
         },
-        false,
-        false,
-        false,
         undefined,
-        undefined,
+        false,
         false,
       ]
     }
-    underlineColorAndroid="transparent"
-  />
-  <Icon
-    allowFontScaling={false}
-    color="#86939e"
-    name="glass"
-    size={16}
-    style={
+    inputStyle={
       Array [
         Object {
-          "backgroundColor": "transparent",
-          "position": "absolute",
-          "top": 15.5,
+          "color": "#86939e",
         },
+        undefined,
+      ]
+    }
+    leftIcon={
+      <Icon
+        color="#86939e"
+        name="magnify"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={18}
+        type="material-community"
+        underlayColor="white"
+      />
+    }
+    leftIconContainerStyle={
+      Array [
         Object {
-          "left": 16,
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    placeholderTextColor="#86939e"
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
         },
         undefined,
       ]
@@ -76,54 +107,79 @@ exports[`Default SearchBar component should render with a custom methods 1`] = `
         "borderBottomWidth": 1,
         "borderTopColor": "#000",
         "borderTopWidth": 1,
+        "padding": 8,
       },
-      false,
       undefined,
+      false,
     ]
   }
 >
-  <TextInput
-    allowFontScaling={true}
-    onChangeText={[MockFunction]}
-    onClear={[MockFunction]}
-    placeholderTextColor="#86939e"
-    style={
+  <Input
+    containerStyle={
+      Object {
+        "width": "100%",
+      }
+    }
+    inputContainerStyle={
       Array [
         Object {
           "backgroundColor": "#303337",
+          "borderBottomWidth": 0,
           "borderRadius": 3,
-          "color": "#86939e",
-          "fontSize": 17.5,
           "height": 30,
-          "margin": 8,
           "overflow": "hidden",
-          "paddingLeft": 26,
-          "paddingRight": 19,
         },
-        false,
-        false,
-        false,
         undefined,
-        undefined,
+        false,
         false,
       ]
     }
-    underlineColorAndroid="transparent"
-  />
-  <Icon
-    allowFontScaling={false}
-    color="#86939e"
-    name="search"
-    size={16}
-    style={
+    inputStyle={
       Array [
         Object {
-          "backgroundColor": "transparent",
-          "position": "absolute",
-          "top": 15.5,
+          "color": "#86939e",
         },
+        undefined,
+      ]
+    }
+    leftIcon={
+      <Icon
+        color="#86939e"
+        name="magnify"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={18}
+        type="material-community"
+        underlayColor="white"
+      />
+    }
+    leftIconContainerStyle={
+      Array [
         Object {
-          "left": 16,
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onChangeText={[Function]}
+    onClear={[MockFunction]}
+    onFocus={[Function]}
+    placeholderTextColor="#86939e"
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
         },
         undefined,
       ]
@@ -142,108 +198,106 @@ exports[`Default SearchBar component should render with icons 1`] = `
         "borderBottomWidth": 1,
         "borderTopColor": "#000",
         "borderTopWidth": 1,
+        "padding": 8,
+      },
+      Object {
+        "height": 70,
       },
       Object {
         "backgroundColor": "#e1e8ee",
         "borderBottomColor": "#e1e1e1",
         "borderTopColor": "#e1e1e1",
       },
-      Object {
-        "height": 70,
-      },
     ]
   }
 >
-  <TextInput
-    allowFontScaling={true}
-    onChangeText={[Function]}
-    onClear={[Function]}
-    placeholderTextColor="#86939e"
-    style={
+  <Input
+    containerStyle={
+      Object {
+        "width": "100%",
+      }
+    }
+    inputContainerStyle={
       Array [
         Object {
           "backgroundColor": "#303337",
+          "borderBottomWidth": 0,
           "borderRadius": 3,
-          "color": "#86939e",
-          "fontSize": 17.5,
           "height": 30,
-          "margin": 8,
           "overflow": "hidden",
-          "paddingLeft": 26,
-          "paddingRight": 19,
         },
+        undefined,
         Object {
           "backgroundColor": "#bdc6cf",
         },
         false,
-        false,
-        undefined,
-        Object {
-          "paddingRight": 50,
-        },
-        false,
       ]
     }
-    underlineColorAndroid="transparent"
-  />
-  <Icon
-    allowFontScaling={false}
-    color="#86939e"
-    name="search"
-    size={16}
-    style={
+    inputStyle={
       Array [
         Object {
-          "backgroundColor": "transparent",
-          "position": "absolute",
-          "top": 15.5,
-        },
-        Object {
-          "left": 16,
+          "color": "#86939e",
         },
         undefined,
       ]
     }
-  />
-  <Icon
-    allowFontScaling={false}
-    color="red"
-    name="3d-rotation"
-    onPress={[Function]}
-    size={16}
-    style={
+    leftIcon={
+      <Icon
+        color="#86939e"
+        name="magnify"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={18}
+        type="material-community"
+        underlayColor="white"
+      />
+    }
+    leftIconContainerStyle={
       Array [
         Object {
-          "backgroundColor": "transparent",
-          "position": "absolute",
-          "top": 15.5,
-        },
-        Object {
-          "right": 16,
+          "marginLeft": 8,
         },
         undefined,
       ]
     }
-  />
-  <ActivityIndicator
-    animating={true}
-    color="#86939e"
-    hidesWhenStopped={true}
-    size="small"
-    style={
+    onBlur={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    placeholderTextColor="#86939e"
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      >
+        <ActivityIndicator
+          animating={true}
+          color="#999999"
+          hidesWhenStopped={true}
+          size="small"
+          style={
+            Array [
+              Object {
+                "marginRight": 5,
+              },
+              Object {
+                "flex": 1,
+              },
+            ]
+          }
+        />
+      </View>
+    }
+    rightIconContainerStyle={
       Array [
         Object {
-          "backgroundColor": "transparent",
-          "position": "absolute",
-          "right": 16,
-          "top": 13,
+          "marginRight": 8,
         },
-        Object {
-          "flex": 1,
-        },
-        Object {
-          "right": 35,
-        },
+        undefined,
       ]
     }
   />
@@ -260,40 +314,84 @@ exports[`Default SearchBar component should render without icon 1`] = `
         "borderBottomWidth": 1,
         "borderTopColor": "#000",
         "borderTopWidth": 1,
+        "padding": 8,
       },
-      false,
       undefined,
+      false,
     ]
   }
 >
-  <TextInput
-    allowFontScaling={true}
-    onChangeText={[Function]}
-    onClear={[Function]}
-    placeholderTextColor="#86939e"
-    style={
+  <Input
+    containerStyle={
+      Object {
+        "width": "100%",
+      }
+    }
+    inputContainerStyle={
       Array [
         Object {
           "backgroundColor": "#303337",
+          "borderBottomWidth": 0,
           "borderRadius": 3,
-          "color": "#86939e",
-          "fontSize": 17.5,
           "height": 30,
-          "margin": 8,
           "overflow": "hidden",
-          "paddingLeft": 26,
-          "paddingRight": 19,
         },
+        undefined,
         false,
-        Object {
-          "paddingLeft": 9,
-        },
         Object {
           "borderRadius": 15,
         },
+      ]
+    }
+    inputStyle={
+      Array [
+        Object {
+          "color": "#86939e",
+        },
         undefined,
+      ]
+    }
+    leftIcon={
+      <Icon
+        color="#86939e"
+        name="magnify"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={18}
+        type="material-community"
+        underlayColor="white"
+      />
+    }
+    leftIconContainerStyle={
+      Array [
+        Object {
+          "marginLeft": 8,
+        },
         undefined,
-        false,
+      ]
+    }
+    noIcon={true}
+    onBlur={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    placeholderTextColor="#86939e"
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
+        },
+        undefined,
       ]
     }
     underlineColorAndroid="red"
@@ -311,54 +409,79 @@ exports[`Default SearchBar component should render without issues 1`] = `
         "borderBottomWidth": 1,
         "borderTopColor": "#000",
         "borderTopWidth": 1,
+        "padding": 8,
       },
-      false,
       undefined,
+      false,
     ]
   }
 >
-  <TextInput
-    allowFontScaling={true}
-    onChangeText={[Function]}
-    onClear={[Function]}
-    placeholderTextColor="#86939e"
-    style={
+  <Input
+    containerStyle={
+      Object {
+        "width": "100%",
+      }
+    }
+    inputContainerStyle={
       Array [
         Object {
           "backgroundColor": "#303337",
+          "borderBottomWidth": 0,
           "borderRadius": 3,
-          "color": "#86939e",
-          "fontSize": 17.5,
           "height": 30,
-          "margin": 8,
           "overflow": "hidden",
-          "paddingLeft": 26,
-          "paddingRight": 19,
         },
-        false,
-        false,
-        false,
         undefined,
-        undefined,
+        false,
         false,
       ]
     }
-    underlineColorAndroid="transparent"
-  />
-  <Icon
-    allowFontScaling={false}
-    color="#86939e"
-    name="search"
-    size={16}
-    style={
+    inputStyle={
       Array [
         Object {
-          "backgroundColor": "transparent",
-          "position": "absolute",
-          "top": 15.5,
+          "color": "#86939e",
         },
+        undefined,
+      ]
+    }
+    leftIcon={
+      <Icon
+        color="#86939e"
+        name="magnify"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={18}
+        type="material-community"
+        underlayColor="white"
+      />
+    }
+    leftIconContainerStyle={
+      Array [
         Object {
-          "left": 16,
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    placeholderTextColor="#86939e"
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
         },
         undefined,
       ]

--- a/src/searchbar/__tests__/__snapshots__/SearchBar-default.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar-default.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Default SearchBar component should render with a custom icon 1`] = `
+exports[`Default SearchBar component should render with a custom clear icon 1`] = `
 <View
   style={
     Array [
@@ -23,10 +23,95 @@ exports[`Default SearchBar component should render with a custom icon 1`] = `
         "width": "100%",
       }
     }
-    icon={
+    inputContainerStyle={
+      Array [
+        Object {
+          "backgroundColor": "#303337",
+          "borderBottomWidth": 0,
+          "borderRadius": 3,
+          "height": 30,
+          "overflow": "hidden",
+        },
+        undefined,
+        false,
+        false,
+      ]
+    }
+    inputStyle={
+      Array [
+        Object {
+          "color": "#86939e",
+        },
+        undefined,
+      ]
+    }
+    leftIcon={
+      <Icon
+        color="#86939e"
+        name="magnify"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={18}
+        type="material-community"
+        underlayColor="white"
+      />
+    }
+    leftIconContainerStyle={
+      Array [
+        Object {
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    placeholderTextColor="#86939e"
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`Default SearchBar component should render with a custom clear icon component 1`] = `
+<View
+  style={
+    Array [
       Object {
-        "name": "glass",
-        "type": "font-awesome",
+        "backgroundColor": "#393e42",
+        "borderBottomColor": "#000",
+        "borderBottomWidth": 1,
+        "borderTopColor": "#000",
+        "borderTopWidth": 1,
+        "padding": 8,
+      },
+      undefined,
+      false,
+    ]
+  }
+>
+  <Input
+    containerStyle={
+      Object {
+        "width": "100%",
       }
     }
     inputContainerStyle={
@@ -188,6 +273,185 @@ exports[`Default SearchBar component should render with a custom methods 1`] = `
 </View>
 `;
 
+exports[`Default SearchBar component should render with a custom search icon 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#393e42",
+        "borderBottomColor": "#000",
+        "borderBottomWidth": 1,
+        "borderTopColor": "#000",
+        "borderTopWidth": 1,
+        "padding": 8,
+      },
+      undefined,
+      Object {
+        "backgroundColor": "#e1e8ee",
+        "borderBottomColor": "#e1e1e1",
+        "borderTopColor": "#e1e1e1",
+      },
+    ]
+  }
+>
+  <Input
+    containerStyle={
+      Object {
+        "width": "100%",
+      }
+    }
+    inputContainerStyle={
+      Array [
+        Object {
+          "backgroundColor": "#303337",
+          "borderBottomWidth": 0,
+          "borderRadius": 3,
+          "height": 30,
+          "overflow": "hidden",
+        },
+        undefined,
+        Object {
+          "backgroundColor": "#bdc6cf",
+        },
+        false,
+      ]
+    }
+    inputStyle={
+      Array [
+        Object {
+          "color": "#86939e",
+        },
+        undefined,
+      ]
+    }
+    leftIcon={
+      <Icon
+        color="#86939e"
+        name="magnify"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={50}
+        type="material-community"
+        underlayColor="white"
+      />
+    }
+    leftIconContainerStyle={
+      Array [
+        Object {
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    placeholderTextColor="#86939e"
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`Default SearchBar component should render with a custom search icon component 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#393e42",
+        "borderBottomColor": "#000",
+        "borderBottomWidth": 1,
+        "borderTopColor": "#000",
+        "borderTopWidth": 1,
+        "padding": 8,
+      },
+      undefined,
+      false,
+    ]
+  }
+>
+  <Input
+    containerStyle={
+      Object {
+        "width": "100%",
+      }
+    }
+    inputContainerStyle={
+      Array [
+        Object {
+          "backgroundColor": "#303337",
+          "borderBottomWidth": 0,
+          "borderRadius": 3,
+          "height": 30,
+          "overflow": "hidden",
+        },
+        undefined,
+        false,
+        Object {
+          "borderRadius": 15,
+        },
+      ]
+    }
+    inputStyle={
+      Array [
+        Object {
+          "color": "#86939e",
+        },
+        undefined,
+      ]
+    }
+    leftIcon={<View />}
+    leftIconContainerStyle={
+      Array [
+        Object {
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    placeholderTextColor="#86939e"
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
 exports[`Default SearchBar component should render with icons 1`] = `
 <View
   style={
@@ -304,7 +568,7 @@ exports[`Default SearchBar component should render with icons 1`] = `
 </View>
 `;
 
-exports[`Default SearchBar component should render without icon 1`] = `
+exports[`Default SearchBar component should render without clear icon 1`] = `
 <View
   style={
     Array [
@@ -338,9 +602,7 @@ exports[`Default SearchBar component should render without icon 1`] = `
         },
         undefined,
         false,
-        Object {
-          "borderRadius": 15,
-        },
+        false,
       ]
     }
     inputStyle={
@@ -371,7 +633,6 @@ exports[`Default SearchBar component should render without icon 1`] = `
         undefined,
       ]
     }
-    noIcon={true}
     onBlur={[Function]}
     onChangeText={[Function]}
     onClear={[Function]}
@@ -394,7 +655,6 @@ exports[`Default SearchBar component should render without icon 1`] = `
         undefined,
       ]
     }
-    underlineColorAndroid="red"
   />
 </View>
 `;
@@ -456,6 +716,86 @@ exports[`Default SearchBar component should render without issues 1`] = `
         underlayColor="white"
       />
     }
+    leftIconContainerStyle={
+      Array [
+        Object {
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    placeholderTextColor="#86939e"
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`Default SearchBar component should render without search icon 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#393e42",
+        "borderBottomColor": "#000",
+        "borderBottomWidth": 1,
+        "borderTopColor": "#000",
+        "borderTopWidth": 1,
+        "padding": 8,
+      },
+      undefined,
+      false,
+    ]
+  }
+>
+  <Input
+    containerStyle={
+      Object {
+        "width": "100%",
+      }
+    }
+    inputContainerStyle={
+      Array [
+        Object {
+          "backgroundColor": "#303337",
+          "borderBottomWidth": 0,
+          "borderRadius": 3,
+          "height": 30,
+          "overflow": "hidden",
+        },
+        undefined,
+        false,
+        false,
+      ]
+    }
+    inputStyle={
+      Array [
+        Object {
+          "color": "#86939e",
+        },
+        undefined,
+      ]
+    }
+    leftIcon={null}
     leftIconContainerStyle={
       Array [
         Object {

--- a/src/searchbar/__tests__/__snapshots__/SearchBar-ios.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar-ios.js.snap
@@ -97,6 +97,200 @@ exports[`iOS SearchBar component should render with a custom Cancel button title
 </View>
 `;
 
+exports[`iOS SearchBar component should render with a custom clear icon 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#f5f5f5",
+        "flexDirection": "row",
+        "paddingBottom": 13,
+        "paddingTop": 13,
+        "width": 750,
+      },
+      undefined,
+    ]
+  }
+>
+  <Input
+    containerStyle={
+      Object {
+        "flex": 0,
+        "width": null,
+      }
+    }
+    inputContainerStyle={
+      Array [
+        Object {
+          "backgroundColor": "#dcdce1",
+          "borderBottomWidth": 0,
+          "borderRadius": 9,
+          "height": 36,
+          "marginLeft": 15,
+        },
+        Object {
+          "marginRight": 15,
+          "width": 718,
+        },
+        undefined,
+      ]
+    }
+    inputStyle={
+      Array [
+        Object {
+          "marginLeft": 6,
+        },
+        undefined,
+      ]
+    }
+    leftIcon={
+      <Icon
+        color="#7d7d7d"
+        name="ios-search"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={20}
+        type="ionicon"
+        underlayColor="white"
+      />
+    }
+    leftIconContainerStyle={
+      Array [
+        Object {
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onCancel={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    placeholderTextColor="#7d7d7d"
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+  />
+  <Button
+    onPress={[Function]}
+    title="Cancel"
+  />
+</View>
+`;
+
+exports[`iOS SearchBar component should render with a custom clear icon component 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#f5f5f5",
+        "flexDirection": "row",
+        "paddingBottom": 13,
+        "paddingTop": 13,
+        "width": 750,
+      },
+      undefined,
+    ]
+  }
+>
+  <Input
+    containerStyle={
+      Object {
+        "flex": 0,
+        "width": null,
+      }
+    }
+    inputContainerStyle={
+      Array [
+        Object {
+          "backgroundColor": "#dcdce1",
+          "borderBottomWidth": 0,
+          "borderRadius": 9,
+          "height": 36,
+          "marginLeft": 15,
+        },
+        Object {
+          "marginRight": 15,
+          "width": 718,
+        },
+        undefined,
+      ]
+    }
+    inputStyle={
+      Array [
+        Object {
+          "marginLeft": 6,
+        },
+        undefined,
+      ]
+    }
+    leftIcon={
+      <Icon
+        color="#7d7d7d"
+        name="ios-search"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={20}
+        type="ionicon"
+        underlayColor="white"
+      />
+    }
+    leftIconContainerStyle={
+      Array [
+        Object {
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onCancel={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    placeholderTextColor="#7d7d7d"
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+  />
+  <Button
+    onPress={[Function]}
+    title="Cancel"
+  />
+</View>
+`;
+
 exports[`iOS SearchBar component should render with a custom methods 1`] = `
 <View
   style={
@@ -247,11 +441,97 @@ exports[`iOS SearchBar component should render with a custom search icon 1`] = `
         raised={false}
         reverse={false}
         reverseColor="white"
-        size={20}
+        size={50}
         type="ionicon"
         underlayColor="white"
       />
     }
+    leftIconContainerStyle={
+      Array [
+        Object {
+          "marginLeft": 8,
+        },
+        undefined,
+      ]
+    }
+    onBlur={[Function]}
+    onCancel={[Function]}
+    onChangeText={[Function]}
+    onClear={[Function]}
+    onFocus={[Function]}
+    placeholderTextColor="#7d7d7d"
+    rightIcon={
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      />
+    }
+    rightIconContainerStyle={
+      Array [
+        Object {
+          "marginRight": 8,
+        },
+        undefined,
+      ]
+    }
+  />
+  <Button
+    onPress={[Function]}
+    title="Cancel"
+  />
+</View>
+`;
+
+exports[`iOS SearchBar component should render with a custom search icon component 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#f5f5f5",
+        "flexDirection": "row",
+        "paddingBottom": 13,
+        "paddingTop": 13,
+        "width": 750,
+      },
+      undefined,
+    ]
+  }
+>
+  <Input
+    containerStyle={
+      Object {
+        "flex": 0,
+        "width": null,
+      }
+    }
+    inputContainerStyle={
+      Array [
+        Object {
+          "backgroundColor": "#dcdce1",
+          "borderBottomWidth": 0,
+          "borderRadius": 9,
+          "height": 36,
+          "marginLeft": 15,
+        },
+        Object {
+          "marginRight": 15,
+          "width": 718,
+        },
+        undefined,
+      ]
+    }
+    inputStyle={
+      Array [
+        Object {
+          "marginLeft": 6,
+        },
+        undefined,
+      ]
+    }
+    leftIcon={<View />}
     leftIconContainerStyle={
       Array [
         Object {
@@ -647,18 +927,7 @@ exports[`iOS SearchBar component should render without search icon 1`] = `
         undefined,
       ]
     }
-    leftIcon={
-      <Icon
-        color="#7d7d7d"
-        name="ios-search"
-        raised={false}
-        reverse={false}
-        reverseColor="white"
-        size={20}
-        type="ionicon"
-        underlayColor="white"
-      />
-    }
+    leftIcon={null}
     leftIconContainerStyle={
       Array [
         Object {
@@ -667,7 +936,6 @@ exports[`iOS SearchBar component should render without search icon 1`] = `
         undefined,
       ]
     }
-    noIcon={true}
     onBlur={[Function]}
     onCancel={[Function]}
     onChangeText={[Function]}

--- a/src/searchbar/__tests__/__snapshots__/SearchBar-ios.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar-ios.js.snap
@@ -41,7 +41,6 @@ exports[`iOS SearchBar component should render with a custom Cancel button title
     inputStyle={
       Array [
         Object {
-          "flex": 1,
           "marginLeft": 6,
         },
         undefined,
@@ -49,10 +48,14 @@ exports[`iOS SearchBar component should render with a custom Cancel button title
     }
     leftIcon={
       <Icon
-        allowFontScaling={false}
         color="#7d7d7d"
         name="ios-search"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
         size={20}
+        type="ionicon"
+        underlayColor="white"
       />
     }
     leftIconContainerStyle={
@@ -135,7 +138,6 @@ exports[`iOS SearchBar component should render with a custom methods 1`] = `
     inputStyle={
       Array [
         Object {
-          "flex": 1,
           "marginLeft": 6,
         },
         undefined,
@@ -143,10 +145,14 @@ exports[`iOS SearchBar component should render with a custom methods 1`] = `
     }
     leftIcon={
       <Icon
-        allowFontScaling={false}
         color="#7d7d7d"
         name="ios-search"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
         size={20}
+        type="ionicon"
+        underlayColor="white"
       />
     }
     leftIconContainerStyle={
@@ -229,13 +235,23 @@ exports[`iOS SearchBar component should render with a custom search icon 1`] = `
     inputStyle={
       Array [
         Object {
-          "flex": 1,
           "marginLeft": 6,
         },
         undefined,
       ]
     }
-    leftIcon={<View />}
+    leftIcon={
+      <Icon
+        color="#7d7d7d"
+        name="ios-search"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={20}
+        type="ionicon"
+        underlayColor="white"
+      />
+    }
     leftIconContainerStyle={
       Array [
         Object {
@@ -318,7 +334,6 @@ exports[`iOS SearchBar component should render with loading 1`] = `
     inputStyle={
       Array [
         Object {
-          "flex": 1,
           "marginLeft": 6,
         },
         undefined,
@@ -326,10 +341,14 @@ exports[`iOS SearchBar component should render with loading 1`] = `
     }
     leftIcon={
       <Icon
-        allowFontScaling={false}
         color="#7d7d7d"
         name="ios-search"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
         size={20}
+        type="ionicon"
+        underlayColor="white"
       />
     }
     leftIconContainerStyle={
@@ -361,7 +380,9 @@ exports[`iOS SearchBar component should render with loading 1`] = `
           size="small"
           style={
             Array [
-              false,
+              Object {
+                "marginRight": 5,
+              },
               Object {
                 "flex": 1,
               },
@@ -427,7 +448,6 @@ exports[`iOS SearchBar component should render without clear icon 1`] = `
     inputStyle={
       Array [
         Object {
-          "flex": 1,
           "marginLeft": 6,
         },
         undefined,
@@ -435,10 +455,14 @@ exports[`iOS SearchBar component should render without clear icon 1`] = `
     }
     leftIcon={
       <Icon
-        allowFontScaling={false}
         color="#7d7d7d"
         name="ios-search"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
         size={20}
+        type="ionicon"
+        underlayColor="white"
       />
     }
     leftIconContainerStyle={
@@ -521,7 +545,6 @@ exports[`iOS SearchBar component should render without issues 1`] = `
     inputStyle={
       Array [
         Object {
-          "flex": 1,
           "marginLeft": 6,
         },
         undefined,
@@ -529,10 +552,14 @@ exports[`iOS SearchBar component should render without issues 1`] = `
     }
     leftIcon={
       <Icon
-        allowFontScaling={false}
         color="#7d7d7d"
         name="ios-search"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
         size={20}
+        type="ionicon"
+        underlayColor="white"
       />
     }
     leftIconContainerStyle={
@@ -615,11 +642,22 @@ exports[`iOS SearchBar component should render without search icon 1`] = `
     inputStyle={
       Array [
         Object {
-          "flex": 1,
           "marginLeft": 6,
         },
         undefined,
       ]
+    }
+    leftIcon={
+      <Icon
+        color="#7d7d7d"
+        name="ios-search"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={20}
+        type="ionicon"
+        underlayColor="white"
+      />
     }
     leftIconContainerStyle={
       Array [
@@ -629,6 +667,7 @@ exports[`iOS SearchBar component should render without search icon 1`] = `
         undefined,
       ]
     }
+    noIcon={true}
     onBlur={[Function]}
     onCancel={[Function]}
     onChangeText={[Function]}

--- a/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SearchBar wrapper component should render a default SearchBar if wrong platform 1`] = `
-<Search
-  icon={Object {}}
+<SearchBar
   lightTheme={false}
   loadingProps={Object {}}
-  noIcon={false}
+  onBlur={[Function]}
   onChangeText={[Function]}
   onClear={[Function]}
+  onFocus={[Function]}
   placeholderTextColor="#86939e"
   platform="wrong-platform"
   round={false}
@@ -17,9 +17,7 @@ exports[`SearchBar wrapper component should render a default SearchBar if wrong 
 
 exports[`SearchBar wrapper component should render an Android SearchBar 1`] = `
 <SearchBar
-  clearIcon={true}
   loadingProps={Object {}}
-  noIcon={false}
   onBlur={[Function]}
   onCancel={[Function]}
   onChangeText={[Function]}
@@ -33,9 +31,7 @@ exports[`SearchBar wrapper component should render an Android SearchBar 1`] = `
 exports[`SearchBar wrapper component should render an iOS SearchBar 1`] = `
 <SearchBar
   cancelButtonTitle="Cancel"
-  clearIcon={true}
   loadingProps={Object {}}
-  noIcon={false}
   onBlur={[Function]}
   onCancel={[Function]}
   onChangeText={[Function]}
@@ -48,13 +44,13 @@ exports[`SearchBar wrapper component should render an iOS SearchBar 1`] = `
 `;
 
 exports[`SearchBar wrapper component should render without issues 1`] = `
-<Search
-  icon={Object {}}
+<SearchBar
   lightTheme={false}
   loadingProps={Object {}}
-  noIcon={false}
+  onBlur={[Function]}
   onChangeText={[Function]}
   onClear={[Function]}
+  onFocus={[Function]}
   placeholderTextColor="#86939e"
   platform="default"
   round={false}


### PR DESCRIPTION
## Description

The default searchbar had to be refactored to have the same props as the platform specific ones
Moreover, I think it's still good to support the object icons as we had in `< 1.0.0`.

## `renderIcon`

The `renderIcon` helper (inspired by @martinezguillaume in the `ListItem`) should help to handle icons in every components.

**Usage**
```
renderIcon(iconProps, { ...yourDefaultIcon })
```

**Behavior**
- `iconProps={false}`: default icon won't be rendered
- `iconProps={null}`: default icon won't be rendered
- `iconProps` or nothing: default icon will be rendered with all default props
- `iconProps={{ size: 20 }}` icon will be rendered with an overridden size
- `iconProps={{ type: 'material', name: 'close' }}` icon will be rendered with a custom type and name (keep the default color and size)
- `iconProps={<CustomComponent />}` `CustomComponent` will be rendered


### Ideally, we should use this helper everywhere to be consistent on the Icon usage across all components.

## SearchBars

- Default searchbar now uses the `Input` of RNE, as the other searchbars
- Same look and feel as before
- **You can now customize all icons for all searchbars**
1) `clearIcon` (all searchbars)
2) `searchIcon` (all searchbars)
3) `cancelIcon` (Android searchbar only)

## Examples

|Code|Preview|
|-----|--------|
|`searchIcon={{ color: 'red' }}`|![image](https://user-images.githubusercontent.com/17592779/39175073-acf12052-47a9-11e8-8f10-a93a3037d53e.png)|
|`searchIcon={false}` or `searchIcon={null}`|![image](https://user-images.githubusercontent.com/17592779/39175182-ef72bb0c-47a9-11e8-8255-f733b7436b84.png)|
|`clearIcon={{ size: '30' }}`|![image](https://user-images.githubusercontent.com/17592779/39175252-1a3c90c4-47aa-11e8-93c6-01a86ca4acbd.png)|
|`cancelIcon={{ type: 'font-awesome', name: 'chevron-left' }}` (Android only)|![image](https://user-images.githubusercontent.com/17592779/39175372-6f977304-47aa-11e8-9d54-fdf9d3494d60.png)|

## TODO

- [x] Docs
- [x] Tests