### PR TITLE
Typo?

### DIFF
--- a/docs/listitem.md
+++ b/docs/listitem.md
@@ -285,7 +285,7 @@ replace element with custom element (optional)
 
 |                             Type                              |  Default  |
 | :-----------------------------------------------------------: | :-------: |
-| View or TouchableHighlight if onPress method is added as prop | component |
+| View or TouchableOpacity if onPress method is added as prop | component |
 
 ---
 

--- a/website/versioned_docs/version-1.0.0-beta4/listitem.md
+++ b/website/versioned_docs/version-1.0.0-beta4/listitem.md
@@ -286,7 +286,7 @@ replace element with custom element (optional)
 
 |                             Type                              |  Default  |
 | :-----------------------------------------------------------: | :-------: |
-| View or TouchableHighlight if onPress method is added as prop | component |
+| View or TouchableOpacity if onPress method is added as prop | component |
 
 ---
 


### PR DESCRIPTION
It seems that a touchableopacity is added - not a touchablehighlight.

shouldn't a touchablehighlight be used here?
* https://medium.com/differential/better-cross-platform-react-native-components-cb8aadeba472
* https://stackoverflow.com/questions/39123357/when-to-use-touchablenativefeedback-touchablehighlight-or-touchableopacity

thanks!