### PR TITLE
ci(travis) Pin version of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- stable
+- 9.11.1
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
Node 10 currently breaks builds cause of missing whitelist console in react native jest setup. https://github.com/facebook/jest/issues/2567#issuecomment-384487860 Pinning node version until react-native/jest bumps

Required for #1156 to deploy.