### PR TITLE
featute(tooltip): first proposal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ import Avatar from './avatar/Avatar';
 import Rating from './rating/Rating';
 import Header from './header/Header';
 import PricingCard from './pricing/PricingCard';
+import Tooltip from './tooltip/Tooltip';
 
 // helpers
 import Text from './text/Text';
@@ -42,6 +43,7 @@ export {
   Input,
   ListItem,
   PricingCard,
+  Tooltip,
   SocialIcon,
   Text,
   Divider,

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -1,0 +1,234 @@
+import * as React from 'react';
+import { Text, TouchableOpacity, Modal, View } from 'react-native';
+import NativeMethodsMixin from 'react-native/Libraries/Renderer/shims/NativeMethodsMixin';
+import PropTypes from 'prop-types';
+
+import Triangle from './Triangle';
+import { Colors, ScreenWidth, ScreenHeight, isIOS } from './helpers';
+import getTooltipCoordinate from './getTooltipCoordinate';
+
+
+class Tooltip extends React.PureComponent {
+  state = {
+    isVisible: false,
+    yOffset: 0,
+    xOffset: 0,
+    elementWidth: 0,
+    elementHeight: 0,
+  };
+
+  static defaultProps = {
+    withOverlay: true,
+    hightlightColor: 'transparent',
+    withPointer: true,
+    toggleOnPress: true,
+    tooltipHeight: 40,
+    tooltipWidth: 150,
+    tooltipContainerStyle: {},
+    tooltipTextStyle: {},
+    backgroundColor: Colors.darkergray,
+    onClose: () => {},
+  };
+
+  renderedElement;
+
+  toggleTooltip = () => {
+    const { onClose } = this.props;
+    this.setState(prevState => {
+      if (prevState.isVisible && !isIOS) {
+        onClose && onClose();
+      }
+
+      return { isVisible: !prevState.isVisible };
+    });
+  };
+
+  wrapWithPress = (toggleOnPress, children) => {
+    if (toggleOnPress) {
+      return (
+        <TouchableOpacity onPress={this.toggleTooltip} activeOpacity={1}>
+          {children}
+        </TouchableOpacity>
+      );
+    }
+
+    return children;
+  };
+
+  getTooltipStyle = () => {
+    const { yOffset, xOffset, elementHeight, elementWidth } = this.state;
+    const {
+      tooltipHeight,
+      backgroundColor,
+      tooltipWidth,
+      tooltipContainerStyle,
+      withPointer,
+      tooltipContainerDefaultStyle,
+    } = this.props;
+
+    const { x, y } = getTooltipCoordinate(
+      xOffset,
+      yOffset,
+      elementWidth,
+      elementHeight,
+      ScreenWidth,
+      ScreenHeight,
+      tooltipWidth,
+      tooltipHeight,
+      withPointer,
+    );
+    const tooltipDefaultStyle = {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flex: 1,
+      backgroundColor,
+      borderRadius: 10,
+      padding: 10,
+    };
+
+    const defaultToUse = tooltipContainerDefaultStyle || tooltipDefaultStyle;
+    return {
+      ...defaultToUse,
+      position: 'absolute',
+      left: x,
+      top: y,
+      width: tooltipWidth,
+      height: tooltipHeight,
+      ...tooltipContainerStyle,
+    };
+  };
+
+  renderPointer = () => {
+    const { yOffset, xOffset, elementHeight, elementWidth } = this.state;
+    const { backgroundColor, pointerColor } = this.props;
+    const pastMiddleLine = yOffset > ScreenHeight / 2;
+
+    return (
+      <View
+        style={{
+          position: 'absolute',
+          top: pastMiddleLine ? yOffset - 13 : yOffset + elementHeight - 2,
+          left: xOffset + elementWidth / 2 - 7.5,
+        }}
+      >
+        <Triangle
+          style={{ borderBottomColor: pointerColor || backgroundColor }}
+          isDown={pastMiddleLine}
+        />
+      </View>
+    );
+  };
+  renderContent = (withTooltip) => {
+    const {
+      tooltipComponent,
+      withPointer,
+      tooltipText,
+      toggleOnPress,
+      tooltipTextStyle,
+      hightlightColor,
+    } = this.props;
+
+    if (!withTooltip)
+      return this.wrapWithPress(toggleOnPress, this.props.children);
+
+    const { yOffset, xOffset } = this.state;
+    return (
+      <React.Fragment>
+        <View
+          style={{
+            position: 'absolute',
+            top: yOffset,
+            left: xOffset,
+            backgroundColor: hightlightColor,
+            overflow: 'visible',
+          }}
+        >
+          {this.props.children}
+        </View>
+        {withPointer && this.renderPointer()}
+        <View style={{ ...this.getTooltipStyle() }}>
+          {tooltipComponent ? (
+            tooltipComponent
+          ) : (
+            <Text style={tooltipTextStyle}>{tooltipText}</Text>
+          )}
+        </View>
+      </React.Fragment>
+    );
+  };
+
+  componentDidMount() {
+    // wait to compute onLayout values.
+    setTimeout(this.getElementPosition, 500);
+  }
+
+  getElementPosition = () => {
+    if (this.renderedElement) {
+      NativeMethodsMixin.measureInWindow.call(
+        this.renderedElement,
+        (x, y, width, height) => {
+          this.setState({
+            xOffset: x,
+            yOffset: y,
+            elementWidth: width,
+            elementHeight: height,
+          });
+        },
+      );
+    }
+  };
+
+  render() {
+    const { isVisible } = this.state;
+    const { onClose, withOverlay } = this.props;
+
+    return (
+      <View collapsable={false} ref={e => (this.renderedElement = e)}>
+        {this.renderContent(false)}
+        <Modal
+          animationType="fade"
+          visible={isVisible}
+          transparent
+          onDismiss={onClose}
+          onRequestClose={onClose}
+        >
+          <TouchableOpacity
+            style={styles.container(withOverlay)}
+            onPress={this.toggleTooltip}
+            activeOpacity={1}
+          >
+            {this.renderContent(true)}
+          </TouchableOpacity>
+        </Modal>
+      </View>
+    );
+  }
+}
+
+Tooltip.propTypes = {
+  children: PropTypes.element,
+  withPointer: PropTypes.bool,
+  tooltipText: PropTypes.string,
+  tooltipComponent: PropTypes.element,
+  toggleOnPress: PropTypes.bool,
+  tooltipHeight: PropTypes.number,
+  tooltipWidth: PropTypes.number,
+  tooltipContainerStyle: PropTypes.any,
+  pointerColor: PropTypes.string,
+  tooltipTextStyle: PropTypes.any,
+  onClose: PropTypes.func,
+  withOverlay: PropTypes.bool,
+  backgroundColor: PropTypes.string,
+  highlightColor: PropTypes.string,
+  tooltipContainerDefaultStyle: PropTypes.any,
+}
+
+const styles = {
+  container: (withOverlay) => ({
+    backgroundColor: withOverlay ? Colors.overlay_bright : 'transparent',
+    flex: 1,
+  }),
+};
+
+export default Tooltip;

--- a/src/tooltip/Triangle.js
+++ b/src/tooltip/Triangle.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import ViewPropTypes from '../config/ViewPropTypes';
+
+const Triangle = ({ style, isDown }) => (
+  <View style={[styles.triangle, style, isDown ? styles.down : {}]} />
+);
+
+Triangle.propTypes = {
+  style: ViewPropTypes.style,
+  isDown: PropTypes.bool,
+}
+
+const styles = StyleSheet.create({
+  down: {
+    transform: [{ rotate: '180deg' }],
+  },
+  triangle: {
+    width: 0,
+    height: 0,
+    backgroundColor: 'transparent',
+    borderStyle: 'solid',
+    borderLeftWidth: 8,
+    borderRightWidth: 8,
+    borderBottomWidth: 15,
+    borderLeftColor: 'transparent',
+    borderRightColor: 'transparent',
+    borderBottomColor: 'white',
+  },
+});
+
+export default Triangle;

--- a/src/tooltip/getTooltipCoordinate.js
+++ b/src/tooltip/getTooltipCoordinate.js
@@ -1,0 +1,130 @@
+const getArea = (a, b) => a * b;
+
+const getPointDistance = (a, b) =>
+  Math.sqrt(Math.pow(a[0] - b[0], 2) + Math.pow(a[1] - b[1], 2));
+
+/*
+type Coord = {
+  x: number,
+  y: number,
+};
+
+  ~Tooltip coordinate system:~
+  The tooltip coordinates are based on the element which it is wrapping.
+  We take the x and y coordinates of the element and find the best position
+  to place the tooltip. To find the best position we look for the side with the
+  most space. In order to find the side with the most space we divide the the 
+  surroundings in four quadrants and check for the one with biggest area.
+  Once we know the quandrant with the biggest area it place the tooltip in that
+  direction.
+
+  To find the areas we first get 5 coordinate points. The center and the other 4 extreme points
+  which together make a perfect cross shape.
+
+  Once we know the coordincates we can get the length of the vertices which form each quadrant.
+  Since they are squares we only need two.
+*/
+
+const getTooltipCoordinate = (
+  x,
+  y,
+  width,
+  height,
+  ScreenWidth,
+  ScreenHeight,
+  tooltipWidth,
+  tooltipHeight,
+  withPointer,
+) => {
+  // The following are point coordinates: [x, y]
+  const center = [x + width / 2, y + height / 2];
+  const pOne = [center[0], 0];
+  const pTwo = [ScreenWidth, center[1]];
+  const pThree = [center[0], ScreenHeight];
+  const pFour = [0, center[1]];
+
+  // vertices
+  const vOne = getPointDistance(center, pOne);
+  const vTwo = getPointDistance(center, pTwo);
+  const vThree = getPointDistance(center, pThree);
+  const vFour = getPointDistance(center, pFour);
+
+  // Quadrant areas.
+  // type Areas = {
+  //   area: number,
+  //   id: number,
+  // };
+
+  const areas = [
+    getArea(vOne, vFour),
+    getArea(vOne, vTwo),
+    getArea(vTwo, vThree),
+    getArea(vThree, vFour),
+  ].map((each, index) => ({ area: each, id: index }));
+
+  const sortedArea = areas.sort((a, b) => b.area - a.area);
+
+  // deslocated points
+  const dX = 0.001;
+  const dY = height / 2;
+
+  // Deslocate the coordinates in the direction of the quadrant.
+  const directionCorrection = [[-1, -1], [1, -1], [1, 1], [-1, 1]];
+  const deslocateReferencePoint = [
+    [-tooltipWidth, -tooltipHeight],
+    [0, -tooltipHeight],
+    [0, 0],
+    [-tooltipWidth, 0],
+  ];
+
+  // current quadrant index
+  const qIndex = sortedArea[0].id;
+
+  const getWithPointerOffsetY = () =>
+    withPointer ? 10 * directionCorrection[qIndex][1] : 0;
+  const getWithPointerOffsetX = () =>
+    withPointer ? center[0] - 18 * directionCorrection[qIndex][0] : center[0];
+
+  const newX =
+    getWithPointerOffsetX() +
+    (dX * directionCorrection[qIndex][0] + deslocateReferencePoint[qIndex][0]);
+
+  return {
+    x: constraintX(newX, qIndex, center[0], ScreenWidth, tooltipWidth),
+    y:
+      center[1] +
+      (dY * directionCorrection[qIndex][1] +
+        deslocateReferencePoint[qIndex][1]) +
+      getWithPointerOffsetY(),
+  };
+};
+
+const constraintX = (
+  newX,
+  qIndex,
+  x,
+  ScreenWidth,
+  tooltipWidth,
+) => {
+  switch (qIndex) {
+    // 0 and 3 are the left side quadrants.
+    case 0:
+    case 3: {
+      const maxWidth = newX > ScreenWidth ? ScreenWidth - 10 : newX;
+      return newX < 1 ? 10 : maxWidth;
+    }
+    // 1 and 2 are the right side quadrants
+    case 1:
+    case 2: {
+      const leftOverSpace = ScreenWidth - newX;
+      return leftOverSpace >= tooltipWidth
+        ? newX
+        : newX - (tooltipWidth - leftOverSpace + 10);
+    }
+    default: {
+      return 0;
+    }
+  }
+};
+
+export default getTooltipCoordinate;

--- a/src/tooltip/helpers.js
+++ b/src/tooltip/helpers.js
@@ -1,0 +1,11 @@
+import { Platform, Dimensions } from 'react-native';
+
+const Screen = Dimensions.get('window');
+export const ScreenWidth: number = Screen.width;
+export const ScreenHeight: number = Screen.height;
+export const isIOS = Platform.OS === 'ios';
+
+export const Colors = {
+  darkergray: '#617080',
+  overlay_bright: 'rgba(250, 250, 250, 0.70)',
+};


### PR DESCRIPTION
### Proposal
Tooltip is something commonly used, I had a couple situations where I needed a tooltip and most of the time I've always encountered heavily styled ones. This is my attempt to a smart and very customisable tooltip. I decided to propose to RNE because I started using RNE recently and I'm very satisfied with it, I feel as it is exactly what we need from an UI toolkit.

Nonetheless I published this tooltip [here](https://github.com/AndreiCalazans/rn-tooltip) so I could start using it, but instead of maintaining it there I'd love to just use it with RNE.

### Usage

<img width="290" alt="screen shot 2018-05-05 at 15 58 20" src="https://user-images.githubusercontent.com/20777666/39666709-8bb84b1c-507e-11e8-9d9a-d3ed61fce3b4.png">

<img width='290' src='https://user-images.githubusercontent.com/20777666/39666712-93ddabfc-507e-11e8-814f-43618a37b619.gif'>

```javascript
import { Tooltip, Text } from 'react-native-elements';

...

<Tooltip tooltipWidth={200} tooltipText="Tooltip info goes here">
  <Text>Press me</Text>
</Tooltip>
```

### Props

```javascript
Tooltip.propTypes = {
  children: PropTypes.element,
  withPointer: PropTypes.bool,
  tooltipText: PropTypes.string,
  tooltipComponent: PropTypes.element,
  toggleOnPress: PropTypes.bool,
  tooltipHeight: PropTypes.number,
  tooltipWidth: PropTypes.number,
  tooltipContainerStyle: PropTypes.any,
  pointerColor: PropTypes.string,
  tooltipTextStyle: PropTypes.any,
  onClose: PropTypes.func,
  withOverlay: PropTypes.bool,
  backgroundColor: PropTypes.string,
  highlightColor: PropTypes.string,
  tooltipContainerDefaultStyle: PropTypes.any,
}
```

```javascript
static defaultProps = {
    withOverlay: true,
    hightlightColor: 'transparent',
    withPointer: true,
    toggleOnPress: true,
    tooltipHeight: 40,
    tooltipWidth: 150,
    tooltipContainerStyle: {},
    tooltipTextStyle: {},
    backgroundColor: Colors.darkergray,
    onClose: () => {},
  };

```

### Todos
If you guys approve this and decide that We can add the tooltip to RNE then the things below are still missing. I'll add them upon acceptance of this proposal.
- [ ] Add typescript types for Tooltip.
- [ ] Add Tooltip section to docs.


