### PR TITLE
Cleanup SearchBar typings and docs

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1238,7 +1238,7 @@ export type IconNode = boolean | React.ReactElement<{}> | IconProps;
 
 export interface SearchBarBase extends TextInputProperties {
   /**
-   * Styling for the input's view container
+   * Styling for the searchbar container
    */
   containerStyle?: StyleProp<ViewStyle>;
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1234,11 +1234,28 @@ export interface SearchBarWrapperProps {
   platform?: 'default' | 'ios' | 'android';
 }
 
-export interface SearchBarPropsDefault extends TextInputProperties {
+export type IconNode = boolean | React.ReactElement<{}> | IconProps;
+
+export interface SearchBarBase extends TextInputProperties {
   /**
-   * TextInput container styling
+   * Styling for the input's view container
    */
   containerStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * Optional styling for the TextInput's container
+   */
+  inputContainerStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * Override the clear Icon props or use a custom component. Use null or false to hide the icon.
+   */
+  clearIcon?: IconNode;
+
+  /**
+   * Override the search Icon props or use a custom component. Use null or false to hide the icon.
+   */
+  searchIcon?: IconNode;
 
   /**
    * TextInput styling
@@ -1246,114 +1263,9 @@ export interface SearchBarPropsDefault extends TextInputProperties {
   inputStyle?: StyleProp<TextStyle>;
 
   /**
-   * @deprecated
-   * Get ref of TextInput
-   */
-  textInputRef?(ref: TextInput): void;
-
-  /**
-   * @deprecated
-   * Get ref of TextInput container
-   */
-  containerRef?(ref: any): void;
-
-  /**
-   * Specify color, styling, or another Material Icon Name
-   */
-  icon?: IconObject;
-
-  /**
-   * Remove icon from textinput
-   *
-   * @default false
-   */
-  noIcon?: boolean;
-
-  /**
-   * @default false		change theme to light theme
-   */
-  lightTheme?: boolean;
-
-  /**
-   * Change TextInput styling to rounded corners
-   *
-   * @default false
-   */
-  round?: boolean;
-
-  /**
-   * Specify other than the default transparent underline color
-   *
-   * @default 'transparent'
-   */
-  underlineColorAndroid?: string;
-
-  /**
-   * Specify color, styling of the loading ActivityIndicator effect
-   *
-   * @default "{ color: '#86939e' }"
-   */
-  loadingIcon?: IconObject;
-
-  /**
-   * Show the loading ActivityIndicator effect
-   *
-   * @default false
-   */
-  showLoadingIcon?: boolean;
-
-  /**
-   * Set the placeholder text
-   *
-   * @default ''
-   */
-  placeholder?: string;
-
-  /**
-   * Set the color of the placeholder text
-   *
-   * @default '#86939e'
-   */
-  placeholderTextColor?: string;
-
-  /**
-   * Method to fire when text is changed
-   */
-  onChangeText?(text: string): void;
-
-  /**
-   * Method fired when text is cleared via the clear button
-   */
-  onClear?(): void;
-
-  /**
-   * Specify color, styling, or another Material Icon Name
-   * (Note: pressing on this icon clears text inside the searchbar)
-   *
-   * @default "{ color: '#86939e', name: 'search' }"
-   */
-  clearIcon?: IconObject;
-}
-
-export interface SearchBarPropsPlatform extends TextInputProperties {
-  /**
-   * If to show the clear icon or not
-   *
-   * @default true
-   */
-  clearIcon?: boolean;
-
-  /**
    * Optional props to pass to the ActivityIndicator
    */
   loadingProps?: ActivityIndicatorProperties;
-
-  /**
-   * Hide the search icon
-   *
-   * @default false
-   */
-  noIcon?: boolean;
 
   /**
    * If to show the loading indicator
@@ -1361,16 +1273,6 @@ export interface SearchBarPropsPlatform extends TextInputProperties {
    * @default false
    */
   showLoading?: boolean;
-
-  /**
-   * Styling for the input's view container
-   */
-  containerStyle?: StyleProp<ViewStyle>;
-
-  /**
-   * Optional icon to replace the search icon
-   */
-  leftIcon?: IconObject;
 
   /**
    * Container style for the left icon
@@ -1383,19 +1285,9 @@ export interface SearchBarPropsPlatform extends TextInputProperties {
   rightIconContainerStyle?: StyleProp<ViewStyle>;
 
   /**
-   * Optional styling for the input
-   */
-  inputStyle?: StyleProp<TextStyle>;
-
-  /**
    * Callback fired when the clear button is pressed
    */
   onClear?(): void;
-
-  /**
-   * Callback fired when the cancel button is pressed
-   */
-  onCancel?(): void;
 
   /**
    * Callback fired when the input is focused
@@ -1408,14 +1300,46 @@ export interface SearchBarPropsPlatform extends TextInputProperties {
   onBlur?(): void;
 
   /**
-   * Callback fired when the text in the input changes
+   * Method to fire when text is changed
    */
-  onChangeText?(): void;
+  onChangeText?(text: string): void;
+}
+
+export interface SearchBarPropsDefault extends SearchBarBase {
+  /**
+   * Change theme to light theme
+   *
+   * @default false
+   */
+  lightTheme?: boolean;
+
+  /**
+   * Change TextInput styling to rounded corners
+   *
+   * @default false
+   */
+  round?: boolean;
+}
+
+export interface SearchBarPropsAndroid extends SearchBarBase {
+  /**
+   * Override the cancel Icon props or use a custom component. Use null or false to hide the icon.
+   */
+  cancelIcon?: IconNode;
+}
+
+export interface SearchBarPropsPlatform extends SearchBarBase {
+  /**
+   * Callback fired when the cancel button is pressed
+   */
+  onCancel?(): void;
 }
 
 type SearchBarProps = SearchBarWrapperProps &
+  SearchBarBase &
+  SearchBarPropsPlatform &
   SearchBarPropsDefault &
-  SearchBarPropsPlatform;
+  SearchBarPropsAndroid;
 
 /**
  * SearchBar component

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1225,7 +1225,9 @@ export interface RatingProps {
  */
 export class Rating extends React.Component<RatingProps, any> {}
 
-export interface SearchBarWrapperProps {
+export type IconNode = boolean | React.ReactElement<{}> | IconProps;
+
+export interface SearchBarWrapper {
   /**
    * What style of search bar to display
    *
@@ -1233,8 +1235,6 @@ export interface SearchBarWrapperProps {
    */
   platform?: 'default' | 'ios' | 'android';
 }
-
-export type IconNode = boolean | React.ReactElement<{}> | IconProps;
 
 export interface SearchBarBase extends TextInputProperties {
   /**
@@ -1305,7 +1305,7 @@ export interface SearchBarBase extends TextInputProperties {
   onChangeText?(text: string): void;
 }
 
-export interface SearchBarPropsDefault extends SearchBarBase {
+export interface SearchBarDefault extends SearchBarBase {
   /**
    * Change theme to light theme
    *
@@ -1321,25 +1321,25 @@ export interface SearchBarPropsDefault extends SearchBarBase {
   round?: boolean;
 }
 
-export interface SearchBarPropsAndroid extends SearchBarBase {
-  /**
-   * Override the cancel Icon props or use a custom component. Use null or false to hide the icon.
-   */
-  cancelIcon?: IconNode;
-}
-
-export interface SearchBarPropsPlatform extends SearchBarBase {
+export interface SearchBarPlatform extends SearchBarBase {
   /**
    * Callback fired when the cancel button is pressed
    */
   onCancel?(): void;
 }
 
-type SearchBarProps = SearchBarWrapperProps &
+export interface SearchBarAndroid extends SearchBarPlatform {
+  /**
+   * Override the cancel Icon props or use a custom component. Use null or false to hide the icon.
+   */
+  cancelIcon?: IconNode;
+}
+
+type SearchBarProps = SearchBarWrapper &
   SearchBarBase &
-  SearchBarPropsPlatform &
-  SearchBarPropsDefault &
-  SearchBarPropsAndroid;
+  SearchBarPlatform &
+  SearchBarDefault &
+  SearchBarAndroid;
 
 /**
  * SearchBar component

--- a/src/searchbar/SearchBar-default.js
+++ b/src/searchbar/SearchBar-default.js
@@ -1,12 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import {
-  ActivityIndicator,
-  View,
-  StyleSheet,
-  Dimensions,
-  Text,
-} from 'react-native';
+import { ActivityIndicator, View, StyleSheet, Text } from 'react-native';
 import colors from '../config/colors';
 import renderNode from '../helpers/renderNode';
 import ViewPropTypes from '../config/ViewPropTypes';
@@ -15,7 +9,6 @@ import nodeType from '../helpers/nodeType';
 import Input from '../input/Input';
 import Icon from '../icons/Icon';
 
-const SCREEN_WIDTH = Dimensions.get('window').width;
 const defaultSearchIcon = {
   type: 'material-community',
   size: 18,

--- a/src/searchbar/SearchBar-ios.js
+++ b/src/searchbar/SearchBar-ios.js
@@ -10,13 +10,11 @@ import {
   ActivityIndicator,
   Text,
 } from 'react-native';
-import Ionicon from 'react-native-vector-icons/Ionicons';
 
 import ViewPropTypes from '../config/ViewPropTypes';
 import Input from '../input/Input';
 import Icon from '../icons/Icon';
-import renderNode from 'react-native-elements/src/helpers/renderNode';
-import nodeType from 'react-native-elements/src/helpers/nodeType';
+import { renderNode, nodeType } from '../helpers';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const IOS_GRAY = '#7d7d7d';
@@ -26,6 +24,7 @@ const defaultSearchIcon = {
   name: 'ios-search',
   color: IOS_GRAY,
 };
+
 class SearchBar extends Component {
   focus = () => {
     this.input.focus();

--- a/website/versioned_docs/version-1.0.0-beta4/searchbar.md
+++ b/website/versioned_docs/version-1.0.0-beta4/searchbar.md
@@ -1,6 +1,7 @@
 ---
-id: searchbar
+id: version-1.0.0-beta4-searchbar
 title: SearchBar
+original_id: searchbar
 ---
 
 ## Default SearchBar
@@ -26,22 +27,13 @@ import { SearchBar } from 'react-native-elements'
   placeholder='Type Here...' />
 
 <SearchBar
-  clearIcon={{ color: 'red' }}
-  searchIcon={false} // You could have passed `null` too
+  noIcon
   onChangeText={someMethod}
   onClear={someMethod}
   placeholder='Type Here...' />
 
 <SearchBar
   round
-  searchIcon={{ size: 24 }}
-  onChangeText={someMethod}
-  onClear={someMethod}
-  placeholder='Type Here...' />
-
-<SearchBar
-  lightTheme
-  searchIcon={<CustomComponent />}
   onChangeText={someMethod}
   onClear={someMethod}
   placeholder='Type Here...' />
@@ -50,6 +42,13 @@ import { SearchBar } from 'react-native-elements'
   lightTheme
   onChangeText={someMethod}
   onClear={someMethod}
+  placeholder='Type Here...' />
+
+<SearchBar
+  lightTheme
+  onChangeText={someMethod}
+  onClear={someMethod}
+  icon={{ type: 'font-awesome', name: 'search' }}
   placeholder='Type Here...' />
 
 <SearchBar
@@ -62,83 +61,42 @@ import { SearchBar } from 'react-native-elements'
   showLoading
   platform="android"
   placeholder='Search' />
-
-<SearchBar
-  showLoading
-  platform="android"
-  cancelIcon={{ type: 'font-awesome', name: 'chevron-left' }}
-  placeholder='Search' />
 ```
 
 ### Props
 
-> This component inherits all [React Native Elements Input props](/react-native-elements/docs/input.html#props), which means [all native TextInput props that come with a standard React Native TextInput element](https://facebook.github.io/react-native/docs/textinput.html), along with the following:
+> This component inherits [all native TextInput props that come with a standard React Native TextInput element](https://facebook.github.io/react-native/docs/textinput.html), along with the following:
 
-* [`platform`](#platform)
 * [`clearIcon`](#clearicon)
-* [`searchIcon`](#searchIcon)
-* [`cancelIcon`](#cancelIcon) (**`platform="android"` only**)
 * [`containerStyle`](#containerstyle)
+* [`icon`](#icon)
 * [`inputContainerStyle`](#inputcontainerstyle)
 * [`inputStyle`](#inputstyle)
-* [`lightTheme`](#lighttheme) (**`platform="default"` only**)
+* [`lightTheme`](#lighttheme)
 * [`loadingProps`](#loadingprops)
 * [`noIcon`](#noicon)
 * [`onChangeText`](#onchangetext)
 * [`onClear`](#onclear)
 * [`placeholder`](#placeholder)
 * [`placeholderTextColor`](#placeholdertextcolor)
-* [`round`](#round) (**`platform="default"` only**)
+* [`round`](#round)
 * [`showLoading`](#showloading)
 * [`underlineColorAndroid`](#underlinecolorandroid)
 * [`cancelButtonTitle`](#cancelbuttontitle)
-* [`cancelButtonProps`](#cancelbuttonprops)
 * [`onCancel`](#oncancel)
+* [`platform`](#platform)
 
 ---
 
 # Reference
 
-### `platform`
-
-choose the look and feel of the search bar. One of "default", "ios", "android"
-
-|  Type  |  Default  |
-| :----: | :-------: |
-| string | "default" |
-
----
-
 ### `clearIcon`
 
-This props allows to override the `Icon` props or use a custom component.
-Use `null` or `false` to hide the icon.
+specify color, styling, or another [Material Icon Name](https://design.google.com/icons/) (Note: pressing on this icon clears text inside the searchbar)
 
-|                                             Type                                              | Default |
-| :-------------------------------------------------------------------------------------------: | :-----: |
-| {[...Icon props](/react-native-elements/docs/icon.html#icon-props)}<br/>**OR**<br/> component |  none   |
-
----
-
-### `searchIcon`
-
-This props allows to override the `Icon` props or use a custom component.
-Use `null` or `false` to hide the icon.
-
-|                                             Type                                              | Default |
-| :-------------------------------------------------------------------------------------------: | :-----: |
-| {[...Icon props](/react-native-elements/docs/icon.html#icon-props)}<br/>**OR**<br/> component |  none   |
-
----
-
-### `cancelIcon` (**`platform="android"` only**)
-
-This props allows to override the `Icon` props or use a custom component.
-Use `null` or `false` to hide the icon.
-
-|                                             Type                                              | Default |
-| :-------------------------------------------------------------------------------------------: | :-----: |
-| {[...Icon props](/react-native-elements/docs/icon.html#icon-props)}<br/>**OR**<br/> component |  none   |
+|                          Type                          |               Default               |
+| :----------------------------------------------------: | :---------------------------------: |
+| object {name (string), color (string), style (object)} | { color: '#86939e', name: 'close' } |
 
 ---
 
@@ -149,6 +107,16 @@ style the container of the SearchBar
 |      Type      |      Default      |
 | :------------: | :---------------: |
 | object (style) | inherited styling |
+
+---
+
+### `icon`
+
+specify type, name, color, and styling of the icon
+
+|                                 Type                                  |                        Default                         |
+| :-------------------------------------------------------------------: | :----------------------------------------------------: |
+| object {type (string), name (string), color (string), style (object)} | { type: 'material', color: '#86939e', name: 'search' } |
 
 ---
 
@@ -172,7 +140,7 @@ style the TextInput
 
 ---
 
-### `lightTheme` (**`platform="default"` only**)
+### `lightTheme`
 
 change theme to light theme
 
@@ -189,6 +157,16 @@ props passed to ActivityIndicator
 |  Type  | Default |
 | :----: | :-----: |
 | object |   { }   |
+
+---
+
+### `noIcon`
+
+remove icon from textinput
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
 
 ---
 
@@ -232,7 +210,7 @@ set the color of the placeholder text
 
 ---
 
-### `round` (**`platform="default"` only**)
+### `round`
 
 change TextInput styling to rounded corners
 
@@ -272,16 +250,6 @@ specify other than the default transparent underline color
 
 ---
 
-### `cancelButtonProps`
-
-**(iOS only)** props passed to Button
-
-|  Type  | Default |
-| :----: | :-----: |
-| object |   { }   |
-
----
-
 ### `onCancel`
 
 callback fired when pressing the cancel button (iOS) or the back icon (Android)
@@ -289,6 +257,16 @@ callback fired when pressing the cancel button (iOS) or the back icon (Android)
 |   Type   | Default |
 | :------: | :-----: |
 | function |  null   |
+
+---
+
+### `platform`
+
+choose the look and feel of the search bar. One of "default", "ios", "android"
+
+|  Type  |  Default  |
+| :----: | :-------: |
+| string | "default" |
 
 ---
 


### PR DESCRIPTION
Cleanup SearchBar typings into:
* SearchBarWrapper(only `platform` prop)
* SearchBarBase (props used on all SearchBars)
* SearchBarDefault (props used only on `platform="default"`)
* SearchBarPlatform (props used on `platform="ios|android"`)
* SearchBarAndroid (props used on `platform="android"`) 

Also added missing `inputContainerStyle` to docs. (Fixes #1123)