### PR TITLE
Doc improvement: fix url hash conflict

### DIFF
--- a/website/versioned_docs/version-0.19.0/lists.md
+++ b/website/versioned_docs/version-0.19.0/lists.md
@@ -199,11 +199,11 @@ styles = StyleSheet.create({
 
 ### List Props
 
-* [`containerStyle`](#containerstyle)
+* [`containerStyle`](#containerstyle-list)
 
 ---
 
-### `containerStyle`
+### `containerStyle` (List)
 
 style the list container
 
@@ -221,7 +221,7 @@ style the list container
 * [`avatarStyle`](#avatarstyle)
 * [`chevronColor`](#chevroncolor)
 * [`component`](#component)
-* [`containerStyle`](#containerstyle)
+* [`containerStyle`](#containerstyle-listitem)
 * [`disabled`](#disabled)
 * [`disabledStyle`](#disabledstyle)
 * [`fontFamily`](#fontfamily)
@@ -340,7 +340,7 @@ replace element with custom element (optional)
 
 ---
 
-### `containerStyle`
+### `containerStyle` (ListItem)
 
 additional main container styling (optional)
 


### PR DESCRIPTION
for version 0.19.0 `Lists`
both `List` and `ListItem` have `containerStyle` props, however the two items link to the same url hash (#containerstyle)