### PR TITLE
Add overlayStyle prop to Card

### DIFF
--- a/src/card/Card.js
+++ b/src/card/Card.js
@@ -22,6 +22,7 @@ const Card = props => {
     containerStyle,
     wrapperStyle,
     imageWrapperStyle,
+    overlayStyle,
     title,
     titleStyle,
     titleNumberOfLines,

--- a/src/card/Card.js
+++ b/src/card/Card.js
@@ -84,7 +84,11 @@ const Card = props => {
               {...imageProps}
             >
               {(featuredTitle || featuredSubtitle) && (
-                <View style={styles.overlayContainer}>
+                <View style={[
+                  styles.overlayContainer,
+                  overlayStyle && overlayStyle,
+                ]}
+                >
                   {featuredTitle && (
                     <Text
                       style={[


### PR DESCRIPTION
Encountered "issue" with changing the overlayContainer style:
overlayContainer: {
    flex: 1,
    alignItems: 'center',
    backgroundColor: 'rgba(0, 0, 0, 0.2)',
    alignSelf: 'stretch',
    justifyContent: 'center',
    position: 'absolute',
    top: 0,
    left: 0,
    right: 0,
    bottom: 0,
  },

It could be an oversight or I may be missing something but the opacity was messing up the background.

PR code seemed to give me more control via the overlyStyle prop.

Thanks for taking a look and giving some feedback. 