### PR TITLE
Allow PricingCard to render without info prop

### DIFF
--- a/src/pricing/PricingCard.js
+++ b/src/pricing/PricingCard.js
@@ -34,14 +34,13 @@ const PricingCard = props => {
           {title}
         </Text>
         <Text style={[styles.pricingPrice, pricingStyle]}>{price}</Text>
-        {info &&
-          info.map((item, i) => {
-            return (
-              <Text key={i} style={[styles.pricingInfo, infoStyle]}>
-                {item}
-              </Text>
-            );
-          })}
+        {info.map((item, i) => {
+          return (
+            <Text key={i} style={[styles.pricingInfo, infoStyle]}>
+              {item}
+            </Text>
+          );
+        })}
         <Button
           title={button.title}
           buttonStyle={[
@@ -73,6 +72,7 @@ PricingCard.propTypes = {
 
 PricingCard.defaultProps = {
   color: colors.primary,
+  info: [],
 };
 
 const styles = StyleSheet.create({

--- a/src/pricing/PricingCard.js
+++ b/src/pricing/PricingCard.js
@@ -34,13 +34,14 @@ const PricingCard = props => {
           {title}
         </Text>
         <Text style={[styles.pricingPrice, pricingStyle]}>{price}</Text>
-        {info.map((item, i) => {
-          return (
-            <Text key={i} style={[styles.pricingInfo, infoStyle]}>
-              {item}
-            </Text>
-          );
-        })}
+        {info &&
+          info.map((item, i) => {
+            return (
+              <Text key={i} style={[styles.pricingInfo, infoStyle]}>
+                {item}
+              </Text>
+            );
+          })}
         <Button
           title={button.title}
           buttonStyle={[

--- a/src/pricing/__tests__/PricingCard.js
+++ b/src/pricing/__tests__/PricingCard.js
@@ -6,10 +6,7 @@ import PricingCard from '../PricingCard';
 describe('PricingCard component', () => {
   it('should render without issues', () => {
     const component = shallow(
-      <PricingCard
-        info={['1 User', 'Basic Support', 'All Core Features']}
-        button={{ title: 'GET STARTED', icon: 'flight-takeoff' }}
-      />
+      <PricingCard button={{ title: 'GET STARTED', icon: 'flight-takeoff' }} />
     );
 
     expect(component.length).toBe(1);

--- a/src/pricing/__tests__/PricingCard.js
+++ b/src/pricing/__tests__/PricingCard.js
@@ -6,6 +6,18 @@ import PricingCard from '../PricingCard';
 describe('PricingCard component', () => {
   it('should render without issues', () => {
     const component = shallow(
+      <PricingCard
+        info={['1 User', 'Basic Support', 'All Core Features']}
+        button={{ title: 'GET STARTED', icon: 'flight-takeoff' }}
+      />
+    );
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should render without info', () => {
+    const component = shallow(
       <PricingCard button={{ title: 'GET STARTED', icon: 'flight-takeoff' }} />
     );
 

--- a/src/pricing/__tests__/__snapshots__/PricingCard.js.snap
+++ b/src/pricing/__tests__/__snapshots__/PricingCard.js.snap
@@ -174,6 +174,111 @@ exports[`PricingCard component should render with props 1`] = `
 </Component>
 `;
 
+exports[`PricingCard component should render without info 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "backgroundColor": "white",
+        "borderColor": "#e1e8ee",
+        "borderWidth": 1,
+        "margin": 15,
+        "marginBottom": 15,
+        "padding": 15,
+        "shadowColor": "rgba(0,0,0, .2)",
+        "shadowOffset": Object {
+          "height": 1,
+          "width": 0,
+        },
+        "shadowOpacity": 0.5,
+        "shadowRadius": 0.5,
+      },
+      undefined,
+    ]
+  }
+>
+  <Component
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+  >
+    <TextElement
+      style={
+        Array [
+          Object {
+            "color": "#2089dc",
+            "fontSize": 37.5,
+            "fontWeight": "800",
+            "textAlign": "center",
+          },
+          undefined,
+          Object {
+            "color": "#2089dc",
+          },
+        ]
+      }
+    />
+    <TextElement
+      style={
+        Array [
+          Object {
+            "fontSize": 50,
+            "fontWeight": "700",
+            "marginBottom": 10,
+            "marginTop": 10,
+            "textAlign": "center",
+          },
+          undefined,
+        ]
+      }
+    />
+    <Button
+      TouchableComponent={[Function]}
+      buttonStyle={
+        Array [
+          Object {
+            "marginBottom": 10,
+            "marginTop": 15,
+          },
+          undefined,
+          Object {
+            "backgroundColor": "#2089dc",
+          },
+        ]
+      }
+      clear={false}
+      disabled={false}
+      icon={
+        <Icon
+          color="white"
+          name="flight-takeoff"
+          raised={false}
+          reverse={false}
+          reverseColor="white"
+          size={15}
+          underlayColor="white"
+        />
+      }
+      iconRight={false}
+      loadingProps={
+        Object {
+          "color": "white",
+          "size": "small",
+        }
+      }
+      onPress={[Function]}
+      raised={false}
+      title="GET STARTED"
+    />
+  </Component>
+</Component>
+`;
+
 exports[`PricingCard component should render without issues 1`] = `
 <Component
   style={
@@ -237,6 +342,57 @@ exports[`PricingCard component should render without issues 1`] = `
         ]
       }
     />
+    <TextElement
+      key="0"
+      style={
+        Array [
+          Object {
+            "color": "#86939e",
+            "fontWeight": "600",
+            "marginBottom": 5,
+            "marginTop": 5,
+            "textAlign": "center",
+          },
+          undefined,
+        ]
+      }
+    >
+      1 User
+    </TextElement>
+    <TextElement
+      key="1"
+      style={
+        Array [
+          Object {
+            "color": "#86939e",
+            "fontWeight": "600",
+            "marginBottom": 5,
+            "marginTop": 5,
+            "textAlign": "center",
+          },
+          undefined,
+        ]
+      }
+    >
+      Basic Support
+    </TextElement>
+    <TextElement
+      key="2"
+      style={
+        Array [
+          Object {
+            "color": "#86939e",
+            "fontWeight": "600",
+            "marginBottom": 5,
+            "marginTop": 5,
+            "textAlign": "center",
+          },
+          undefined,
+        ]
+      }
+    >
+      All Core Features
+    </TextElement>
     <Button
       TouchableComponent={[Function]}
       buttonStyle={

--- a/src/pricing/__tests__/__snapshots__/PricingCard.js.snap
+++ b/src/pricing/__tests__/__snapshots__/PricingCard.js.snap
@@ -237,57 +237,6 @@ exports[`PricingCard component should render without issues 1`] = `
         ]
       }
     />
-    <TextElement
-      key="0"
-      style={
-        Array [
-          Object {
-            "color": "#86939e",
-            "fontWeight": "600",
-            "marginBottom": 5,
-            "marginTop": 5,
-            "textAlign": "center",
-          },
-          undefined,
-        ]
-      }
-    >
-      1 User
-    </TextElement>
-    <TextElement
-      key="1"
-      style={
-        Array [
-          Object {
-            "color": "#86939e",
-            "fontWeight": "600",
-            "marginBottom": 5,
-            "marginTop": 5,
-            "textAlign": "center",
-          },
-          undefined,
-        ]
-      }
-    >
-      Basic Support
-    </TextElement>
-    <TextElement
-      key="2"
-      style={
-        Array [
-          Object {
-            "color": "#86939e",
-            "fontWeight": "600",
-            "marginBottom": 5,
-            "marginTop": 5,
-            "textAlign": "center",
-          },
-          undefined,
-        ]
-      }
-    >
-      All Core Features
-    </TextElement>
     <Button
       TouchableComponent={[Function]}
       buttonStyle={


### PR DESCRIPTION
As per documentation[1] the PriceCard should be able to work without any content in the info props, this fails because there is no condition check for its value before its its mapped.

*Updated test case for minimum props : removed 'info' as it should work without info.

[1] https://react-native-training.github.io/react-native-elements/docs/0.19.0/pricing.html

Performing PR on branch next as requested on #1246 