### PR TITLE
fix: define missing InputProp for Input

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -691,10 +691,15 @@ export class Divider extends React.Component<DividerProps, any> {}
 
 export interface InputProps extends TextInputProperties {
   /**
-   * Styling for Input Component Container (optional)
+   * Styling for view containing the label, the input and the error message (optional)
    */
   containerStyle?: StyleProp<ViewStyle>;
 
+  /**
+   * Styling for Input Component Container (optional)
+   */
+  inputContainerStyle?: StyleProp<ViewStyle>;
+  
   /**
    * Displays an icon to the left (optional)
    */


### PR DESCRIPTION
Make typescript match https://react-native-training.github.io/react-native-elements/docs/input.html

- inputContainerStyle was missing
- containerStyle comment was incorrect