### PR TITLE
Allow No Borders in ButtonGroup

### DIFF
--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -75,17 +75,20 @@ const ButtonGroup = props => {
                 borderRightWidth:
                   i === 0
                     ? 0
-                    : (innerBorderStyle && innerBorderStyle.width) || 1,
+                    : innerBorderStyle && innerBorderStyle.width !== undefined
+                      ? innerBorderStyle.width
+                      : 1,
                 borderRightColor:
                   (innerBorderStyle && innerBorderStyle.color) || colors.grey4,
               },
               i === 1 && {
                 borderLeftWidth:
-                  (innerBorderStyle && innerBorderStyle.width) || 1,
+                  innerBorderStyle && innerBorderStyle.width !== undefined
+                    ? innerBorderStyle.width
+                    : 1,
                 borderLeftColor:
                   (innerBorderStyle && innerBorderStyle.color) || colors.grey4,
-              },
-              i === buttons.length - 1 && {
+              },= buttons.length - 1 && {
                 ...lastBorderStyle,
                 borderTopRightRadius: containerBorderRadius,
                 borderBottomRightRadius: containerBorderRadius,


### PR DESCRIPTION
Update ButtonGroup.js to allow 0 values in `innerBorderStyle.width`.

Add a check for undefined instead of falsy value.