### PR TITLE
Fixed <Input> bug that caused errorMessage and label to render an empty string outside of <Text>

### DIFF
--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -75,7 +75,7 @@ class Input extends Component {
 
     return (
       <View style={[{ width: '90%' }, containerStyle]}>
-        {label && <Text style={[styles.label, labelStyle]}>{label}</Text>}
+        {!!label && <Text style={[styles.label, labelStyle]}>{label}</Text>}
         <Animated.View
           style={[
             styles.inputContainer,
@@ -106,7 +106,7 @@ class Input extends Component {
             </View>
           )}
         </Animated.View>
-        {errorMessage && (
+        {!!errorMessage && (
           <Text style={[styles.error, errorStyle && errorStyle]}>
             {errorMessage}
           </Text>


### PR DESCRIPTION
Addressed #1136 by checking for an empty string as well as null using the !! (not not) operator. 