### PR TITLE
ButtonGroup fixes

### DIFF
--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -38,6 +38,12 @@ const ButtonGroup = props => {
     ...attributes
   } = props;
 
+  let innerBorderWidth = 1;
+
+  if (innerBorderStyle && innerBorderStyle.hasOwnProperty('width')) {
+    innerBorderWidth = innerBorderStyle.width;
+  }
+
   return (
     <View
       {...attributes}
@@ -54,16 +60,12 @@ const ButtonGroup = props => {
               // react-native ref: https://github.com/facebook/react-native/issues/8236
               styles.button,
               i < buttons.length - 1 && {
-                borderRightWidth:
-                  i === 0
-                    ? 0
-                    : (innerBorderStyle && innerBorderStyle.width) || 1,
+                borderRightWidth: i === 0 ? 0 : innerBorderWidth,
                 borderRightColor:
                   (innerBorderStyle && innerBorderStyle.color) || colors.grey4,
               },
               i === 1 && {
-                borderLeftWidth:
-                  (innerBorderStyle && innerBorderStyle.width) || 1,
+                borderLeftWidth: innerBorderWidth,
                 borderLeftColor:
                   (innerBorderStyle && innerBorderStyle.color) || colors.grey4,
               },

--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -4,7 +4,6 @@ import {
   View,
   Text as NativeText,
   StyleSheet,
-  TouchableHighlight,
   TouchableNativeFeedback,
   TouchableOpacity,
   Platform,
@@ -48,29 +47,12 @@ const ButtonGroup = props => {
         const isSelected = selectedIndex === i || selectedIndexes.includes(i);
 
         return (
-          <Component
-            activeOpacity={activeOpacity}
-            setOpacityTo={setOpacityTo}
-            onHideUnderlay={onHideUnderlay}
-            onShowUnderlay={onShowUnderlay}
-            underlayColor={underlayColor || colors.primary}
-            disabled={disableSelected && isSelected ? true : false}
-            onPress={() => {
-              if (selectMultiple) {
-                if (selectedIndexes.includes(i)) {
-                  onPress(selectedIndexes.filter(index => index !== i));
-                } else {
-                  onPress([...selectedIndexes, i]);
-                }
-              } else {
-                onPress(i);
-              }
-            }}
+          <View
             key={i}
             style={[
-              styles.button,
               // FIXME: This is a workaround to the borderColor and borderRadius bug
               // react-native ref: https://github.com/facebook/react-native/issues/8236
+              styles.button,
               i < buttons.length - 1 && {
                 borderRightWidth:
                   i === 0
@@ -96,32 +78,53 @@ const ButtonGroup = props => {
               },
             ]}
           >
-            <View
-              style={[
-                styles.textContainer,
-                buttonStyle && buttonStyle,
-                isSelected && {
-                  backgroundColor: colors.primary,
-                },
-                isSelected && selectedButtonStyle && selectedButtonStyle,
-              ]}
+            <Component
+              activeOpacity={activeOpacity}
+              setOpacityTo={setOpacityTo}
+              onHideUnderlay={onHideUnderlay}
+              onShowUnderlay={onShowUnderlay}
+              underlayColor={underlayColor || colors.primary}
+              disabled={disableSelected && isSelected ? true : false}
+              onPress={() => {
+                if (selectMultiple) {
+                  if (selectedIndexes.includes(i)) {
+                    onPress(selectedIndexes.filter(index => index !== i));
+                  } else {
+                    onPress([...selectedIndexes, i]);
+                  }
+                } else {
+                  onPress(i);
+                }
+              }}
+              style={styles.button}
             >
-              {button.element ? (
-                <button.element />
-              ) : (
-                <Text
-                  style={[
-                    styles.buttonText,
-                    textStyle && textStyle,
-                    isSelected && { color: '#fff' },
-                    isSelected && selectedTextStyle,
-                  ]}
-                >
-                  {button}
-                </Text>
-              )}
-            </View>
-          </Component>
+              <View
+                style={[
+                  styles.textContainer,
+                  buttonStyle && buttonStyle,
+                  isSelected && {
+                    backgroundColor: colors.primary,
+                  },
+                  isSelected && selectedButtonStyle && selectedButtonStyle,
+                ]}
+              >
+                {button.element ? (
+                  <button.element />
+                ) : (
+                  <Text
+                    style={[
+                      styles.buttonText,
+                      textStyle && textStyle,
+                      isSelected && { color: '#fff' },
+                      isSelected && selectedTextStyle,
+                    ]}
+                  >
+                    {button}
+                  </Text>
+                )}
+              </View>
+            </Component>
+          </View>
         );
       })}
     </View>

--- a/src/buttons/__tests__/ButtonGroup.js
+++ b/src/buttons/__tests__/ButtonGroup.js
@@ -66,4 +66,13 @@ describe('ButtonGroup Component', () => {
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();
   });
+
+  it('should render without inner borders', () => {
+    const component = shallow(
+      <ButtonGroup buttons={buttons} innerBorderStyle={{ width: 0 }} />
+    );
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
 });

--- a/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
+++ b/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
@@ -778,6 +778,219 @@ exports[`ButtonGroup Component should render with button.element 1`] = `
 </Component>
 `;
 
+exports[`ButtonGroup Component should render without inner borders 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "backgroundColor": "#fff",
+        "borderColor": "#e3e3e3",
+        "borderRadius": 3,
+        "borderWidth": 1,
+        "flexDirection": "row",
+        "height": 40,
+        "marginBottom": 5,
+        "marginLeft": 10,
+        "marginRight": 10,
+        "marginTop": 5,
+        "overflow": "hidden",
+      },
+      undefined,
+    ]
+  }
+>
+  <Component
+    key="0"
+    style={
+      Array [
+        Object {
+          "flex": 1,
+        },
+        Object {
+          "borderRightColor": "#bdc6cf",
+          "borderRightWidth": 0,
+        },
+        false,
+        false,
+        Object {
+          "borderBottomLeftRadius": 3,
+          "borderTopLeftRadius": 3,
+        },
+      ]
+    }
+  >
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+      underlayColor="#2089dc"
+    >
+      <Component
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+            false,
+            false,
+          ]
+        }
+      >
+        <TextElement
+          style={
+            Array [
+              Object {
+                "color": "#5e6977",
+                "fontSize": 16.25,
+                "fontWeight": "500",
+              },
+              undefined,
+              false,
+              false,
+            ]
+          }
+        >
+          Button 1
+        </TextElement>
+      </Component>
+    </TouchableOpacity>
+  </Component>
+  <Component
+    key="1"
+    style={
+      Array [
+        Object {
+          "flex": 1,
+        },
+        Object {
+          "borderRightColor": "#bdc6cf",
+          "borderRightWidth": 0,
+        },
+        Object {
+          "borderLeftColor": "#bdc6cf",
+          "borderLeftWidth": 0,
+        },
+        false,
+        false,
+      ]
+    }
+  >
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+      underlayColor="#2089dc"
+    >
+      <Component
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+            false,
+            false,
+          ]
+        }
+      >
+        <TextElement
+          style={
+            Array [
+              Object {
+                "color": "#5e6977",
+                "fontSize": 16.25,
+                "fontWeight": "500",
+              },
+              undefined,
+              false,
+              false,
+            ]
+          }
+        >
+          Button 2
+        </TextElement>
+      </Component>
+    </TouchableOpacity>
+  </Component>
+  <Component
+    key="2"
+    style={
+      Array [
+        Object {
+          "flex": 1,
+        },
+        false,
+        false,
+        Object {
+          "borderBottomRightRadius": 3,
+          "borderTopRightRadius": 3,
+        },
+        false,
+      ]
+    }
+  >
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+      underlayColor="#2089dc"
+    >
+      <Component
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+            false,
+            false,
+          ]
+        }
+      >
+        <TextElement
+          style={
+            Array [
+              Object {
+                "color": "#5e6977",
+                "fontSize": 16.25,
+                "fontWeight": "500",
+              },
+              undefined,
+              false,
+              false,
+            ]
+          }
+        >
+          Button 3
+        </TextElement>
+      </Component>
+    </TouchableOpacity>
+  </Component>
+</Component>
+`;
+
 exports[`ButtonGroup Component should render without issues 1`] = `
 <Component
   style={

--- a/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
+++ b/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
@@ -23,11 +23,8 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
     ]
   }
 >
-  <TouchableOpacity
-    activeOpacity={0.2}
-    disabled={false}
+  <Component
     key="0"
-    onPress={[Function]}
     style={
       Array [
         Object {
@@ -45,47 +42,55 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
         },
       ]
     }
-    underlayColor="#2089dc"
   >
-    <Component
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          },
-          Object {
-            "backgroundColor": "blue",
-          },
-          false,
-          false,
-        ]
+        Object {
+          "flex": 1,
+        }
       }
+      underlayColor="#2089dc"
     >
-      <TextElement
+      <Component
         style={
           Array [
             Object {
-              "color": "#5e6977",
-              "fontSize": 16.25,
-              "fontWeight": "500",
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
             },
-            undefined,
+            Object {
+              "backgroundColor": "blue",
+            },
             false,
             false,
           ]
         }
       >
-        Button 1
-      </TextElement>
-    </Component>
-  </TouchableOpacity>
-  <TouchableOpacity
-    activeOpacity={0.2}
-    disabled={false}
+        <TextElement
+          style={
+            Array [
+              Object {
+                "color": "#5e6977",
+                "fontSize": 16.25,
+                "fontWeight": "500",
+              },
+              undefined,
+              false,
+              false,
+            ]
+          }
+        >
+          Button 1
+        </TextElement>
+      </Component>
+    </TouchableOpacity>
+  </Component>
+  <Component
     key="1"
-    onPress={[Function]}
     style={
       Array [
         Object {
@@ -103,47 +108,55 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
         false,
       ]
     }
-    underlayColor="#2089dc"
   >
-    <Component
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          },
-          Object {
-            "backgroundColor": "blue",
-          },
-          false,
-          false,
-        ]
+        Object {
+          "flex": 1,
+        }
       }
+      underlayColor="#2089dc"
     >
-      <TextElement
+      <Component
         style={
           Array [
             Object {
-              "color": "#5e6977",
-              "fontSize": 16.25,
-              "fontWeight": "500",
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
             },
-            undefined,
+            Object {
+              "backgroundColor": "blue",
+            },
             false,
             false,
           ]
         }
       >
-        Button 2
-      </TextElement>
-    </Component>
-  </TouchableOpacity>
-  <TouchableOpacity
-    activeOpacity={0.2}
-    disabled={false}
+        <TextElement
+          style={
+            Array [
+              Object {
+                "color": "#5e6977",
+                "fontSize": 16.25,
+                "fontWeight": "500",
+              },
+              undefined,
+              false,
+              false,
+            ]
+          }
+        >
+          Button 2
+        </TextElement>
+      </Component>
+    </TouchableOpacity>
+  </Component>
+  <Component
     key="2"
-    onPress={[Function]}
     style={
       Array [
         Object {
@@ -158,42 +171,53 @@ exports[`ButtonGroup Component should have onPress event 1`] = `
         false,
       ]
     }
-    underlayColor="#2089dc"
   >
-    <Component
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          },
-          Object {
-            "backgroundColor": "blue",
-          },
-          false,
-          false,
-        ]
+        Object {
+          "flex": 1,
+        }
       }
+      underlayColor="#2089dc"
     >
-      <TextElement
+      <Component
         style={
           Array [
             Object {
-              "color": "#5e6977",
-              "fontSize": 16.25,
-              "fontWeight": "500",
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
             },
-            undefined,
+            Object {
+              "backgroundColor": "blue",
+            },
             false,
             false,
           ]
         }
       >
-        Button 3
-      </TextElement>
-    </Component>
-  </TouchableOpacity>
+        <TextElement
+          style={
+            Array [
+              Object {
+                "color": "#5e6977",
+                "fontSize": 16.25,
+                "fontWeight": "500",
+              },
+              undefined,
+              false,
+              false,
+            ]
+          }
+        >
+          Button 3
+        </TextElement>
+      </Component>
+    </TouchableOpacity>
+  </Component>
 </Component>
 `;
 
@@ -218,11 +242,8 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
     ]
   }
 >
-  <TouchableOpacity
-    activeOpacity={0.2}
-    disabled={false}
+  <Component
     key="0"
-    onPress={[Function]}
     style={
       Array [
         Object {
@@ -240,29 +261,25 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
         },
       ]
     }
-    underlayColor="#2089dc"
   >
-    <Component
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          },
-          undefined,
-          false,
-          false,
-        ]
+        Object {
+          "flex": 1,
+        }
       }
+      underlayColor="#2089dc"
     >
-      <TextElement
+      <Component
         style={
           Array [
             Object {
-              "color": "#5e6977",
-              "fontSize": 16.25,
-              "fontWeight": "500",
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
             },
             undefined,
             false,
@@ -270,15 +287,27 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
           ]
         }
       >
-        Button 1
-      </TextElement>
-    </Component>
-  </TouchableOpacity>
-  <TouchableOpacity
-    activeOpacity={0.2}
-    disabled={false}
+        <TextElement
+          style={
+            Array [
+              Object {
+                "color": "#5e6977",
+                "fontSize": 16.25,
+                "fontWeight": "500",
+              },
+              undefined,
+              false,
+              false,
+            ]
+          }
+        >
+          Button 1
+        </TextElement>
+      </Component>
+    </TouchableOpacity>
+  </Component>
+  <Component
     key="1"
-    onPress={[Function]}
     style={
       Array [
         Object {
@@ -296,29 +325,25 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
         false,
       ]
     }
-    underlayColor="#2089dc"
   >
-    <Component
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          },
-          undefined,
-          false,
-          false,
-        ]
+        Object {
+          "flex": 1,
+        }
       }
+      underlayColor="#2089dc"
     >
-      <TextElement
+      <Component
         style={
           Array [
             Object {
-              "color": "#5e6977",
-              "fontSize": 16.25,
-              "fontWeight": "500",
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
             },
             undefined,
             false,
@@ -326,15 +351,27 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
           ]
         }
       >
-        Button 2
-      </TextElement>
-    </Component>
-  </TouchableOpacity>
-  <TouchableOpacity
-    activeOpacity={0.2}
-    disabled={false}
+        <TextElement
+          style={
+            Array [
+              Object {
+                "color": "#5e6977",
+                "fontSize": 16.25,
+                "fontWeight": "500",
+              },
+              undefined,
+              false,
+              false,
+            ]
+          }
+        >
+          Button 2
+        </TextElement>
+      </Component>
+    </TouchableOpacity>
+  </Component>
+  <Component
     key="2"
-    onPress={[Function]}
     style={
       Array [
         Object {
@@ -350,29 +387,25 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
         false,
       ]
     }
-    underlayColor="#2089dc"
   >
-    <Component
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          },
-          undefined,
-          false,
-          false,
-        ]
+        Object {
+          "flex": 1,
+        }
       }
+      underlayColor="#2089dc"
     >
-      <TextElement
+      <Component
         style={
           Array [
             Object {
-              "color": "#5e6977",
-              "fontSize": 16.25,
-              "fontWeight": "500",
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
             },
             undefined,
             false,
@@ -380,10 +413,25 @@ exports[`ButtonGroup Component should render lastButtonStyle 1`] = `
           ]
         }
       >
-        Button 3
-      </TextElement>
-    </Component>
-  </TouchableOpacity>
+        <TextElement
+          style={
+            Array [
+              Object {
+                "color": "#5e6977",
+                "fontSize": 16.25,
+                "fontWeight": "500",
+              },
+              undefined,
+              false,
+              false,
+            ]
+          }
+        >
+          Button 3
+        </TextElement>
+      </Component>
+    </TouchableOpacity>
+  </Component>
 </Component>
 `;
 
@@ -408,11 +456,8 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
     ]
   }
 >
-  <TouchableOpacity
-    activeOpacity={0.2}
-    disabled={false}
+  <Component
     key="0"
-    onPress={[Function]}
     style={
       Array [
         Object {
@@ -430,29 +475,25 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
         },
       ]
     }
-    underlayColor="#2089dc"
   >
-    <Component
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          },
-          undefined,
-          false,
-          false,
-        ]
+        Object {
+          "flex": 1,
+        }
       }
+      underlayColor="#2089dc"
     >
-      <TextElement
+      <Component
         style={
           Array [
             Object {
-              "color": "#5e6977",
-              "fontSize": 16.25,
-              "fontWeight": "500",
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
             },
             undefined,
             false,
@@ -460,15 +501,27 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
           ]
         }
       >
-        Button 1
-      </TextElement>
-    </Component>
-  </TouchableOpacity>
-  <TouchableOpacity
-    activeOpacity={0.2}
-    disabled={false}
+        <TextElement
+          style={
+            Array [
+              Object {
+                "color": "#5e6977",
+                "fontSize": 16.25,
+                "fontWeight": "500",
+              },
+              undefined,
+              false,
+              false,
+            ]
+          }
+        >
+          Button 1
+        </TextElement>
+      </Component>
+    </TouchableOpacity>
+  </Component>
+  <Component
     key="1"
-    onPress={[Function]}
     style={
       Array [
         Object {
@@ -486,53 +539,61 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
         false,
       ]
     }
-    underlayColor="#2089dc"
   >
-    <Component
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          },
-          undefined,
-          Object {
-            "backgroundColor": "#2089dc",
-          },
-          Object {
-            "backgroundColor": "red",
-          },
-        ]
+        Object {
+          "flex": 1,
+        }
       }
+      underlayColor="#2089dc"
     >
-      <TextElement
+      <Component
         style={
           Array [
             Object {
-              "color": "#5e6977",
-              "fontSize": 16.25,
-              "fontWeight": "500",
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
             },
             undefined,
             Object {
-              "color": "#fff",
+              "backgroundColor": "#2089dc",
             },
             Object {
-              "fontSize": 12,
+              "backgroundColor": "red",
             },
           ]
         }
       >
-        Button 2
-      </TextElement>
-    </Component>
-  </TouchableOpacity>
-  <TouchableOpacity
-    activeOpacity={0.2}
-    disabled={false}
+        <TextElement
+          style={
+            Array [
+              Object {
+                "color": "#5e6977",
+                "fontSize": 16.25,
+                "fontWeight": "500",
+              },
+              undefined,
+              Object {
+                "color": "#fff",
+              },
+              Object {
+                "fontSize": 12,
+              },
+            ]
+          }
+        >
+          Button 2
+        </TextElement>
+      </Component>
+    </TouchableOpacity>
+  </Component>
+  <Component
     key="2"
-    onPress={[Function]}
     style={
       Array [
         Object {
@@ -547,29 +608,25 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
         false,
       ]
     }
-    underlayColor="#2089dc"
   >
-    <Component
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          },
-          undefined,
-          false,
-          false,
-        ]
+        Object {
+          "flex": 1,
+        }
       }
+      underlayColor="#2089dc"
     >
-      <TextElement
+      <Component
         style={
           Array [
             Object {
-              "color": "#5e6977",
-              "fontSize": 16.25,
-              "fontWeight": "500",
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
             },
             undefined,
             false,
@@ -577,10 +634,25 @@ exports[`ButtonGroup Component should render selectedIndex 1`] = `
           ]
         }
       >
-        Button 3
-      </TextElement>
-    </Component>
-  </TouchableOpacity>
+        <TextElement
+          style={
+            Array [
+              Object {
+                "color": "#5e6977",
+                "fontSize": 16.25,
+                "fontWeight": "500",
+              },
+              undefined,
+              false,
+              false,
+            ]
+          }
+        >
+          Button 3
+        </TextElement>
+      </Component>
+    </TouchableOpacity>
+  </Component>
 </Component>
 `;
 
@@ -605,11 +677,8 @@ exports[`ButtonGroup Component should render with button.element 1`] = `
     ]
   }
 >
-  <TouchableOpacity
-    activeOpacity={0.2}
-    disabled={false}
+  <Component
     key="0"
-    onPress={[Function]}
     style={
       Array [
         Object {
@@ -627,30 +696,38 @@ exports[`ButtonGroup Component should render with button.element 1`] = `
         },
       ]
     }
-    underlayColor="#2089dc"
   >
-    <Component
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          },
-          undefined,
-          false,
-          false,
-        ]
+        Object {
+          "flex": 1,
+        }
       }
+      underlayColor="#2089dc"
     >
-      <Text />
-    </Component>
-  </TouchableOpacity>
-  <TouchableOpacity
-    activeOpacity={0.2}
-    disabled={false}
+      <Component
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+            false,
+            false,
+          ]
+        }
+      >
+        <Text />
+      </Component>
+    </TouchableOpacity>
+  </Component>
+  <Component
     key="1"
-    onPress={[Function]}
     style={
       Array [
         Object {
@@ -668,25 +745,36 @@ exports[`ButtonGroup Component should render with button.element 1`] = `
         false,
       ]
     }
-    underlayColor="#2089dc"
   >
-    <Component
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          },
-          undefined,
-          false,
-          false,
-        ]
+        Object {
+          "flex": 1,
+        }
       }
+      underlayColor="#2089dc"
     >
-      <View />
-    </Component>
-  </TouchableOpacity>
+      <Component
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            undefined,
+            false,
+            false,
+          ]
+        }
+      >
+        <View />
+      </Component>
+    </TouchableOpacity>
+  </Component>
 </Component>
 `;
 
@@ -711,11 +799,8 @@ exports[`ButtonGroup Component should render without issues 1`] = `
     ]
   }
 >
-  <TouchableOpacity
-    activeOpacity={0.2}
-    disabled={false}
+  <Component
     key="0"
-    onPress={[Function]}
     style={
       Array [
         Object {
@@ -733,29 +818,25 @@ exports[`ButtonGroup Component should render without issues 1`] = `
         },
       ]
     }
-    underlayColor="#2089dc"
   >
-    <Component
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          },
-          undefined,
-          false,
-          false,
-        ]
+        Object {
+          "flex": 1,
+        }
       }
+      underlayColor="#2089dc"
     >
-      <TextElement
+      <Component
         style={
           Array [
             Object {
-              "color": "#5e6977",
-              "fontSize": 16.25,
-              "fontWeight": "500",
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
             },
             undefined,
             false,
@@ -763,15 +844,27 @@ exports[`ButtonGroup Component should render without issues 1`] = `
           ]
         }
       >
-        Button 1
-      </TextElement>
-    </Component>
-  </TouchableOpacity>
-  <TouchableOpacity
-    activeOpacity={0.2}
-    disabled={false}
+        <TextElement
+          style={
+            Array [
+              Object {
+                "color": "#5e6977",
+                "fontSize": 16.25,
+                "fontWeight": "500",
+              },
+              undefined,
+              false,
+              false,
+            ]
+          }
+        >
+          Button 1
+        </TextElement>
+      </Component>
+    </TouchableOpacity>
+  </Component>
+  <Component
     key="1"
-    onPress={[Function]}
     style={
       Array [
         Object {
@@ -789,29 +882,25 @@ exports[`ButtonGroup Component should render without issues 1`] = `
         false,
       ]
     }
-    underlayColor="#2089dc"
   >
-    <Component
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          },
-          undefined,
-          false,
-          false,
-        ]
+        Object {
+          "flex": 1,
+        }
       }
+      underlayColor="#2089dc"
     >
-      <TextElement
+      <Component
         style={
           Array [
             Object {
-              "color": "#5e6977",
-              "fontSize": 16.25,
-              "fontWeight": "500",
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
             },
             undefined,
             false,
@@ -819,15 +908,27 @@ exports[`ButtonGroup Component should render without issues 1`] = `
           ]
         }
       >
-        Button 2
-      </TextElement>
-    </Component>
-  </TouchableOpacity>
-  <TouchableOpacity
-    activeOpacity={0.2}
-    disabled={false}
+        <TextElement
+          style={
+            Array [
+              Object {
+                "color": "#5e6977",
+                "fontSize": 16.25,
+                "fontWeight": "500",
+              },
+              undefined,
+              false,
+              false,
+            ]
+          }
+        >
+          Button 2
+        </TextElement>
+      </Component>
+    </TouchableOpacity>
+  </Component>
+  <Component
     key="2"
-    onPress={[Function]}
     style={
       Array [
         Object {
@@ -842,29 +943,25 @@ exports[`ButtonGroup Component should render without issues 1`] = `
         false,
       ]
     }
-    underlayColor="#2089dc"
   >
-    <Component
+    <TouchableOpacity
+      activeOpacity={0.2}
+      disabled={false}
+      onPress={[Function]}
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-          },
-          undefined,
-          false,
-          false,
-        ]
+        Object {
+          "flex": 1,
+        }
       }
+      underlayColor="#2089dc"
     >
-      <TextElement
+      <Component
         style={
           Array [
             Object {
-              "color": "#5e6977",
-              "fontSize": 16.25,
-              "fontWeight": "500",
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
             },
             undefined,
             false,
@@ -872,9 +969,24 @@ exports[`ButtonGroup Component should render without issues 1`] = `
           ]
         }
       >
-        Button 3
-      </TextElement>
-    </Component>
-  </TouchableOpacity>
+        <TextElement
+          style={
+            Array [
+              Object {
+                "color": "#5e6977",
+                "fontSize": 16.25,
+                "fontWeight": "500",
+              },
+              undefined,
+              false,
+              false,
+            ]
+          }
+        >
+          Button 3
+        </TextElement>
+      </Component>
+    </TouchableOpacity>
+  </Component>
 </Component>
 `;


### PR DESCRIPTION
### Fix blinking border on tap
Before the borders were applied on the touchable. So when the user taps on a TouchableOpacity for example, the border would blink as well. This PR wraps the touchable in a View and applies the border to the View.

### Fix 0-width border on innerBorderStyle
Before when setting `innerBorderStyle={{ width: 0 }}`; the border would still remain. This is because the logic for the innerBorderStyle was faulty, as comparing `innerBorderStyle && innerBorderStyle.width` would always be false if the width is 0 since in Javascript the 0 will be coerced to false. This PR fixes the logic by using object.hasOwnProperty to correctly check if the width was passed. Inspired by #1274. Fixes #1300.