### PR TITLE
Hoist the isFocused() method from the react native input element

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -774,6 +774,13 @@ export class Input extends React.Component<InputProps, any> {
   focus(): void;
 
   /**
+   * Calls isFocused() on the Input
+   *
+   * eg `let focused = this.inputRef.isFocused()`
+   */
+  isFocused(): boolean;
+
+  /**
    * Calls blur on the Input
    *
    * eg `this.inputRef.blur()`

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -30,6 +30,10 @@ class Input extends Component {
     this.input.focus();
   }
 
+  isFocused() {
+    return this.input.isFocused();
+  }
+
   blur() {
     this.input.blur();
   }


### PR DESCRIPTION
As per other component methods (focus(), blur()) etc that are passed-through from the contained React Native component, this will simply return the result of isFocused() in that component.