### PR TITLE
Do not use index as a key

### DIFF
--- a/website/versioned_docs/version-0.19.0/lists.md
+++ b/website/versioned_docs/version-0.19.0/lists.md
@@ -27,11 +27,11 @@ const list = [
 
 <List containerStyle={{marginBottom: 20}}>
   {
-    list.map((l, i) => (
+    list.map((l) => (
       <ListItem
         roundAvatar
         avatar={{uri:l.avatar_url}}
-        key={i}
+        key={l.name}
         title={l.name}
       />
     ))
@@ -58,9 +58,9 @@ const list = [
 
 <List>
   {
-    list.map((item, i) => (
+    list.map((item) => (
       <ListItem
-        key={i}
+        key={item.title}
         title={item.title}
         leftIcon={{name: item.icon}}
       />


### PR DESCRIPTION
Using index as a key is a bad practice and should be avoided. Please see https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318 for details.

Since many devs would just copy and paste the code, I believe it is exceptionally important to promote good practices in the docs.