### PR TITLE
fix: add missing "size" prop to CheckBox types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -618,6 +618,13 @@ export interface CheckBoxProps {
   textStyle?: StyleProp<TextStyle>;
 
   /**
+   * Size of the checkbox
+   *
+   * @default 24
+   */
+  size?: number;
+
+  /**
    * onLongPress function for checkbox
    */
   onLongPress?(): void;


### PR DESCRIPTION
🖖 Heya. The `size` prop was missing in CheckBox's type defs.