### PR TITLE
feat(Icon): Add disabled and disabledStyle

### DIFF
--- a/docs/icon.md
+++ b/docs/icon.md
@@ -5,17 +5,36 @@ title: Icon
 
 ![Icon](/react-native-elements/img/icons.png)
 
-Icons take the name of a [material icon](https://design.google.com/icons/) as a prop. Use the [icon directory](https://oblador.github.io/react-native-vector-icons/) to search for icons
+Icons take the name of a [material icon](https://design.google.com/icons/) as a
+prop. Use the
+[icon directory](https://oblador.github.io/react-native-vector-icons/) to search
+for icons
 
-> You can override Material icons with one of the following: [material-community](https://materialdesignicons.com/), [font-awesome](http://fontawesome.io/icons/), [octicon](https://octicons.github.com/), [ionicon](http://ionicons.com/), [foundation](http://zurb.com/playground/foundation-icon-fonts-3), [evilicon](http://evil-icons.io/), [simple-line-icon](http://simplelineicons.com/), [zocial](http://weloveiconfonts.com/), or [entypo](http://www.entypo.com/) by providing a type prop.
+> You can override Material icons with one of the following:
+> [material-community](https://materialdesignicons.com/),
+> [font-awesome](http://fontawesome.io/icons/),
+> [octicon](https://octicons.github.com/), [ionicon](http://ionicons.com/),
+> [foundation](http://zurb.com/playground/foundation-icon-fonts-3),
+> [evilicon](http://evil-icons.io/),
+> [simple-line-icon](http://simplelineicons.com/),
+> [zocial](http://weloveiconfonts.com/), or [entypo](http://www.entypo.com/) by
+> providing a type prop.
 
 > Hint: use **reverse** to make your icon look like a button
 
 ### Custom Icon Fonts
 
-Register your own custom icons by calling `registerCustomIconType('customid', customFont)`. Create a custom font by following the [ instructions for creating a custom font here](https://github.com/oblador/react-native-vector-icons#custom-fonts). Also, you can use [Fontello](http://fontello.com/) to generate custom icon fonts.
+Register your own custom icons by calling
+`registerCustomIconType('customid', customFont)`. Create a custom font by
+following the
+[ instructions for creating a custom font here](https://github.com/oblador/react-native-vector-icons#custom-fonts).
+Also, you can use [Fontello](http://fontello.com/) to generate custom icon
+fonts.
 
-If you are looking to implement custom icon fonts, please look at our example app [here](https://github.com/react-native-training/react-native-elements-app/blob/master/src/views/buttons_home.js) to see how to use them with React Native Elements.
+If you are looking to implement custom icon fonts, please look at our example
+app
+[here](https://github.com/react-native-training/react-native-elements-app/blob/master/src/views/buttons_home.js)
+to see how to use them with React Native Elements.
 
 ```js
 import { Icon } from 'react-native-elements'
@@ -55,6 +74,8 @@ import { Icon } from 'react-native-elements'
 * [`color`](#color)
 * [`containerStyle`](#containerstyle)
 * [`component`](#component)
+* [`disabled`](#disabled)
+* [`disabledStyle`](#disabledstyle)
 * [`onPress`](#onpress)
 * [`iconStyle`](#iconstyle)
 * [`name`](#name)
@@ -82,7 +103,8 @@ name of icon (required)
 
 ### `type`
 
-type (defaults to material, options are `material-community, zocial, font-awesome, octicon, ionicon, foundation, evilicon, simple-line-icon, feather or entypo`)
+type (defaults to material, options are
+`material-community, zocial, font-awesome, octicon, ionicon, foundation, evilicon, simple-line-icon, feather or entypo`)
 
 |  Type  | Default  |
 | :----: | :------: |
@@ -127,6 +149,27 @@ update React Native Component (optional)
 |          Type          |                                        Default                                        |
 | :--------------------: | :-----------------------------------------------------------------------------------: |
 | React Native component | View if no onPress method is defined, TouchableHighlight if onPress method is defined |
+
+---
+
+### `disabled`
+
+Disables onPress events (optional). Only works when `onPress` has a handler.
+
+|  Type   | Default |
+| :-----: | :-----: |
+| boolean |  false  |
+
+---
+
+### `disabledStyle`
+
+Style for the button when disabled (optional). Only works when `onPress` has a
+handler.
+
+|  Type   |              Default               |
+| :-----: | :--------------------------------: |
+| boolean | `{{ backgroundColor: '#D1D5D8' }}` |
 
 ---
 

--- a/src/header/__tests__/__snapshots__/NavButton.js.snap
+++ b/src/header/__tests__/__snapshots__/NavButton.js.snap
@@ -3,6 +3,7 @@
 exports[`NavButton Component should render without issues 1`] = `
 <Icon
   color="black"
+  disabled={false}
   raised={false}
   reverse={false}
   reverseColor="white"

--- a/src/icons/Icon.js
+++ b/src/icons/Icon.js
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   Platform,
   TouchableHighlight,
@@ -22,6 +22,8 @@ const Icon = props => {
     raised,
     containerStyle,
     reverseColor,
+    disabled,
+    disabledStyle,
     onPress,
     component: Component = onPress ? TouchableHighlight : View,
     ...attributes
@@ -33,7 +35,7 @@ const Icon = props => {
       <Component
         {...attributes}
         underlayColor={reverse ? color : underlayColor || color}
-        style={[
+        style={StyleSheet.flatten([
           (reverse || raised) && styles.button,
           (reverse || raised) && {
             borderRadius: size + 4,
@@ -46,11 +48,17 @@ const Icon = props => {
             alignItems: 'center',
             justifyContent: 'center',
           },
-        ]}
+          disabled && styles.disabled,
+          disabled && disabledStyle,
+        ])}
+        {...onPress && { disabled }}
         onPress={onPress}
       >
         <Icon
-          style={[{ backgroundColor: 'transparent' }, iconStyle && iconStyle]}
+          style={StyleSheet.flatten([
+            { backgroundColor: 'transparent' },
+            iconStyle && iconStyle,
+          ])}
           size={size}
           name={name}
           color={reverse ? reverseColor : color}
@@ -73,6 +81,8 @@ Icon.propTypes = {
   iconStyle: NativeText.propTypes.style,
   onPress: PropTypes.func,
   reverseColor: PropTypes.string,
+  disabled: PropTypes.bool,
+  disabledStyle: ViewPropTypes.style,
 };
 
 Icon.defaultProps = {
@@ -82,6 +92,7 @@ Icon.defaultProps = {
   size: 24,
   color: 'black',
   reverseColor: 'white',
+  disabled: false,
 };
 
 const styles = StyleSheet.create({
@@ -100,6 +111,9 @@ const styles = StyleSheet.create({
         elevation: 2,
       },
     }),
+  },
+  disabled: {
+    backgroundColor: '#D1D5D8',
   },
 });
 

--- a/src/icons/__tests__/Icon.js
+++ b/src/icons/__tests__/Icon.js
@@ -33,4 +33,23 @@ describe('Icon component', () => {
     touchable.simulate('press');
     expect(onPress).toHaveBeenCalledTimes(1);
   });
+
+  it('should apply default disabled styles', () => {
+    const onPress = jest.fn();
+    const component = shallow(<Icon onPress={onPress} name="wifi" disabled />);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should apply custom disabled styles', () => {
+    const onPress = jest.fn();
+    const component = shallow(
+      <Icon
+        onPress={onPress}
+        name="wifi"
+        disabled
+        disabledStyle={{ backgroundColor: 'pink' }}
+      />
+    );
+    expect(toJson(component)).toMatchSnapshot();
+  });
 });

--- a/src/icons/__tests__/__snapshots__/Icon.js.snap
+++ b/src/icons/__tests__/__snapshots__/Icon.js.snap
@@ -1,25 +1,80 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Icon component should apply custom disabled styles 1`] = `
+<Component>
+  <TouchableHighlight
+    activeOpacity={0.85}
+    delayPressOut={100}
+    disabled={true}
+    onPress={[MockFunction]}
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "pink",
+        "justifyContent": "center",
+      }
+    }
+    underlayColor="white"
+  >
+    <Icon
+      allowFontScaling={false}
+      color="black"
+      name="wifi"
+      size={24}
+      style={
+        Object {
+          "backgroundColor": "transparent",
+        }
+      }
+    />
+  </TouchableHighlight>
+</Component>
+`;
+
+exports[`Icon component should apply default disabled styles 1`] = `
+<Component>
+  <TouchableHighlight
+    activeOpacity={0.85}
+    delayPressOut={100}
+    disabled={true}
+    onPress={[MockFunction]}
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#D1D5D8",
+        "justifyContent": "center",
+      }
+    }
+    underlayColor="white"
+  >
+    <Icon
+      allowFontScaling={false}
+      color="black"
+      name="wifi"
+      size={24}
+      style={
+        Object {
+          "backgroundColor": "transparent",
+        }
+      }
+    />
+  </TouchableHighlight>
+</Component>
+`;
+
 exports[`Icon component should render with icon type 1`] = `
 <Component>
   <Component
     style={
-      Array [
-        Object {
-          "margin": 7,
-        },
-        Object {
-          "borderRadius": 28,
-          "height": 52,
-          "width": 52,
-        },
-        false,
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "red",
-          "justifyContent": "center",
-        },
-      ]
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "red",
+        "borderRadius": 28,
+        "height": 52,
+        "justifyContent": "center",
+        "margin": 7,
+        "width": 52,
+      }
     }
     underlayColor="red"
   >
@@ -29,14 +84,9 @@ exports[`Icon component should render with icon type 1`] = `
       name="alert"
       size={24}
       style={
-        Array [
-          Object {
-            "backgroundColor": "transparent",
-          },
-          Object {
-            "backgroundColor": "peru",
-          },
-        ]
+        Object {
+          "backgroundColor": "peru",
+        }
       }
     />
   </Component>
@@ -47,16 +97,11 @@ exports[`Icon component should render without issues 1`] = `
 <Component>
   <Component
     style={
-      Array [
-        false,
-        false,
-        false,
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "transparent",
-          "justifyContent": "center",
-        },
-      ]
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "transparent",
+        "justifyContent": "center",
+      }
     }
     underlayColor="white"
   >
@@ -66,12 +111,9 @@ exports[`Icon component should render without issues 1`] = `
       name="wifi"
       size={24}
       style={
-        Array [
-          Object {
-            "backgroundColor": "transparent",
-          },
-          undefined,
-        ]
+        Object {
+          "backgroundColor": "transparent",
+        }
       }
     />
   </Component>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -961,6 +961,18 @@ export interface IconProps {
    * @default 'white'
    */
   reverseColor?: string;
+
+  /**
+   * Disables the Icon
+   *
+   * Only works if `onPress` passed in
+   */
+  disabled?: boolean;
+
+  /**
+   * Styles for the Icon when disabled
+   */
+  disabledStyle?: StyleProp<ViewStyle>;
 }
 
 /**

--- a/src/list/__tests__/__snapshots__/ListItem.js.snap
+++ b/src/list/__tests__/__snapshots__/ListItem.js.snap
@@ -51,6 +51,7 @@ exports[`ListItem component should render with left icon 1`] = `
   >
     <Icon
       color="red"
+      disabled={false}
       name="wifi"
       raised={false}
       reverse={false}

--- a/src/pricing/__tests__/__snapshots__/PricingCard.js.snap
+++ b/src/pricing/__tests__/__snapshots__/PricingCard.js.snap
@@ -151,6 +151,7 @@ exports[`PricingCard component should render with props 1`] = `
       icon={
         <Icon
           color="white"
+          disabled={false}
           name="flight-takeoff"
           raised={false}
           reverse={false}
@@ -256,6 +257,7 @@ exports[`PricingCard component should render without info 1`] = `
       icon={
         <Icon
           color="white"
+          disabled={false}
           name="flight-takeoff"
           raised={false}
           reverse={false}
@@ -412,6 +414,7 @@ exports[`PricingCard component should render without issues 1`] = `
       icon={
         <Icon
           color="white"
+          disabled={false}
           name="flight-takeoff"
           raised={false}
           reverse={false}

--- a/src/searchbar/__tests__/__snapshots__/SearchBar-android.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar-android.js.snap
@@ -36,6 +36,7 @@ exports[`Android SearchBar component should render with a custom cancel icon 1`]
     leftIcon={
       <Icon
         color="rgba(0, 0, 0, 0.54)"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}
@@ -115,6 +116,7 @@ exports[`Android SearchBar component should render with a custom cancel icon com
     leftIcon={
       <Icon
         color="rgba(0, 0, 0, 0.54)"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}
@@ -194,6 +196,7 @@ exports[`Android SearchBar component should render with a custom clear icon 1`] 
     leftIcon={
       <Icon
         color="rgba(0, 0, 0, 0.54)"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}
@@ -273,6 +276,7 @@ exports[`Android SearchBar component should render with a custom clear icon comp
     leftIcon={
       <Icon
         color="rgba(0, 0, 0, 0.54)"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}
@@ -352,6 +356,7 @@ exports[`Android SearchBar component should render with a custom methods 1`] = `
     leftIcon={
       <Icon
         color="rgba(0, 0, 0, 0.54)"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}
@@ -431,6 +436,7 @@ exports[`Android SearchBar component should render with a custom search icon 1`]
     leftIcon={
       <Icon
         color="rgba(0, 0, 0, 0.54)"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}
@@ -578,6 +584,7 @@ exports[`Android SearchBar component should render with loading 1`] = `
     leftIcon={
       <Icon
         color="rgba(0, 0, 0, 0.54)"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}
@@ -674,6 +681,7 @@ exports[`Android SearchBar component should render without cancel icon 1`] = `
     leftIcon={
       <Icon
         color="rgba(0, 0, 0, 0.54)"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}
@@ -753,6 +761,7 @@ exports[`Android SearchBar component should render without clear icon 1`] = `
     leftIcon={
       <Icon
         color="rgba(0, 0, 0, 0.54)"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}
@@ -832,6 +841,7 @@ exports[`Android SearchBar component should render without issues 1`] = `
     leftIcon={
       <Icon
         color="rgba(0, 0, 0, 0.54)"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}

--- a/src/searchbar/__tests__/__snapshots__/SearchBar-default.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar-default.js.snap
@@ -48,6 +48,7 @@ exports[`Default SearchBar component should render with a custom clear icon 1`] 
     leftIcon={
       <Icon
         color="#86939e"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}
@@ -139,6 +140,7 @@ exports[`Default SearchBar component should render with a custom clear icon comp
     leftIcon={
       <Icon
         color="#86939e"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}
@@ -230,6 +232,7 @@ exports[`Default SearchBar component should render with a custom methods 1`] = `
     leftIcon={
       <Icon
         color="#86939e"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}
@@ -327,6 +330,7 @@ exports[`Default SearchBar component should render with a custom search icon 1`]
     leftIcon={
       <Icon
         color="#86939e"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}
@@ -508,6 +512,7 @@ exports[`Default SearchBar component should render with icons 1`] = `
     leftIcon={
       <Icon
         color="#86939e"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}
@@ -616,6 +621,7 @@ exports[`Default SearchBar component should render without clear icon 1`] = `
     leftIcon={
       <Icon
         color="#86939e"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}
@@ -707,6 +713,7 @@ exports[`Default SearchBar component should render without issues 1`] = `
     leftIcon={
       <Icon
         color="#86939e"
+        disabled={false}
         name="magnify"
         raised={false}
         reverse={false}

--- a/src/searchbar/__tests__/__snapshots__/SearchBar-ios.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar-ios.js.snap
@@ -47,6 +47,7 @@ exports[`iOS SearchBar component should render with a custom Cancel button title
     leftIcon={
       <Icon
         color="#7d7d7d"
+        disabled={false}
         name="ios-search"
         raised={false}
         reverse={false}
@@ -151,6 +152,7 @@ exports[`iOS SearchBar component should render with a custom clear icon 1`] = `
     leftIcon={
       <Icon
         color="#7d7d7d"
+        disabled={false}
         name="ios-search"
         raised={false}
         reverse={false}
@@ -255,6 +257,7 @@ exports[`iOS SearchBar component should render with a custom clear icon componen
     leftIcon={
       <Icon
         color="#7d7d7d"
+        disabled={false}
         name="ios-search"
         raised={false}
         reverse={false}
@@ -359,6 +362,7 @@ exports[`iOS SearchBar component should render with a custom methods 1`] = `
     leftIcon={
       <Icon
         color="#7d7d7d"
+        disabled={false}
         name="ios-search"
         raised={false}
         reverse={false}
@@ -463,6 +467,7 @@ exports[`iOS SearchBar component should render with a custom search icon 1`] = `
     leftIcon={
       <Icon
         color="#7d7d7d"
+        disabled={false}
         name="ios-search"
         raised={false}
         reverse={false}
@@ -662,6 +667,7 @@ exports[`iOS SearchBar component should render with loading 1`] = `
     leftIcon={
       <Icon
         color="#7d7d7d"
+        disabled={false}
         name="ios-search"
         raised={false}
         reverse={false}
@@ -783,6 +789,7 @@ exports[`iOS SearchBar component should render without clear icon 1`] = `
     leftIcon={
       <Icon
         color="#7d7d7d"
+        disabled={false}
         name="ios-search"
         raised={false}
         reverse={false}
@@ -887,6 +894,7 @@ exports[`iOS SearchBar component should render without issues 1`] = `
     leftIcon={
       <Icon
         color="#7d7d7d"
+        disabled={false}
         name="ios-search"
         raised={false}
         reverse={false}

--- a/src/tile/__tests__/__snapshots__/FeaturedTile.js.snap
+++ b/src/tile/__tests__/__snapshots__/FeaturedTile.js.snap
@@ -78,6 +78,7 @@ exports[`FeaturedTitle component should render with Icon 1`] = `
       >
         <Icon
           color="black"
+          disabled={false}
           name="play-circle"
           raised={false}
           reverse={false}

--- a/src/tile/__tests__/__snapshots__/Tile.js.snap
+++ b/src/tile/__tests__/__snapshots__/Tile.js.snap
@@ -84,6 +84,7 @@ exports[`Tile component should render tile with icon 1`] = `
     >
       <Icon
         color="black"
+        disabled={false}
         name="play-circle"
         raised={false}
         reverse={false}


### PR DESCRIPTION
Adds `disabled` and `disabledStyle` props to the Icon component. 

Ideally, we should do this for all our interactable components. It's a common use case for like forms, where when submitting the fields are disabled.

Usage:

```jsx
<Icon disabled />
<Icon disabled disabledStyle={{ backgroundColor: 'pink' }} />
```