### PR TITLE
[docs] add left/right icon containers to readme

### DIFF
--- a/docs/searchbar.md
+++ b/docs/searchbar.md
@@ -172,6 +172,26 @@ style the TextInput
 
 ---
 
+### `leftIconContainerStyle`
+
+style the icon container on the left side
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |
+
+---
+
+### `rightIconContainerStyle`
+
+style the icon container on the right side
+
+|      Type      |      Default      |
+| :------------: | :---------------: |
+| object (style) | inherited styling |
+
+---
+
 ### `lightTheme` (**`platform="default"` only**)
 
 change theme to light theme


### PR DESCRIPTION
* Adds documentation for `leftIconContainerStyle` and `rightIconContainerStyle` which were added back in January of 2018 (Ref: #837).

Fairly trivial.  Attempted `npm test` but there are unrelated failures per your contributing guidelines.
