### PR TITLE
On start rating event

### DIFF
--- a/docs/rating.md
+++ b/docs/rating.md
@@ -21,6 +21,7 @@ ratingCompleted(rating) {
 <Rating
   showRating
   onFinishRating={this.ratingCompleted}
+  onStartRating={this.ratingStarted}
   style={{ paddingVertical: 10 }}
 />
 
@@ -32,6 +33,7 @@ ratingCompleted(rating) {
   readonly
   imageSize={40}
   onFinishRating={this.ratingCompleted}
+  onStartRating={this.ratingStarted}
   style={{ paddingVertical: 10 }}
 />
 
@@ -42,6 +44,7 @@ ratingCompleted(rating) {
   startingValue={1.57}
   imageSize={40}
   onFinishRating={this.ratingCompleted}
+  onStartRating={this.ratingStarted}
   showRating
   style={{ paddingVertical: 10 }}
 />
@@ -57,6 +60,7 @@ const WATER_IMAGE = require('./water.png')
   ratingCount={10}
   imageSize={30}
   onFinishRating={this.ratingCompleted}
+  onStartRating={this.ratingStarted}
   style={{ paddingVertical: 10 }}
 />
 ```
@@ -89,6 +93,7 @@ const { rating } = this.props;
 ### Props
 
 * [`onFinishRating`](#onfinishrating)
+* [`onStartRating`](#onstartrating)
 * [`fractions`](#fractions)
 * [`imageSize`](#imagesize)
 * [`ratingBackgroundColor`](#ratingbackgroundcolor)
@@ -114,6 +119,16 @@ Callback method when the user finishes rating. Gives you the final rating value 
 |   Type   | Default |
 | :------: | :-----: |
 | function |  none   |
+
+---
+
+### `onStartRating`
+
+Callback method when the user starts the rating. (optional)
+
+|   Type   | Default |
+| :------: | :-----: |
+| function |  undefined   |
 
 ---
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1151,6 +1151,11 @@ export interface RatingProps {
   onFinishRating?(rating: number): void;
 
   /**
+   * Callback method when the user starts rating.
+   */
+  onStartRating?(): void;
+
+  /**
    * Choose one of the built-in types: star, rocket, bell, heart or use type custom to render a custom image
    */
   type?: 'star' | 'rocket' | 'bell' | 'heart' | 'custom';

--- a/src/rating/Rating.js
+++ b/src/rating/Rating.js
@@ -55,8 +55,7 @@ export default class Rating extends Component {
     ratingCount: 5,
     showReadOnlyText: true,
     imageSize: STAR_WIDTH,
-    onFinishRating: () => console.log('Attach a function here.'),
-    onStartRating: () => console.log('Attach a function here.'),
+    onFinishRating: () => console.log('Attach a onFinishRating function here.'),
   };
 
   constructor(props) {
@@ -74,7 +73,9 @@ export default class Rating extends Component {
         this.setState({ position: newPosition, value: gesture.dx });
       },
       onPanResponderGrant: () => {
-        onStartRating();
+        if (typeof onStartRating === 'function') {
+          onStartRating();
+        }
       },
       onPanResponderRelease: () => {
         const rating = this.getCurrentRating();

--- a/src/rating/Rating.js
+++ b/src/rating/Rating.js
@@ -56,12 +56,13 @@ export default class Rating extends Component {
     showReadOnlyText: true,
     imageSize: STAR_WIDTH,
     onFinishRating: () => console.log('Attach a function here.'),
+    onStartRating: () => console.log('Attach a function here.'),
   };
 
   constructor(props) {
     super(props);
 
-    const { onFinishRating, fractions } = this.props;
+    const { onFinishRating, fractions, onStartRating } = this.props;
 
     const position = new Animated.ValueXY();
 
@@ -71,6 +72,9 @@ export default class Rating extends Component {
         const newPosition = new Animated.ValueXY();
         newPosition.setValue({ x: gesture.dx, y: 0 });
         this.setState({ position: newPosition, value: gesture.dx });
+      },
+      onPanResponderGrant: () => {
+        onStartRating();
       },
       onPanResponderRelease: () => {
         const rating = this.getCurrentRating();
@@ -350,6 +354,7 @@ Rating.propTypes = {
   ratingCount: PropTypes.number,
   imageSize: PropTypes.number,
   onFinishRating: PropTypes.func,
+  onStartRating: PropTypes.func,
   showRating: PropTypes.bool,
   style: ViewPropTypes.style,
   ratingTextColor: PropTypes.string,


### PR DESCRIPTION
 When using a rating component inside a ScrollView on iOS, the scrollview don't lock the scroll causing the rating component to get very laggy.

![demo gif](https://media.giphy.com/media/2jMDCyI9S18sL7xsMD/giphy.gif)

The onStartRating callback is useful on iOS because I can lock the scroll via the scrollEnabled prop on the start rating callback.