### PR TITLE
fix(ListItem): Don't display empty rightTitle or rightSubtitle

### DIFF
--- a/src/list/ListItem.js
+++ b/src/list/ListItem.js
@@ -114,7 +114,7 @@ const ListItem = props => {
             ])}
           </View>
         )}
-        {(rightTitle || rightSubtitle) && (
+        {(!!rightTitle || !!rightSubtitle) && (
           <View
             style={[styles.rightContentContainer, rightContentContainerStyle]}
           >


### PR DESCRIPTION
Android crashes when using `rightTitle || rightSubtitle` to test if the values are present. Instead, we should make sure the value of those props are cast to Booleans before we check.

Closes #1391