### PR TITLE
docs(Card): Remove Lato fontFamily from examples

### DIFF
--- a/website/versioned_docs/version-0.19.0/card.md
+++ b/website/versioned_docs/version-0.19.0/card.md
@@ -63,7 +63,6 @@ import { Card, ListItem, Button } from 'react-native-elements'
   <Button
     icon={{name: 'code'}}
     backgroundColor='#03A9F4'
-    fontFamily='Lato'
     buttonStyle={{borderRadius: 0, marginLeft: 0, marginRight: 0, marginBottom: 0}}
     title='VIEW NOW' />
 </Card>

--- a/website/versioned_docs/version-1.0.0-beta3/card.md
+++ b/website/versioned_docs/version-1.0.0-beta3/card.md
@@ -63,7 +63,6 @@ import { Card, ListItem, Button, Icon } from 'react-native-elements'
   <Button
     icon={<Icon name='code' color='#ffffff' />}
     backgroundColor='#03A9F4'
-    fontFamily='Lato'
     buttonStyle={{borderRadius: 0, marginLeft: 0, marginRight: 0, marginBottom: 0}}
     title='VIEW NOW' />
 </Card>


### PR DESCRIPTION
People were getting errors copying and pasting these snippets since they
don't have Lato installed