### PR TITLE
(Icon): Added prepending of platform to icon names for Ionicon icons

### DIFF
--- a/src/icons/Icon.js
+++ b/src/icons/Icon.js
@@ -28,6 +28,12 @@ const Icon = props => {
   } = props;
 
   let Icon = getIconType(type || 'material');
+  if(type === 'ionicon') {
+    if(!name.startsWith('md-') && !name.startsWith('ios-')) {
+      name = Platform.OS === 'ios' ? 'ios' : 'md' + '-' + name;
+    }
+  }
+  
   return (
     <View style={containerStyle && containerStyle}>
       <Component


### PR DESCRIPTION
Ionicons have platform "dependant" icon names, so every icon exists in both IOS and Material Design styles,
this change makes it so if you dont specify an OS for your icon it automatically prepends the OS to the name prop using `Platform.OS`.
If you do specify an OS in the name prop like `ios-star` it makes no modifications.

**Example:**
```
<Icon
  name={`${Platform.OS === 'ios' ? 'ios' : 'md'}-star`}
  type='ionicon'
/>
```
to
```
<Icon
  name='star'
  type='ionicon'
/>
```