### PR TITLE
[ListItem] Add android as default for list styling

### DIFF
--- a/src/list/ListItem.js
+++ b/src/list/ListItem.js
@@ -194,7 +194,7 @@ const styles = StyleSheet.create({
       ios: {
         padding: 14,
       },
-      android: {
+      default: {
         padding: 16,
       },
     }),
@@ -208,7 +208,7 @@ const styles = StyleSheet.create({
       ios: {
         fontSize: 17,
       },
-      android: {
+      default: {
         fontSize: 16,
       },
     }),
@@ -219,7 +219,7 @@ const styles = StyleSheet.create({
       ios: {
         fontSize: 15,
       },
-      android: {
+      default: {
         color: ANDROID_SECONDARY,
         fontSize: 14,
       },


### PR DESCRIPTION
Currently there is no styling for `ListItem` in `react-native-web` (and other platforms) because they are only applied to `android` and `ios`.

I changed `android` to `default` so android style is applied.

`react-native-web` example:

Before:
![before](https://user-images.githubusercontent.com/12607663/45221782-cee77c00-b2b2-11e8-93db-ba8f1833908b.png)
After:
![after](https://user-images.githubusercontent.com/12607663/45221791-d60e8a00-b2b2-11e8-8526-9e2ad9b1a4a8.png)

