### PR TITLE
feat(Input): add inputComponent prop (closes #1408)

### DIFF
--- a/docs/input.md
+++ b/docs/input.md
@@ -47,20 +47,21 @@ import { Input } from 'react-native-elements';
 
 > This component inherits [all native TextInput props that come with a standard React Native TextInput element](https://facebook.github.io/react-native/docs/textinput.html), along with the following:
 
-* [`containerStyle`](#containerstyle)
-* [`inputContainerStyle`](#inputcontainerstyle)
-* [`errorMessage`](#errormessage)
-* [`errorStyle`](#errorstyle)
-* [`errorProps`](#errorprops)
-* [`inputStyle`](#inputstyle)
-* [`label`](#label)
-* [`labelStyle`](#labelStyle)
-* [`labelProps`](#labelprops)
-* [`leftIcon`](#lefticon)
-* [`leftIconContainerStyle`](#lefticoncontainerstyle)
-* [`rightIcon`](#righticon)
-* [`rightIconContainerStyle`](#righticoncontainerstyle)
-* [`shake`](#shake)
+- [`containerStyle`](#containerstyle)
+- [`inputContainerStyle`](#inputcontainerstyle)
+- [`errorMessage`](#errormessage)
+- [`errorStyle`](#errorstyle)
+- [`errorProps`](#errorprops)
+- [`inputComponent`](#inputComponent)
+- [`inputStyle`](#inputstyle)
+- [`label`](#label)
+- [`labelStyle`](#labelStyle)
+- [`labelProps`](#labelprops)
+- [`leftIcon`](#lefticon)
+- [`leftIconContainerStyle`](#lefticoncontainerstyle)
+- [`rightIcon`](#righticon)
+- [`rightIconContainerStyle`](#righticoncontainerstyle)
+- [`shake`](#shake)
 
 ---
 
@@ -113,6 +114,16 @@ props to be passed to the React Native `Text` component used to display the erro
 |                                      Type                                       | Default |
 | :-----------------------------------------------------------------------------: | :-----: |
 | {[...Text props](https://facebook.github.io/react-native/docs/text.html#props)} |  none   |
+
+---
+
+### `inputComponent`
+
+component that will be rendered in place of the React Native `TextInput` (optional)
+
+|          Type          |  Default  |
+| :--------------------: | :-------: |
+| React Native Component | TextInput |
 
 ---
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -740,6 +740,11 @@ export interface InputProps extends TextInputProperties {
   rightIconContainerStyle?: StyleProp<ViewStyle>;
 
   /**
+   * Renders component in place of the React Native `TextInput` (optional)
+   */
+  inputComponent?: React.ComponentClass<any>;
+
+  /**
    * 	Adds styling to input component (optional)
    */
   inputStyle?: StyleProp<TextStyle>;

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -6,7 +6,6 @@ import {
   Text,
   View,
   TextInput,
-  Dimensions,
   Animated,
   Easing,
   Platform,
@@ -65,6 +64,7 @@ class Input extends Component {
       leftIconContainerStyle,
       rightIcon,
       rightIconContainerStyle,
+      inputComponent: InputComponent = TextInput,
       inputStyle,
       errorStyle,
       errorProps,
@@ -81,7 +81,11 @@ class Input extends Component {
 
     return (
       <View style={[{ width: '90%' }, containerStyle]}>
-        {!!label && <Text {...labelProps} style={[styles.label, labelStyle]}>{label}</Text>}
+        {!!label && (
+          <Text {...labelProps} style={[styles.label, labelStyle]}>
+            {label}
+          </Text>
+        )}
         <Animated.View
           style={[
             styles.inputContainer,
@@ -100,7 +104,7 @@ class Input extends Component {
               {renderNode(Icon, leftIcon)}
             </View>
           )}
-          <TextInput
+          <InputComponent
             underlineColorAndroid="transparent"
             {...attributes}
             ref={this._inputRef}
@@ -113,7 +117,10 @@ class Input extends Component {
           )}
         </Animated.View>
         {!!errorMessage && (
-          <Text {...errorProps} style={[styles.error, errorStyle && errorStyle]}>
+          <Text
+            {...errorProps}
+            style={[styles.error, errorStyle && errorStyle]}
+          >
             {errorMessage}
           </Text>
         )}
@@ -133,6 +140,7 @@ Input.propTypes = {
   rightIconContainerStyle: ViewPropTypes.style,
 
   inputStyle: Text.propTypes.style,
+  inputComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 
   shake: PropTypes.any,
 

--- a/src/input/__tests__/Input.js
+++ b/src/input/__tests__/Input.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { View } from 'react-native';
+import toJson from 'enzyme-to-json';
+import Input from '../Input';
+
+describe('Input component', () => {
+  it('should match snapshot', () => {
+    const component = shallow(<Input />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+  describe('containerStyle prop', () => {
+    it('should match snapshot', () => {
+      const component = shallow(<Input containerStyle={{ width: 200 }} />);
+      expect(component.length).toBe(1);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+  describe('inputContainerStyle prop', () => {
+    it('should match snapshot', () => {
+      const component = shallow(<Input inputContainerStyle={{ width: 200 }} />);
+      expect(component.length).toBe(1);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+  describe('inputStyle prop', () => {
+    it('should match snapshot', () => {
+      const component = shallow(<Input inputStyle={{ width: 200 }} />);
+      expect(component.length).toBe(1);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+  describe('leftIcon prop', () => {
+    it('should match snapshot', () => {
+      const component = shallow(
+        <Input leftIcon={{ type: 'feather', name: 'user' }} />
+      );
+      expect(component.length).toBe(1);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+    it('along with leftIconContainerStyle should match snapshot', () => {
+      const component = shallow(
+        <Input
+          leftIcon={{ type: 'feather', name: 'user' }}
+          leftIconContainerStyle={{ width: 200 }}
+        />
+      );
+      expect(component.length).toBe(1);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+  describe('rightIcon prop', () => {
+    it('should match snapshot', () => {
+      const component = shallow(
+        <Input rightIcon={{ type: 'feather', name: 'user' }} />
+      );
+      expect(component.length).toBe(1);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+    it('along with rightIconContainerStyle should match snapshot', () => {
+      const component = shallow(
+        <Input
+          rightIcon={{ type: 'feather', name: 'user' }}
+          rightIconContainerStyle={{ width: 200 }}
+        />
+      );
+      expect(component.length).toBe(1);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+  describe('label prop', () => {
+    it('should match snapshot', () => {
+      const component = shallow(<Input label="My Label" />);
+      expect(component.length).toBe(1);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+    it('along with labelStyle should match snapshot', () => {
+      const component = shallow(
+        <Input label="My Label" labelStyle={{ width: 200 }} />
+      );
+      expect(component.length).toBe(1);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+  describe('errorMessage prop', () => {
+    it('should match snapshot', () => {
+      const component = shallow(<Input errorMessage="My Error Message" />);
+      expect(component.length).toBe(1);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+    it('along with errorStyle should match snapshot', () => {
+      const component = shallow(
+        <Input errorMessage="My Error Message" errorStyle={{ width: 200 }} />
+      );
+      expect(component.length).toBe(1);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+  describe('placeholder prop', () => {
+    it('should match snapshot', () => {
+      const component = shallow(<Input placeholder="My Placeholder" />);
+      expect(component.length).toBe(1);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+  describe('inputComponent prop', () => {
+    const CustomComponent = props => <View {...props}>Custom!</View>;
+    it('should match snapshot', () => {
+      const component = shallow(<Input inputComponent={CustomComponent} />);
+      expect(component.length).toBe(1);
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+  // TextInput props
+  describe('onTouch prop', () => {
+    it('should properly call callback', () => {
+      const onTouchSpy = jest.fn();
+      const component = shallow(<Input onTouch={onTouchSpy} />);
+      component.find('TextInput').simulate('touch');
+      expect(onTouchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe('onFocus prop', () => {
+    it('should properly call callback', () => {
+      const onFocusSpy = jest.fn();
+      const component = shallow(<Input onFocus={onFocusSpy} />);
+      component.find('TextInput').simulate('focus');
+      expect(onFocusSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/input/__tests__/__snapshots__/Input.js.snap
+++ b/src/input/__tests__/__snapshots__/Input.js.snap
@@ -1,0 +1,913 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Input component containerStyle prop should match snapshot 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "width": "90%",
+      },
+      Object {
+        "width": 200,
+      },
+    ]
+  }
+>
+  <AnimatedComponent
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderBottomWidth": 1,
+          "borderColor": "#86939e",
+          "flexDirection": "row",
+        },
+        undefined,
+        Object {
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <TextInput
+      allowFontScaling={true}
+      style={
+        Array [
+          Object {
+            "alignSelf": "center",
+            "color": "black",
+            "flex": 1,
+            "fontSize": 18,
+            "height": 40,
+            "marginLeft": 10,
+          },
+          undefined,
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+  </AnimatedComponent>
+</Component>
+`;
+
+exports[`Input component errorMessage prop along with errorStyle should match snapshot 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "width": "90%",
+      },
+      undefined,
+    ]
+  }
+>
+  <AnimatedComponent
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderBottomWidth": 1,
+          "borderColor": "#86939e",
+          "flexDirection": "row",
+        },
+        undefined,
+        Object {
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <TextInput
+      allowFontScaling={true}
+      style={
+        Array [
+          Object {
+            "alignSelf": "center",
+            "color": "black",
+            "flex": 1,
+            "fontSize": 18,
+            "height": 40,
+            "marginLeft": 10,
+          },
+          undefined,
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+  </AnimatedComponent>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "#FF2D00",
+          "fontSize": 12,
+          "margin": 5,
+        },
+        Object {
+          "width": 200,
+        },
+      ]
+    }
+  >
+    My Error Message
+  </Text>
+</Component>
+`;
+
+exports[`Input component errorMessage prop should match snapshot 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "width": "90%",
+      },
+      undefined,
+    ]
+  }
+>
+  <AnimatedComponent
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderBottomWidth": 1,
+          "borderColor": "#86939e",
+          "flexDirection": "row",
+        },
+        undefined,
+        Object {
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <TextInput
+      allowFontScaling={true}
+      style={
+        Array [
+          Object {
+            "alignSelf": "center",
+            "color": "black",
+            "flex": 1,
+            "fontSize": 18,
+            "height": 40,
+            "marginLeft": 10,
+          },
+          undefined,
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+  </AnimatedComponent>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "#FF2D00",
+          "fontSize": 12,
+          "margin": 5,
+        },
+        undefined,
+      ]
+    }
+  >
+    My Error Message
+  </Text>
+</Component>
+`;
+
+exports[`Input component inputComponent prop should match snapshot 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "width": "90%",
+      },
+      undefined,
+    ]
+  }
+>
+  <AnimatedComponent
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderBottomWidth": 1,
+          "borderColor": "#86939e",
+          "flexDirection": "row",
+        },
+        undefined,
+        Object {
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <CustomComponent
+      style={
+        Array [
+          Object {
+            "alignSelf": "center",
+            "color": "black",
+            "flex": 1,
+            "fontSize": 18,
+            "height": 40,
+            "marginLeft": 10,
+          },
+          undefined,
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+  </AnimatedComponent>
+</Component>
+`;
+
+exports[`Input component inputContainerStyle prop should match snapshot 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "width": "90%",
+      },
+      undefined,
+    ]
+  }
+>
+  <AnimatedComponent
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderBottomWidth": 1,
+          "borderColor": "#86939e",
+          "flexDirection": "row",
+        },
+        Object {
+          "width": 200,
+        },
+        Object {
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <TextInput
+      allowFontScaling={true}
+      style={
+        Array [
+          Object {
+            "alignSelf": "center",
+            "color": "black",
+            "flex": 1,
+            "fontSize": 18,
+            "height": 40,
+            "marginLeft": 10,
+          },
+          undefined,
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+  </AnimatedComponent>
+</Component>
+`;
+
+exports[`Input component inputStyle prop should match snapshot 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "width": "90%",
+      },
+      undefined,
+    ]
+  }
+>
+  <AnimatedComponent
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderBottomWidth": 1,
+          "borderColor": "#86939e",
+          "flexDirection": "row",
+        },
+        undefined,
+        Object {
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <TextInput
+      allowFontScaling={true}
+      style={
+        Array [
+          Object {
+            "alignSelf": "center",
+            "color": "black",
+            "flex": 1,
+            "fontSize": 18,
+            "height": 40,
+            "marginLeft": 10,
+          },
+          Object {
+            "width": 200,
+          },
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+  </AnimatedComponent>
+</Component>
+`;
+
+exports[`Input component label prop along with labelStyle should match snapshot 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "width": "90%",
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "#86939e",
+          "fontSize": 16,
+          "fontWeight": "bold",
+        },
+        Object {
+          "width": 200,
+        },
+      ]
+    }
+  >
+    My Label
+  </Text>
+  <AnimatedComponent
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderBottomWidth": 1,
+          "borderColor": "#86939e",
+          "flexDirection": "row",
+        },
+        undefined,
+        Object {
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <TextInput
+      allowFontScaling={true}
+      style={
+        Array [
+          Object {
+            "alignSelf": "center",
+            "color": "black",
+            "flex": 1,
+            "fontSize": 18,
+            "height": 40,
+            "marginLeft": 10,
+          },
+          undefined,
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+  </AnimatedComponent>
+</Component>
+`;
+
+exports[`Input component label prop should match snapshot 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "width": "90%",
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "#86939e",
+          "fontSize": 16,
+          "fontWeight": "bold",
+        },
+        undefined,
+      ]
+    }
+  >
+    My Label
+  </Text>
+  <AnimatedComponent
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderBottomWidth": 1,
+          "borderColor": "#86939e",
+          "flexDirection": "row",
+        },
+        undefined,
+        Object {
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <TextInput
+      allowFontScaling={true}
+      style={
+        Array [
+          Object {
+            "alignSelf": "center",
+            "color": "black",
+            "flex": 1,
+            "fontSize": 18,
+            "height": 40,
+            "marginLeft": 10,
+          },
+          undefined,
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+  </AnimatedComponent>
+</Component>
+`;
+
+exports[`Input component leftIcon prop along with leftIconContainerStyle should match snapshot 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "width": "90%",
+      },
+      undefined,
+    ]
+  }
+>
+  <AnimatedComponent
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderBottomWidth": 1,
+          "borderColor": "#86939e",
+          "flexDirection": "row",
+        },
+        undefined,
+        Object {
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <Component
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "height": 40,
+            "justifyContent": "center",
+          },
+          Object {
+            "marginLeft": 15,
+          },
+          Object {
+            "width": 200,
+          },
+        ]
+      }
+    >
+      <Icon
+        color="black"
+        disabled={false}
+        name="user"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={24}
+        type="feather"
+        underlayColor="white"
+      />
+    </Component>
+    <TextInput
+      allowFontScaling={true}
+      style={
+        Array [
+          Object {
+            "alignSelf": "center",
+            "color": "black",
+            "flex": 1,
+            "fontSize": 18,
+            "height": 40,
+            "marginLeft": 10,
+          },
+          undefined,
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+  </AnimatedComponent>
+</Component>
+`;
+
+exports[`Input component leftIcon prop should match snapshot 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "width": "90%",
+      },
+      undefined,
+    ]
+  }
+>
+  <AnimatedComponent
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderBottomWidth": 1,
+          "borderColor": "#86939e",
+          "flexDirection": "row",
+        },
+        undefined,
+        Object {
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <Component
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "height": 40,
+            "justifyContent": "center",
+          },
+          Object {
+            "marginLeft": 15,
+          },
+          undefined,
+        ]
+      }
+    >
+      <Icon
+        color="black"
+        disabled={false}
+        name="user"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={24}
+        type="feather"
+        underlayColor="white"
+      />
+    </Component>
+    <TextInput
+      allowFontScaling={true}
+      style={
+        Array [
+          Object {
+            "alignSelf": "center",
+            "color": "black",
+            "flex": 1,
+            "fontSize": 18,
+            "height": 40,
+            "marginLeft": 10,
+          },
+          undefined,
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+  </AnimatedComponent>
+</Component>
+`;
+
+exports[`Input component placeholder prop should match snapshot 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "width": "90%",
+      },
+      undefined,
+    ]
+  }
+>
+  <AnimatedComponent
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderBottomWidth": 1,
+          "borderColor": "#86939e",
+          "flexDirection": "row",
+        },
+        undefined,
+        Object {
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <TextInput
+      allowFontScaling={true}
+      placeholder="My Placeholder"
+      style={
+        Array [
+          Object {
+            "alignSelf": "center",
+            "color": "black",
+            "flex": 1,
+            "fontSize": 18,
+            "height": 40,
+            "marginLeft": 10,
+          },
+          undefined,
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+  </AnimatedComponent>
+</Component>
+`;
+
+exports[`Input component rightIcon prop along with rightIconContainerStyle should match snapshot 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "width": "90%",
+      },
+      undefined,
+    ]
+  }
+>
+  <AnimatedComponent
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderBottomWidth": 1,
+          "borderColor": "#86939e",
+          "flexDirection": "row",
+        },
+        undefined,
+        Object {
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <TextInput
+      allowFontScaling={true}
+      style={
+        Array [
+          Object {
+            "alignSelf": "center",
+            "color": "black",
+            "flex": 1,
+            "fontSize": 18,
+            "height": 40,
+            "marginLeft": 10,
+          },
+          undefined,
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+    <Component
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "height": 40,
+            "justifyContent": "center",
+          },
+          Object {
+            "width": 200,
+          },
+        ]
+      }
+    >
+      <Icon
+        color="black"
+        disabled={false}
+        name="user"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={24}
+        type="feather"
+        underlayColor="white"
+      />
+    </Component>
+  </AnimatedComponent>
+</Component>
+`;
+
+exports[`Input component rightIcon prop should match snapshot 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "width": "90%",
+      },
+      undefined,
+    ]
+  }
+>
+  <AnimatedComponent
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderBottomWidth": 1,
+          "borderColor": "#86939e",
+          "flexDirection": "row",
+        },
+        undefined,
+        Object {
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <TextInput
+      allowFontScaling={true}
+      style={
+        Array [
+          Object {
+            "alignSelf": "center",
+            "color": "black",
+            "flex": 1,
+            "fontSize": 18,
+            "height": 40,
+            "marginLeft": 10,
+          },
+          undefined,
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+    <Component
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "height": 40,
+            "justifyContent": "center",
+          },
+          undefined,
+        ]
+      }
+    >
+      <Icon
+        color="black"
+        disabled={false}
+        name="user"
+        raised={false}
+        reverse={false}
+        reverseColor="white"
+        size={24}
+        type="feather"
+        underlayColor="white"
+      />
+    </Component>
+  </AnimatedComponent>
+</Component>
+`;
+
+exports[`Input component should match snapshot 1`] = `
+<Component
+  style={
+    Array [
+      Object {
+        "width": "90%",
+      },
+      undefined,
+    ]
+  }
+>
+  <AnimatedComponent
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderBottomWidth": 1,
+          "borderColor": "#86939e",
+          "flexDirection": "row",
+        },
+        undefined,
+        Object {
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <TextInput
+      allowFontScaling={true}
+      style={
+        Array [
+          Object {
+            "alignSelf": "center",
+            "color": "black",
+            "flex": 1,
+            "fontSize": 18,
+            "height": 40,
+            "marginLeft": 10,
+          },
+          undefined,
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+  </AnimatedComponent>
+</Component>
+`;


### PR DESCRIPTION
- Adds initial unit test for the `Input` component,

- Closes #1408 (support for `inputComponent` prop to pass a custom `TextInput` compatible component)

Thanks!
