### PR TITLE
fix(webpack): exlude 'react-native-touchable-scale' from babel-loader…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,29 @@
 language: node_js
 node_js:
-- 9.11.1
+  - 9.11.1
 cache:
   yarn: true
   directories:
-  - node_modules
-  - website/node_modules
+    - node_modules
+    - website/node_modules
 branches:
   only:
-  - master
-  - next
-  - v0.11.0
+    - master
+    - next
+    - v0.11.0
 install:
-- git fetch --unshallow --all
-- yarn global add codecov
-- yarn
+  - git fetch --unshallow --all
+  - yarn global add codecov
+  - yarn
 script:
-- yarn run test && codecov
+  - yarn run build
+  - yarn run test && codecov
 after_script:
-- ./.ci/expo-ci.sh
+  - ./.ci/expo-ci.sh
 after_success:
-- |
-  if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then
-    git config --global user.name "React Native Elements CI"
-    echo -e "machine github.com\n login react-native-elements-ci\n password $GITHUB_TOKEN" >> ~/.netrc
-    cd website && yarn && GIT_USER=react-native-elements-ci yarn run publish-gh-pages
-  fi
+  - |
+    if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then
+      git config --global user.name "React Native Elements CI"
+      echo -e "machine github.com\n login react-native-elements-ci\n password $GITHUB_TOKEN" >> ~/.netrc
+      cd website && yarn && GIT_USER=react-native-elements-ci yarn run publish-gh-pages
+    fi

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,10 @@ module.exports = {
       {
         test: /\.js$/,
         use: ['babel-loader'],
-        exclude: /node_modules/,
+        exclude:{
+          test : path.resolve(__dirname, 'node_modules'),
+          exclude: path.resolve(__dirname, 'node_modules/react-native-touchable-scale')
+        }
       },
       {
         test: /\.(jpe?g|png|gif)$/i,


### PR DESCRIPTION
… exclusion pattern to allow building to work

With the current setup, I was stuck on the following build issue:

```
ERROR in ./~/react-native-touchable-scale/src/TouchableScale.js
Module parse failed: [...]/react-native-touchable-scale/src/TouchableScale.js Unexpected token (54:6)
You may need an appropriate loader to handle this file type.
| 
|     return (
|       <TouchableWithoutFeedback
|         // todo: pass only TouchableWithoutFeedback's props.
|         {...props}
 @ ./~/react-native-touchable-scale/index.js 1:0-50
 @ ./src/list/ListItem.js
 @ ./src/index.js
```

--- 

EDIT: prettier did auto-fix the `.travis.yml` file, can revert if spacing was intentional.