### PR TITLE
feat(icons): Add support for FontAwesome5

### DIFF
--- a/.ci/setupTests.js
+++ b/.ci/setupTests.js
@@ -1,4 +1,8 @@
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
+jest.mock('react-native-vector-icons/FontAwesome5', () => {
+  return console.log;
+});
+
 configure({ adapter: new Adapter() });

--- a/docs/avatar.md
+++ b/docs/avatar.md
@@ -203,9 +203,9 @@ Styling for outer container
 
 ### `icon`
 
-|  Type                                                                                                                  | Default |
-| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
-| object {name: string, color: string, size: number, type: string (default is material-community, or choose one of simple-line-icon, zocial, font-awesome, octicon, ionicon, foundation, evilicon, or entypo), iconStyle: object(style)} |  none   |
+|                                                                                                                         Type                                                                                                                          | Default |
+| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
+| object {name: string, color: string, size: number, type: string (default is material-community, or choose one of simple-line-icon, zocial, font-awesome,font-awesome-5, octicon, ionicon, foundation, evilicon, or entypo), iconStyle: object(style)} |  none   |
 
 ---
 
@@ -283,9 +283,9 @@ Image source
 
 Size of the avatar
 
-|      Type      | Default |
-| :------------: | :-----: |
-| string(`small`, `medium`, `large`, `xlarge`) or number |  `small` |
+|                          Type                          | Default |
+| :----------------------------------------------------: | :-----: |
+| string(`small`, `medium`, `large`, `xlarge`) or number | `small` |
 
 ---
 
@@ -335,4 +335,4 @@ Custom ImageComponent for Avatar
 
 |            Type            | Default |
 | :------------------------: | :-----: |
-| React component or element |  Image   |
+| React component or element |  Image  |

--- a/docs/checkbox.md
+++ b/docs/checkbox.md
@@ -75,7 +75,10 @@ import { CheckBox } from 'react-native-elements'
 
 ### `iconType`
 
-Icon family, can be one of the following: simple-line-icon, zocial, octicon, material, material-community, ionicon, foundation, evilicon, entypo (required only if specifying an icon that is not from font-awesome)
+Icon family, can be one of the following: simple-line-icon, zocial, octicon,
+material, material-community, ionicon, foundation, evilicon, entypo
+font-awesome, font-awesome-5 (required only if specifying an icon that is not
+from font-awesome)
 
 |  Type  |   Default   |
 | :----: | :---------: |
@@ -187,7 +190,8 @@ onPress function for checkbox (required)
 
 ### `checkedIcon`
 
-Default checked icon ([Font Awesome Icon](http://fontawesome.io/icons/)) (optional)
+Default checked icon ([Font Awesome Icon](http://fontawesome.io/icons/))
+(optional)
 
 |               Type               |    Default     |
 | :------------------------------: | :------------: |
@@ -195,7 +199,8 @@ Default checked icon ([Font Awesome Icon](http://fontawesome.io/icons/)) (option
 
 ### `uncheckedIcon`
 
-Default checked icon ([Font Awesome Icon](http://fontawesome.io/icons/)) (optional)
+Default checked icon ([Font Awesome Icon](http://fontawesome.io/icons/))
+(optional)
 
 |               Type               | Default  |
 | :------------------------------: | :------: |

--- a/docs/icon.md
+++ b/docs/icon.md
@@ -12,7 +12,8 @@ for icons
 
 > You can override Material icons with one of the following:
 > [material-community](https://materialdesignicons.com/),
-> [font-awesome](http://fontawesome.io/icons/),
+> [font-awesome](https://fontawesome.com/v4.7.0/),
+> [font-awesome-5](http://fontawesome.io/icons/),
 > [octicon](https://octicons.github.com/), [ionicon](http://ionicons.com/),
 > [foundation](http://zurb.com/playground/foundation-icon-fonts-3),
 > [evilicon](http://evil-icons.io/),
@@ -104,7 +105,7 @@ name of icon (required)
 ### `type`
 
 type (defaults to material, options are
-`material-community, zocial, font-awesome, octicon, ionicon, foundation, evilicon, simple-line-icon, feather or entypo`)
+`material-community, zocial, font-awesome, font-awesome-5, octicon, ionicon, foundation, evilicon, simple-line-icon, feather or entypo`)
 
 |  Type  | Default  |
 | :----: | :------: |

--- a/docs/tile.md
+++ b/docs/tile.md
@@ -160,9 +160,9 @@ Height for the tile
 
 Icon Component Props (optional)
 
-|                                                                                                                       Type                                                                                                                       | Default |
-| :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
-| object {name: string, color: string, size: number, type: string (default is material, or choose one of material-community, simple-line-icon, zocial, font-awesome, octicon, ionicon, foundation, evilicon, or entypo), iconStyle: object(style)} |  none   |
+|                                                                                                                               Type                                                                                                                               | Default |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
+| object {name: string, color: string, size: number, type: string (default is material, or choose one of material-community, simple-line-icon, zocial, font-awesome, font-awesome-5, octicon, ionicon, foundation, evilicon, or entypo), iconStyle: object(style)} |  none   |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -60,12 +60,12 @@
     "react": "16.3.1",
     "react-dom": "16.2.0",
     "react-native": "0.55.4",
-    "react-native-vector-icons": "^4.4.2",
+    "react-native-vector-icons": "^5.0.0",
     "react-test-renderer": "16.3.1",
     "webpack": "^2.2.1"
   },
   "peerDependencies": {
-    "react-native-vector-icons": "^4.2.0 || ^5.0.0"
+    "react-native-vector-icons": "^5.0.0"
   },
   "jest": {
     "preset": "react-native",

--- a/src/helpers/getIconType.js
+++ b/src/helpers/getIconType.js
@@ -9,6 +9,7 @@ import EntypoIcon from 'react-native-vector-icons/Entypo';
 import FAIcon from 'react-native-vector-icons/FontAwesome';
 import SimpleLineIcon from 'react-native-vector-icons/SimpleLineIcons';
 import FeatherIcon from 'react-native-vector-icons/Feather';
+import FA5Icon from 'react-native-vector-icons/FontAwesome5';
 
 const customIcons = {};
 
@@ -40,6 +41,8 @@ export default type => {
       return SimpleLineIcon;
     case 'feather':
       return FeatherIcon;
+    case 'font-awesome-5':
+      return FA5Icon;
     default:
       if (customIcons.hasOwnProperty(type)) {
         return customIcons[type];

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,6 +32,7 @@ export type IconType =
   | 'foundation'
   | 'evilicon'
   | 'entypo'
+  | 'font-awesome-5'
   | string;
 
 export interface IconObject {
@@ -911,7 +912,7 @@ export interface IconProps {
   name: string;
 
   /**
-   * Type (defaults to material, options are material-community, zocial, font-awesome, octicon, ionicon, foundation, evilicon, simple-line-icon, or entypo)
+   * Type (defaults to material, options are material-community, zocial, font-awesome,font-awesome-5, octicon, ionicon, foundation, evilicon, simple-line-icon, or entypo)
    * @default 'material'
    */
   type?: IconType;
@@ -1883,6 +1884,6 @@ export function getIconType(type: IconType): any;
 export function normalize(size: number): number;
 
 /**
-* Registers custom icons
-*/
+ * Registers custom icons
+ */
 export function registerCustomIconType(id: string, font: any): void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6418,9 +6418,9 @@ react-is@^16.3.1, react-is@^16.3.2:
   version "16.3.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
 
-react-native-vector-icons@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-4.4.2.tgz#090f42ee0396c4cc4eae0ddaa518028ba8df40c7"
+react-native-vector-icons@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-5.0.0.tgz#d0bd6fdda01159db409810718dd04904951a98f5"
   dependencies:
     lodash "^4.0.0"
     prop-types "^15.5.10"


### PR DESCRIPTION
Adds basic support for FontAwesome5.

We need to find a way to support the font weights though. FontAwesome supports different weights https://github.com/oblador/react-native-vector-icons/blob/master/FONTAWESOME5.md#usage