### PR TITLE
Add TextStyle to possible checkmark types.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1022,7 +1022,7 @@ export interface ListItemProps {
   contentContainerStyle?: StyleProp<ViewStyle>;
   rightContentContainerStyle?: StyleProp<ViewStyle>;
   chevron?: boolean | IconProps;
-  checkmark?: boolean | IconProps;
+  checkmark?: boolean | IconProps | TextStyle;
   onPress?(): void;
   onLongPress?(): void;
   title?: string | React.ReactElement<{}>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1022,7 +1022,7 @@ export interface ListItemProps {
   contentContainerStyle?: StyleProp<ViewStyle>;
   rightContentContainerStyle?: StyleProp<ViewStyle>;
   chevron?: boolean | IconProps;
-  checkmark?: boolean | IconProps | TextStyle;
+  checkmark?: boolean | Partial<IconProps>;
   onPress?(): void;
   onLongPress?(): void;
   title?: string | React.ReactElement<{}>;


### PR DESCRIPTION
This type is missing. The example of the changelog for the `<ListItem />`:

```ts
// Before
<ListItem checkmark checkmarkColor="red" />

// After
<ListItem checkmark={{ color: 'red' }} />
```

Currently throws an error. After this fix, it doesn't anymore.