### PR TITLE
Fix Header docs typo

### DIFF
--- a/docs/header.md
+++ b/docs/header.md
@@ -95,7 +95,7 @@ We wanted the Header to be as customisable as possible, so you are free to try d
 
 ### Props
 
-* [`containerstyle`](#containerstyle)
+* [`containerStyle`](#containerstyle)
 * [`backgroundColor`](#backgroundcolor)
 * [`leftComponent`](#leftcomponent)
 * [`centerComponent`](#centercomponent)
@@ -111,7 +111,7 @@ We wanted the Header to be as customisable as possible, so you are free to try d
 
 # Reference
 
-### `containerStyle`
+### `containerstyle`
 
 styling around the main container
 

--- a/docs/header.md
+++ b/docs/header.md
@@ -95,7 +95,7 @@ We wanted the Header to be as customisable as possible, so you are free to try d
 
 ### Props
 
-* [`containerStyle`](#containerstyle)
+* [`containerStyle`](#containerStyle)
 * [`backgroundColor`](#backgroundcolor)
 * [`leftComponent`](#leftcomponent)
 * [`centerComponent`](#centercomponent)
@@ -111,7 +111,7 @@ We wanted the Header to be as customisable as possible, so you are free to try d
 
 # Reference
 
-### `containerstyle`
+### `containerStyle`
 
 styling around the main container
 

--- a/docs/header.md
+++ b/docs/header.md
@@ -95,7 +95,7 @@ We wanted the Header to be as customisable as possible, so you are free to try d
 
 ### Props
 
-* [`containerStyle`](#containerstyle)
+* [`containerstyle`](#containerstyle)
 * [`backgroundColor`](#backgroundcolor)
 * [`leftComponent`](#leftcomponent)
 * [`centerComponent`](#centercomponent)

--- a/docs/header.md
+++ b/docs/header.md
@@ -95,7 +95,7 @@ We wanted the Header to be as customisable as possible, so you are free to try d
 
 ### Props
 
-* [`containerStyle`](#containerStyle)
+* [`containerStyle`](#containerstyle)
 * [`backgroundColor`](#backgroundcolor)
 * [`leftComponent`](#leftcomponent)
 * [`centerComponent`](#centercomponent)

--- a/website/versioned_docs/version-1.0.0-beta6/header.md
+++ b/website/versioned_docs/version-1.0.0-beta6/header.md
@@ -112,7 +112,7 @@ We wanted the Header to be as customisable as possible, so you are free to try d
 
 # Reference
 
-### `containerstyle`
+### `containerStyle`
 
 styling around the main container
 


### PR DESCRIPTION
It shouldn't be `containerstyle` but `containerStyle`.

![image](https://user-images.githubusercontent.com/17120764/46838965-d932f380-cde5-11e8-924e-be2d97a42a2c.png)
