### PR TITLE
Use 'Must be greater than version' for RNVI dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "webpack": "^2.2.1"
   },
   "peerDependencies": {
-    "react-native-vector-icons": "^4.2.0 || ^5.0.0"
+    "react-native-vector-icons": ">4.2.0"
   },
   "jest": {
     "preset": "react-native",


### PR DESCRIPTION
Fix #1464 

RNVI dep:
```
λ cat package.json | grep vector-icons
    "react-native-vector-icons": "^6.0.2"
```

**Tested locally.**

_Before:_
```
λ yarn add https://github.com/haruelrovix/react-native-elements#1464-rnvi-dependency
yarn add v1.10.1
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.4: The platform "win32" is incompatible with this module.
info "fsevents@1.2.4" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
warning "react-native > metro > babel-preset-fbjs > @babel/plugin-check-constants@7.0.0-beta.38" has incorrect peer dependency "@babel/core@7.0.0-beta.38".nstants@7.0.0-beta.38" has incorrect peer dependency "@babel/core@7.0.0-be0 || ^7.0.0-0".ta.38".                                                                   cy "react-native-vector-icons@^4.2.0 || ^5.0.0".
warning " > babel-jest@23.6.0" has unmet peer dependency "babel-core@^6.0.0 || ^7.0.0-0".
warning " > react-native-elements@1.0.0-beta6" has incorrect peer dependency "react-native-vector-icons@^4.2.0 || ^5.0.0".
[4/4] Building fresh packages...
success Saved lockfile.
success Saved 4 new dependencies.
info Direct dependencies
└─ react-native-elements@1.0.0-beta6
info All dependencies
├─ lodash.merge@4.6.1
├─ lodash.times@4.3.2
├─ opencollective-postinstall@2.0.0
└─ react-native-elements@1.0.0-beta6
Done in 11.16s.
```

_After:_
```
> yarn add https://github.com/haruelrovix/react-native-elements#1464-rnvi-dependency
yarn add v1.10.1
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.4: The platform "win32" is incompatible with this module.
info "fsevents@1.2.4" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
warning "react-native > metro > babel-preset-fbjs > @babel/plugin-check-constants@7.0.0-beta.38" has incorrect peer dependency "@babel/core@7.0.0-beta.38".
warning " > babel-jest@23.6.0" has unmet peer dependency "babel-core@^6.0.0 || ^7.0.0-0".
[4/4] Building fresh packages...
success Saved lockfile.
success Saved 1 new dependency.
info Direct dependencies
└─ react-native-elements@1.0.0-beta6
info All dependencies
└─ react-native-elements@1.0.0-beta6
Done in 23.58s.
```