### PR TITLE
Added AntDesign to icons in src/helps/getIconType.js

### DIFF
--- a/src/helpers/getIconType.js
+++ b/src/helpers/getIconType.js
@@ -9,6 +9,7 @@ import EntypoIcon from 'react-native-vector-icons/Entypo';
 import FAIcon from 'react-native-vector-icons/FontAwesome';
 import SimpleLineIcon from 'react-native-vector-icons/SimpleLineIcons';
 import FeatherIcon from 'react-native-vector-icons/Feather';
+import AntIcon from 'react-native-vector-icons/AntDesign';
 
 const customIcons = {};
 
@@ -40,6 +41,8 @@ export default type => {
       return SimpleLineIcon;
     case 'feather':
       return FeatherIcon;
+    case 'antdesign':
+      return AntIcon;
     default:
       if (customIcons.hasOwnProperty(type)) {
         return customIcons[type];


### PR DESCRIPTION
I noticed that Ant Design was missing from the switch statement in this code, so I imported Ant Design and added it to the switch statement to fix it. This is my first time making a pull request like this so apologies if I've messed anything up.