### PR TITLE
feat(Tile): Allow caption to be a React element

### DIFF
--- a/docs/tile.md
+++ b/docs/tile.md
@@ -102,13 +102,13 @@ Text inside the tilt when tile is featured
 
 |  Type  | Default |
 | :----: | :-----: |
-| string |  none   |
+| string **OR** React element or component |  none   |
 
 ---
 
 ### `captionStyle`
 
-Styling for the caption (optional)
+Styling for the caption (optional); use this along with `caption` type `string`
 
 |      Type      | Default |
 | :------------: | :-----: |

--- a/src/tile/FeaturedTile.js
+++ b/src/tile/FeaturedTile.js
@@ -10,9 +10,16 @@ import {
 } from 'react-native';
 
 import { ViewPropTypes, BackgroundImage, withTheme } from '../config';
+import { renderNode } from '../helpers';
 
 import Text from '../text/Text';
 import Icon from '../icons/Icon';
+
+const renderText = (content, defaultProps, style) =>
+  renderNode(Text, content, {
+    ...defaultProps,
+    style: StyleSheet.flatten([style, defaultProps && defaultProps.style]),
+  });
 
 const FeaturedTile = props => {
   const {
@@ -116,18 +123,13 @@ const FeaturedTile = props => {
           >
             {title}
           </Text>
-          {typeof caption === 'string' ? (
-            <Text
-              style={StyleSheet.flatten([
-                styles.text,
-                captionStyle && captionStyle,
-              ])}
-            >
-              {caption}
-            </Text>
-          ) : (
-            caption
-          )}
+          {typeof caption === 'string'
+            ? renderText(
+                caption,
+                { style: captionStyle },
+                StyleSheet.flatten(styles.text)
+              )
+            : caption}
         </View>
       </BackgroundImage>
     </TouchableOpacity>
@@ -137,7 +139,7 @@ const FeaturedTile = props => {
 FeaturedTile.propTypes = {
   title: PropTypes.string,
   icon: PropTypes.object,
-  caption: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  caption: PropTypes.node,
   imageSrc: Image.propTypes.source,
   onPress: PropTypes.func,
   containerStyle: ViewPropTypes.style,

--- a/src/tile/FeaturedTile.js
+++ b/src/tile/FeaturedTile.js
@@ -116,14 +116,18 @@ const FeaturedTile = props => {
           >
             {title}
           </Text>
-          <Text
-            style={StyleSheet.flatten([
-              styles.text,
-              captionStyle && captionStyle,
-            ])}
-          >
-            {caption}
-          </Text>
+          {typeof caption === 'string' ? (
+            <Text
+              style={StyleSheet.flatten([
+                styles.text,
+                captionStyle && captionStyle,
+              ])}
+            >
+              {caption}
+            </Text>
+          ) : (
+            caption
+          )}
         </View>
       </BackgroundImage>
     </TouchableOpacity>

--- a/src/tile/FeaturedTile.js
+++ b/src/tile/FeaturedTile.js
@@ -123,13 +123,11 @@ const FeaturedTile = props => {
           >
             {title}
           </Text>
-          {typeof caption === 'string'
-            ? renderText(
-                caption,
-                { style: captionStyle },
-                StyleSheet.flatten(styles.text)
-              )
-            : caption}
+          {renderText(
+            caption,
+            { style: captionStyle },
+            StyleSheet.flatten(styles.text)
+          )}
         </View>
       </BackgroundImage>
     </TouchableOpacity>

--- a/src/tile/FeaturedTile.js
+++ b/src/tile/FeaturedTile.js
@@ -133,7 +133,7 @@ const FeaturedTile = props => {
 FeaturedTile.propTypes = {
   title: PropTypes.string,
   icon: PropTypes.object,
-  caption: PropTypes.string,
+  caption: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   imageSrc: Image.propTypes.source,
   onPress: PropTypes.func,
   containerStyle: ViewPropTypes.style,

--- a/src/tile/FeaturedTile.js
+++ b/src/tile/FeaturedTile.js
@@ -123,11 +123,7 @@ const FeaturedTile = props => {
           >
             {title}
           </Text>
-          {renderText(
-            caption,
-            { style: captionStyle },
-            StyleSheet.flatten(styles.text)
-          )}
+          {renderText(caption, { style: captionStyle }, styles.text)}
         </View>
       </BackgroundImage>
     </TouchableOpacity>

--- a/src/tile/Tile.js
+++ b/src/tile/Tile.js
@@ -122,7 +122,7 @@ const Tile = props => {
 Tile.propTypes = {
   title: PropTypes.string,
   icon: PropTypes.object,
-  caption: PropTypes.string,
+  caption: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   imageSrc: Image.propTypes.source,
   onPress: PropTypes.func,
   activeOpacity: PropTypes.number,

--- a/src/tile/Tile.js
+++ b/src/tile/Tile.js
@@ -122,7 +122,7 @@ const Tile = props => {
 Tile.propTypes = {
   title: PropTypes.string,
   icon: PropTypes.object,
-  caption: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  caption: PropTypes.node,
   imageSrc: Image.propTypes.source,
   onPress: PropTypes.func,
   activeOpacity: PropTypes.number,

--- a/src/tile/__tests__/FeaturedTile.js
+++ b/src/tile/__tests__/FeaturedTile.js
@@ -80,4 +80,16 @@ describe('FeaturedTitle component', () => {
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();
   });
+
+  it('should render string in caption', () => {
+    const component = shallow(
+      <FeaturedTile
+        imageSrc={{ url: 'http://google.com' }}
+        caption="Caption text"
+      />
+    );
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
 });

--- a/src/tile/__tests__/FeaturedTile.js
+++ b/src/tile/__tests__/FeaturedTile.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { create } from 'react-test-renderer';
+import { Avatar } from 'react-native-elements';
 
 import { ThemeProvider } from '../../config';
 
@@ -66,5 +67,17 @@ describe('FeaturedTitle component', () => {
     ).toBe('I am featured');
 
     expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('should render component in caption', () => {
+    const component = shallow(
+      <FeaturedTile
+        imageSrc={{ url: 'http://google.com' }}
+        caption={<Avatar source={{ uri: 'http://google.com' }} />}
+      />
+    );
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
   });
 });

--- a/src/tile/__tests__/__snapshots__/FeaturedTile.js.snap
+++ b/src/tile/__tests__/__snapshots__/FeaturedTile.js.snap
@@ -206,6 +206,91 @@ exports[`FeaturedTitle component should render component in caption 1`] = `
 </TouchableOpacity>
 `;
 
+exports[`FeaturedTitle component should render string in caption 1`] = `
+<TouchableOpacity
+  activeOpacity={0.2}
+  style={
+    Object {
+      "height": 600,
+      "width": 750,
+    }
+  }
+>
+  <ImageBackground
+    resizeMode="cover"
+    source={
+      Object {
+        "url": "http://google.com",
+      }
+    }
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#ffffff",
+        "height": 600,
+        "justifyContent": "center",
+        "width": 750,
+      }
+    }
+  >
+    <Component
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "stretch",
+          "backgroundColor": "rgba(0,0,0,0.2)",
+          "bottom": 0,
+          "flex": 1,
+          "justifyContent": "center",
+          "left": 0,
+          "paddingBottom": 40,
+          "paddingLeft": 25,
+          "paddingRight": 25,
+          "paddingTop": 45,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      <Component
+        style={
+          Object {
+            "alignItems": "center",
+            "alignSelf": "center",
+            "justifyContent": "center",
+          }
+        }
+      />
+      <Themed.Text
+        h4={true}
+        style={
+          Object {
+            "backgroundColor": "rgba(0,0,0,0)",
+            "color": "#ffffff",
+            "marginBottom": 15,
+            "textAlign": "center",
+          }
+        }
+        testID="featuredTileTitle"
+      />
+      <Themed.Text
+        style={
+          Object {
+            "backgroundColor": "rgba(0,0,0,0)",
+            "color": "#ffffff",
+            "marginBottom": 15,
+            "textAlign": "center",
+          }
+        }
+      >
+        Caption text
+      </Themed.Text>
+    </Component>
+  </ImageBackground>
+</TouchableOpacity>
+`;
+
 exports[`FeaturedTitle component should render with Icon 1`] = `
 <TouchableOpacity
   activeOpacity={0.2}

--- a/src/tile/__tests__/__snapshots__/FeaturedTile.js.snap
+++ b/src/tile/__tests__/__snapshots__/FeaturedTile.js.snap
@@ -126,6 +126,86 @@ exports[`FeaturedTitle component should apply values from theme 1`] = `
 </View>
 `;
 
+exports[`FeaturedTitle component should render component in caption 1`] = `
+<TouchableOpacity
+  activeOpacity={0.2}
+  style={
+    Object {
+      "height": 600,
+      "width": 750,
+    }
+  }
+>
+  <ImageBackground
+    resizeMode="cover"
+    source={
+      Object {
+        "url": "http://google.com",
+      }
+    }
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#ffffff",
+        "height": 600,
+        "justifyContent": "center",
+        "width": 750,
+      }
+    }
+  >
+    <Component
+      style={
+        Object {
+          "alignItems": "center",
+          "alignSelf": "stretch",
+          "backgroundColor": "rgba(0,0,0,0.2)",
+          "bottom": 0,
+          "flex": 1,
+          "justifyContent": "center",
+          "left": 0,
+          "paddingBottom": 40,
+          "paddingLeft": 25,
+          "paddingRight": 25,
+          "paddingTop": 45,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      <Component
+        style={
+          Object {
+            "alignItems": "center",
+            "alignSelf": "center",
+            "justifyContent": "center",
+          }
+        }
+      />
+      <Themed.Text
+        h4={true}
+        style={
+          Object {
+            "backgroundColor": "rgba(0,0,0,0)",
+            "color": "#ffffff",
+            "marginBottom": 15,
+            "textAlign": "center",
+          }
+        }
+        testID="featuredTileTitle"
+      />
+      <Themed.Avatar
+        source={
+          Object {
+            "uri": "http://google.com",
+          }
+        }
+      />
+    </Component>
+  </ImageBackground>
+</TouchableOpacity>
+`;
+
 exports[`FeaturedTitle component should render with Icon 1`] = `
 <TouchableOpacity
   activeOpacity={0.2}

--- a/src/tile/__tests__/__snapshots__/FeaturedTile.js.snap
+++ b/src/tile/__tests__/__snapshots__/FeaturedTile.js.snap
@@ -121,41 +121,6 @@ exports[`FeaturedTitle component should apply values from theme 1`] = `
       >
         I am featured
       </Text>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Object {
-            "backgroundColor": "rgba(0,0,0,0)",
-            "color": "#ffffff",
-            "marginBottom": 15,
-            "textAlign": "center",
-          }
-        }
-        theme={
-          Object {
-            "FeaturedTile": Object {
-              "title": "I am featured",
-            },
-            "colors": Object {
-              "divider": "#bcbbc1",
-              "error": "#ff190c",
-              "grey0": "#393e42",
-              "grey1": "#43484d",
-              "grey2": "#5e6977",
-              "grey3": "#86939e",
-              "grey4": "#bdc6cf",
-              "grey5": "#e1e8ee",
-              "greyOutline": "#bbb",
-              "primary": "#2089dc",
-              "searchBg": "#303337",
-              "secondary": "#8F0CE8",
-            },
-          }
-        }
-        updateTheme={[Function]}
-      />
     </View>
   </View>
 </View>
@@ -236,16 +201,6 @@ exports[`FeaturedTitle component should render with Icon 1`] = `
         }
         testID="featuredTileTitle"
       />
-      <Themed.Text
-        style={
-          Object {
-            "backgroundColor": "rgba(0,0,0,0)",
-            "color": "blue",
-            "marginBottom": 15,
-            "textAlign": "center",
-          }
-        }
-      />
     </Component>
   </ImageBackground>
 </TouchableOpacity>
@@ -321,16 +276,6 @@ exports[`FeaturedTitle component should render with width and height 1`] = `
         }
         testID="featuredTileTitle"
       />
-      <Themed.Text
-        style={
-          Object {
-            "backgroundColor": "rgba(0,0,0,0)",
-            "color": "#ffffff",
-            "marginBottom": 15,
-            "textAlign": "center",
-          }
-        }
-      />
     </Component>
   </ImageBackground>
 </TouchableOpacity>
@@ -403,16 +348,6 @@ exports[`FeaturedTitle component should render without issues 1`] = `
           }
         }
         testID="featuredTileTitle"
-      />
-      <Themed.Text
-        style={
-          Object {
-            "backgroundColor": "rgba(0,0,0,0)",
-            "color": "#ffffff",
-            "marginBottom": 15,
-            "textAlign": "center",
-          }
-        }
       />
     </Component>
   </ImageBackground>

--- a/website/versioned_docs/version-1.0.0-beta6/header.md
+++ b/website/versioned_docs/version-1.0.0-beta6/header.md
@@ -112,7 +112,7 @@ We wanted the Header to be as customisable as possible, so you are free to try d
 
 # Reference
 
-### `containerstyle`
+### `containerStyle`
 
 styling around the main container
 


### PR DESCRIPTION
PR created to solve [issue #1415](https://github.com/react-native-training/react-native-elements/issues/1415) created by [beltrancaliz](https://github.com/beltrancaliz)
I've added possibility to pass object as propTypes to Tile/FeaturedTile instead of passing only simple string.
Also `captionStyle` won't work if you'll pass an object, because you can style it without this prop :)