### PR TITLE
Replace selectedBackgroundColor type with selectedButtonStyle type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -577,11 +577,11 @@ export interface ButtonGroupProps {
     buttonStyle?: StyleProp<ViewStyle>;
 
     /**
-     * Specify color for selected state of button
+     * Specify styling selected button
      *
      * @default 'white'
      */
-    selectedBackgroundColor?: string;
+    selectedButtonStyle?: StyleProp<ViewStyle>;
 
     /**
      * Specify specific styling for text


### PR DESCRIPTION
This is a fix for a typescript type issue I found in 0.19.1, outlined here: https://github.com/react-native-training/react-native-elements/issues/1511