### PR TITLE
fix: Change updateTheme to merge empty object first

### DIFF
--- a/src/config/ThemeProvider.js
+++ b/src/config/ThemeProvider.js
@@ -22,7 +22,7 @@ export default class ThemeProvider extends React.Component {
 
   updateTheme = updates => {
     this.setState(({ theme }) => ({
-      theme: merge(theme, updates),
+      theme: merge({}, theme, updates),
     }));
   };
 


### PR DESCRIPTION
updateTheme uses lodash.merge. merge is a mutative operation which
error as it was trying to mutate a value on state.

Closes #1522