### PR TITLE
Fix small listitem docs error.

### DIFF
--- a/docs/listitem.md
+++ b/docs/listitem.md
@@ -283,9 +283,9 @@ import LinearGradient from 'react-native-linear-gradient' // Only if no expo
 
 replace element with custom element (optional)
 
-|                            Type                             |  Default  |
-| :---------------------------------------------------------: | :-------: |
-| View or TouchableOpacity if onPress method is added as prop | component |
+|                                  Type                                   |  Default  |
+| :---------------------------------------------------------------------: | :-------: |
+| View or TouchableHighlight (default) if onPress method is added as prop | component |
 
 ---
 


### PR DESCRIPTION
The docs in the listitem incorrectly say that the default implementation of the item is a `TouchableOpacity` but it is a `TouchableHighlight`.