### PR TITLE
docs(website): Add central place to show supported icon sets

### DIFF
--- a/docs/avatar.md
+++ b/docs/avatar.md
@@ -213,9 +213,9 @@ Styling for outer container
 
 ### `icon`
 
-|                                                                                                                  Type                                                                                                                  | Default |
-| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
-| object {name: string, color: string, size: number, type: string (default is material-community, or choose one of simple-line-icon, zocial, font-awesome, octicon, ionicon, foundation, evilicon, or entypo), iconStyle: object(style)} |  none   |
+|                                                                                        Type                                                                                         | Default |
+| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
+| object {name: string, color: string, size: number, type: string (default is material, or choose from [supported icon sets](icon.md#available-icon-sets)), iconStyle: object(style)} |  none   |
 
 ---
 

--- a/docs/checkbox.md
+++ b/docs/checkbox.md
@@ -79,13 +79,11 @@ import { CheckBox } from 'react-native-elements'
 
 ### `iconType`
 
-Icon family, can be one of the following: simple-line-icon, zocial, octicon,
-material, material-community, ionicon, foundation, evilicon, entypo (required
-only if specifying an icon that is not from font-awesome)
+type of icon set. [Supported sets here](icon.md#available-icon-sets).
 
-|  Type  |   Default   |
-| :----: | :---------: |
-| string | fontawesome |
+|  Type  |   Default    |
+| :----: | :----------: |
+| string | font-awesome |
 
 ### `Component`
 

--- a/docs/icon.md
+++ b/docs/icon.md
@@ -7,22 +7,26 @@ Icons are visual indicators usually used to describe action or intent.
 
 ![Icon](/react-native-elements/img/icons.png)
 
-Icons take the name of a [material icon](https://design.google.com/icons/) as a
-prop. Use the
-[icon directory](https://oblador.github.io/react-native-vector-icons/) to search
-for icons
-
-> You can override Material icons with one of the following:
-> [material-community](https://materialdesignicons.com/),
-> [font-awesome](http://fontawesome.io/icons/),
-> [octicon](https://octicons.github.com/), [ionicon](http://ionicons.com/),
-> [foundation](http://zurb.com/playground/foundation-icon-fonts-3),
-> [evilicon](http://evil-icons.io/),
-> [simple-line-icon](http://simplelineicons.com/),
-> [zocial](http://weloveiconfonts.com/), or [entypo](http://www.entypo.com/) by
-> providing a type prop.
-
 > Hint: use **reverse** to make your icon look like a button
+
+### Available Icon Sets
+
+The icon sets in React Native Elements are made possible through
+[react-native-vector-icons](https://github.com/oblador/react-native-vector-icons).
+
+The current list of available icons sets are:
+
+* [material](https://material.io/tools/icons)
+* [material-community](https://materialdesignicons.com/)
+* [font-awesome](http://fontawesome.io/icons/)
+* [octicon](https://octicons.github.com/)
+* [ionicon](http://ionicons.com/)
+* [foundation](http://zurb.com/playground/foundation-icon-fonts-3)
+* [evilicon](http://evil-icons.io/)
+* [simple-line-icon](http://simplelineicons.com/)
+* [zocial](http://weloveiconfonts.com/)
+* [entypo](http://www.entypo.com/)
+* [feather](https://feathericons.com/)
 
 ### Custom Icon Fonts
 
@@ -105,8 +109,7 @@ name of icon (required)
 
 ### `type`
 
-type (defaults to material, options are
-`material-community, zocial, font-awesome, octicon, ionicon, foundation, evilicon, simple-line-icon, feather or entypo`)
+type of icon set. [Supported sets here](#available-icon-sets).
 
 |  Type  | Default  |
 | :----: | :------: |

--- a/docs/tile.md
+++ b/docs/tile.md
@@ -106,15 +106,15 @@ Number passed to control opacity on press (optional)
 
 Text inside the tilt when tile is featured
 
-|  Type  | Default |
-| :----: | :-----: |
+|                   Type                   | Default |
+| :--------------------------------------: | :-----: |
 | string **OR** React element or component |  none   |
 
 ---
 
 ### `captionStyle`
 
-Styling for the caption (optional);  You only use this if `caption` is a string
+Styling for the caption (optional); You only use this if `caption` is a string
 
 |      Type      | Default |
 | :------------: | :-----: |
@@ -166,9 +166,9 @@ Height for the tile
 
 Icon Component Props (optional)
 
-|                                                                                                                       Type                                                                                                                       | Default |
-| :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
-| object {name: string, color: string, size: number, type: string (default is material, or choose one of material-community, simple-line-icon, zocial, font-awesome, octicon, ionicon, foundation, evilicon, or entypo), iconStyle: object(style)} |  none   |
+|                                                                                        Type                                                                                         | Default |
+| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: |
+| object {name: string, color: string, size: number, type: string (default is material, or choose from [supported icon sets](icon.md#available-icon-sets)), iconStyle: object(style)} |  none   |
 
 ---
 


### PR DESCRIPTION
Right now it's kind of annoying everytime react-native-vector-icons adds a new font family, that we have to update the list of fonts we support in multiple places.

This change list all the available fonts on the icon page.