### PR TITLE
fix: Overlay needs keys for children

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "lodash.merge": "^4.6.1",
     "lodash.times": "^4.3.2",
     "opencollective-postinstall": "^2.0.0",
-    "prop-types": "^15.5.8"
+    "prop-types": "^15.5.8",
+    "shortid": "^2.2.13"
   },
   "devDependencies": {
     "@types/react": "^16.4.16",

--- a/src/overlay/Overlay.js
+++ b/src/overlay/Overlay.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import shortid from 'shortid';
 import {
   View,
   StyleSheet,
@@ -14,56 +15,67 @@ const dimensions = Dimensions.get('window');
 const windowWidth = dimensions.width;
 const windowHeight = dimensions.height;
 
-const Overlay = props => {
-  const {
-    children,
-    isVisible,
-    containerStyle,
-    overlayStyle,
-    windowBackgroundColor,
-    overlayBackgroundColor,
-    onBackdropPress,
-    borderRadius,
-    width,
-    height,
-    fullScreen,
-    ...rest
-  } = props;
+class Overlay extends React.Component {
+  constructor(props) {
+    super(props);
 
-  if (!isVisible) return null;
+    this.state = {
+      children: Array.isArray(props.children)
+        ? props.children.map(child => ({ ...child, key: shortid.generate() }))
+        : props.children,
+    };
+  }
 
-  return (
-    <TouchableWithoutFeedback onPress={onBackdropPress}>
-      <View
-        testID="overlayContainer"
-        style={StyleSheet.flatten([
-          styles.container,
-          { backgroundColor: windowBackgroundColor },
-          containerStyle,
-        ])}
-        {...rest}
-      >
-        <TouchableWithoutFeedback>
-          <View
-            style={StyleSheet.flatten([
-              styles.overlay,
-              {
-                borderRadius,
-                backgroundColor: overlayBackgroundColor,
-                width,
-                height,
-              },
-              fullScreen && { width: windowWidth, height: windowHeight },
-              overlayStyle,
-            ])}
-          >
-            {children}
-          </View>
-        </TouchableWithoutFeedback>
-      </View>
-    </TouchableWithoutFeedback>
-  );
-};
+  render() {
+    const {
+      isVisible,
+      containerStyle,
+      overlayStyle,
+      windowBackgroundColor,
+      overlayBackgroundColor,
+      onBackdropPress,
+      borderRadius,
+      width,
+      height,
+      fullScreen,
+      ...rest
+    } = this.props;
+
+    if (!isVisible) return null;
+
+    return (
+      <TouchableWithoutFeedback onPress={onBackdropPress}>
+        <View
+          testID="overlayContainer"
+          style={StyleSheet.flatten([
+            styles.container,
+            { backgroundColor: windowBackgroundColor },
+            containerStyle,
+          ])}
+          {...rest}
+        >
+          <TouchableWithoutFeedback>
+            <View
+              style={StyleSheet.flatten([
+                styles.overlay,
+                {
+                  borderRadius,
+                  backgroundColor: overlayBackgroundColor,
+                  width,
+                  height,
+                },
+                fullScreen && { width: windowWidth, height: windowHeight },
+                overlayStyle,
+              ])}
+            >
+              {this.state.children}
+            </View>
+          </TouchableWithoutFeedback>
+        </View>
+      </TouchableWithoutFeedback>
+    );
+  }
+}
 
 Overlay.propTypes = {
   children: PropTypes.any,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6637,6 +6637,11 @@ nan@^2.3.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.1.tgz#8c84f7b14c96b89f57fbc838012180ec8ca39a01"
   integrity sha1-jIT3sUyWuJ9X+8g4ASGA7IyjmgE=
 
+nanoid@^1.0.7:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-1.3.3.tgz#23d4130cb3dcb455c742cbf281163d52f0cd51b0"
+  integrity sha512-07OUEbP7fMX/tFLP3oIa3yTt+sUfDQf99JULSKc/ZNERIVG8T87S+Kt9iu6N4efVzmeMvlXjVUUQcEXKEm0OCQ==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -8367,6 +8372,13 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+shortid@^2.2.13:
+  version "2.2.13"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.13.tgz#b2441e71c664ace458a341d343959f677910ef5b"
+  integrity sha512-dBuNnQGKrJNfjunmXI2X7bl1gnMO4PwbNxrTzO1JvilODmL7WyyCtA+DYxe9XunLXmxmgzFIvKPQ6XRAQrr46Q==
+  dependencies:
+    nanoid "^1.0.7"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
_Problem:_
Each child in an array or iterator should have a unique "key" prop, [references](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318).

_Solution:_
Generate unique key using [shortid](https://www.npmjs.com/package/shortid) for Overlay children if it's an array.

|Before|After|
|-|-|
|<img src="https://user-images.githubusercontent.com/17120764/47782949-111dbe80-dd34-11e8-9c3e-e6206a252ef5.png" width=300 />|<img src="https://user-images.githubusercontent.com/17120764/47783257-d2d4cf00-dd34-11e8-9c79-ad3db474fc99.png" width=300 />|

Fixes #1517 .