### PR TITLE
Fix: paragraphs links in docs

### DIFF
--- a/docs/avatar.md
+++ b/docs/avatar.md
@@ -155,7 +155,7 @@ title: Avatar
 * [`titleStyle`](#titlestyle)
 * [`placeholderStyle`](#placeholderstyle)
 * [`renderPlaceholderContent`](#renderplaceholdercontent)
-* [`ImageComponent`](#ImageComponent)
+* [`ImageComponent`](#imagecomponent)
 
 ---
 

--- a/docs/tooltip.md
+++ b/docs/tooltip.md
@@ -31,8 +31,8 @@ import { Tooltip, Text } from 'react-native-elements';
 * [`popover`](#popover)
 * [`toggleOnPress`](#toggleOnPress)
 * [`width`](#width)
-* [`withOverlay`](#withOverlay)
-* [`withPointer`](#withPointer)
+* [`withOverlay`](#withoverlay)
+* [`withPointer`](#withpointer)
 
 ---
 


### PR DESCRIPTION
I've noticed that some links doesn't work in docs when I want to access specific paragraph, so... here is fixed version :)