### PR TITLE
feat(Header): Add background image

### DIFF
--- a/docs/header.md
+++ b/docs/header.md
@@ -98,6 +98,7 @@ We wanted the Header to be as customisable as possible, so you are free to try d
 * [`containerStyle`](#containerstyle)
 * [`backgroundColor`](#backgroundcolor)
 * [`backgroundImage`](#backgroundimage)
+* [`backgroundImageStyle`](#backgroundimagestyle)
 * [`leftComponent`](#leftcomponent)
 * [`centerComponent`](#centercomponent)
 * [`rightComponent`](#rightcomponent)
@@ -139,6 +140,15 @@ sets backgroundImage for parent component
 |  Type  | Default |
 | :----: | :-----: |
 | object (image) |  none   |
+
+---
+### `backgroundImageStyle`
+
+styling for backgroundImage in the main container
+
+|  Type  | Default |
+| :----: | :-----: |
+| style |  none   |
 
 ---
 

--- a/docs/header.md
+++ b/docs/header.md
@@ -97,6 +97,7 @@ We wanted the Header to be as customisable as possible, so you are free to try d
 
 * [`containerStyle`](#containerstyle)
 * [`backgroundColor`](#backgroundcolor)
+* [`backgroundImage`](#backgroundimage)
 * [`leftComponent`](#leftcomponent)
 * [`centerComponent`](#centercomponent)
 * [`rightComponent`](#rightcomponent)
@@ -128,6 +129,16 @@ sets backgroundColor of the parent component
 |  Type  | Default |
 | :----: | :-----: |
 | string |  none   |
+
+---
+
+### `backgroundImage`
+
+sets backgroundImage for parent component
+
+|  Type  | Default |
+| :----: | :-----: |
+| object (image) |  none   |
 
 ---
 

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -45,6 +45,7 @@ const Header = ({
   rightContainerStyle,
   backgroundColor,
   backgroundImage,
+  backgroundImageStyle,
   containerStyle,
   placement,
   barStyle,
@@ -61,6 +62,7 @@ const Header = ({
       containerStyle,
     ])}
     source={backgroundImage}
+    imageStyle={backgroundImageStyle}
   >
     <StatusBar barStyle={barStyle} {...statusBarProps} />
     <Children
@@ -110,6 +112,7 @@ Header.propTypes = {
   rightContainerStyle: ViewPropTypes.style,
   backgroundColor: PropTypes.string,
   backgroundImage: PropTypes.object,
+  backgroundImageStyle: PropTypes.style,
   containerStyle: ViewPropTypes.style,
   statusBarProps: PropTypes.object,
   barStyle: PropTypes.oneOf(['default', 'light-content', 'dark-content']),

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -1,6 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Platform, StatusBar, StyleSheet, View, ImageBackground } from 'react-native';
+import {
+  Platform,
+  StatusBar,
+  StyleSheet,
+  View,
+  ImageBackground,
+  Image,
+} from 'react-native';
 
 import { ViewPropTypes, getStatusBarHeight, withTheme } from '../config';
 import { renderNode, nodeType } from '../helpers';
@@ -112,7 +119,7 @@ Header.propTypes = {
   rightContainerStyle: ViewPropTypes.style,
   backgroundColor: PropTypes.string,
   backgroundImage: PropTypes.object,
-  backgroundImageStyle: PropTypes.style,
+  backgroundImageStyle: Image.propTypes.style,
   containerStyle: ViewPropTypes.style,
   statusBarProps: PropTypes.object,
   barStyle: PropTypes.oneOf(['default', 'light-content', 'dark-content']),

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -44,7 +44,7 @@ const Header = ({
   centerContainerStyle,
   rightContainerStyle,
   backgroundColor,
-  backgroundImageSource,
+  backgroundImage,
   containerStyle,
   placement,
   barStyle,
@@ -60,7 +60,7 @@ const Header = ({
       backgroundColor && { backgroundColor },
       containerStyle,
     ])}
-    source={backgroundImageSource}
+    source={backgroundImage}
   >
     <StatusBar barStyle={barStyle} {...statusBarProps} />
     <Children
@@ -109,7 +109,7 @@ Header.propTypes = {
   centerContainerStyle: ViewPropTypes.style,
   rightContainerStyle: ViewPropTypes.style,
   backgroundColor: PropTypes.string,
-  backgroundImageSource: PropTypes.object,
+  backgroundImage: PropTypes.object,
   containerStyle: ViewPropTypes.style,
   statusBarProps: PropTypes.object,
   barStyle: PropTypes.oneOf(['default', 'light-content', 'dark-content']),

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Platform, StatusBar, StyleSheet, View } from 'react-native';
+import { Platform, StatusBar, StyleSheet, View, ImageBackground } from 'react-native';
 
 import { ViewPropTypes, getStatusBarHeight, withTheme } from '../config';
 import { renderNode, nodeType } from '../helpers';
@@ -44,6 +44,7 @@ const Header = ({
   centerContainerStyle,
   rightContainerStyle,
   backgroundColor,
+  backgroundImageSource,
   containerStyle,
   placement,
   barStyle,
@@ -51,7 +52,7 @@ const Header = ({
   theme,
   ...attributes
 }) => (
-  <View
+  <ImageBackground
     testID="headerContainer"
     {...attributes}
     style={StyleSheet.flatten([
@@ -59,6 +60,7 @@ const Header = ({
       backgroundColor && { backgroundColor },
       containerStyle,
     ])}
+    source={backgroundImageSource}
   >
     <StatusBar barStyle={barStyle} {...statusBarProps} />
     <Children
@@ -95,7 +97,7 @@ const Header = ({
     >
       {children[2] || rightComponent}
     </Children>
-  </View>
+  </ImageBackground>
 );
 
 Header.propTypes = {
@@ -107,6 +109,7 @@ Header.propTypes = {
   centerContainerStyle: ViewPropTypes.style,
   rightContainerStyle: ViewPropTypes.style,
   backgroundColor: PropTypes.string,
+  backgroundImageSource: PropTypes.object,
   containerStyle: ViewPropTypes.style,
   statusBarProps: PropTypes.object,
   barStyle: PropTypes.oneOf(['default', 'light-content', 'dark-content']),

--- a/src/header/__tests__/Header.js
+++ b/src/header/__tests__/Header.js
@@ -143,4 +143,22 @@ describe('Header Component', () => {
     });
     expect(component.toJSON()).toMatchSnapshot();
   });
+
+  it('should allow to pass backgroundImageSource through prop', () => {
+    const component = shallow(<Header theme={theme} backgroundImage={{ uri: 'http://google.com' }} />);
+
+    expect(
+      component
+        .find(ImageBackground)
+        .first()
+        .props().source
+    ).toEqual({ uri: 'http://google.com' });
+  });
+
+  it('should render with backgroundImage', () => {
+    const component = shallow(<Header theme={theme} backgroundImage={{ uri: 'http://google.com' }} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
 });

--- a/src/header/__tests__/Header.js
+++ b/src/header/__tests__/Header.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, View } from 'react-native';
+import { Button, ImageBackground } from 'react-native';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { create } from 'react-test-renderer';
@@ -96,7 +96,7 @@ describe('Header Component', () => {
 
     expect(
       component
-        .find(View)
+        .find(ImageBackground)
         .first()
         .props().style.backgroundColor
     ).toBe('#aaa');
@@ -109,7 +109,7 @@ describe('Header Component', () => {
 
     expect(
       component
-        .find(View)
+        .find(ImageBackground)
         .at(0)
         .props().style.backgroundColor
     ).toBe('#ccc');

--- a/src/header/__tests__/Header.js
+++ b/src/header/__tests__/Header.js
@@ -161,4 +161,22 @@ describe('Header Component', () => {
     expect(component.length).toBe(1);
     expect(toJson(component)).toMatchSnapshot();
   });
+
+  it('should allow to pass backgroundImageStyle through prop', () => {
+    const component = shallow(<Header theme={theme} backgroundImageStyle={{ opacity: 0.1 }} />);
+
+    expect(
+      component
+        .find(ImageBackground)
+        .first()
+        .props().imageStyle
+    ).toEqual({ opacity: 0.1 });
+  });
+
+  it('should render with backgroundImageStyle', () => {
+    const component = shallow(<Header theme={theme} backgroundImageStyle={{ opacity: 0.1 }} />);
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
 });

--- a/src/header/__tests__/__snapshots__/Header.js.snap
+++ b/src/header/__tests__/__snapshots__/Header.js.snap
@@ -372,6 +372,59 @@ exports[`Header Component should render with backgroundImage 1`] = `
 </ImageBackground>
 `;
 
+exports[`Header Component should render with backgroundImageStyle 1`] = `
+<ImageBackground
+  imageStyle={
+    Object {
+      "opacity": 0.1,
+    }
+  }
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#2089dc",
+      "borderBottomColor": "#f2f2f2",
+      "borderBottomWidth": 0.5,
+      "flexDirection": "row",
+      "height": 64,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 10,
+      "paddingTop": 20,
+    }
+  }
+  testID="headerContainer"
+>
+  <StatusBar
+    animated={false}
+    showHideTransition="fade"
+  />
+  <Children
+    placement="left"
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  />
+  <Children
+    placement="center"
+    style={
+      Object {
+        "flex": 3,
+      }
+    }
+  />
+  <Children
+    placement="right"
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  />
+</ImageBackground>
+`;
+
 exports[`Header Component should render without issues 1`] = `
 <ImageBackground
   style={

--- a/src/header/__tests__/__snapshots__/Header.js.snap
+++ b/src/header/__tests__/__snapshots__/Header.js.snap
@@ -319,6 +319,59 @@ exports[`Header Component should render right component by passing a config thro
 </ImageBackground>
 `;
 
+exports[`Header Component should render with backgroundImage 1`] = `
+<ImageBackground
+  source={
+    Object {
+      "uri": "http://google.com",
+    }
+  }
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#2089dc",
+      "borderBottomColor": "#f2f2f2",
+      "borderBottomWidth": 0.5,
+      "flexDirection": "row",
+      "height": 64,
+      "justifyContent": "space-between",
+      "paddingHorizontal": 10,
+      "paddingTop": 20,
+    }
+  }
+  testID="headerContainer"
+>
+  <StatusBar
+    animated={false}
+    showHideTransition="fade"
+  />
+  <Children
+    placement="left"
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  />
+  <Children
+    placement="center"
+    style={
+      Object {
+        "flex": 3,
+      }
+    }
+  />
+  <Children
+    placement="right"
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  />
+</ImageBackground>
+`;
+
 exports[`Header Component should render without issues 1`] = `
 <ImageBackground
   style={

--- a/src/header/__tests__/__snapshots__/Header.js.snap
+++ b/src/header/__tests__/__snapshots__/Header.js.snap
@@ -15,9 +15,27 @@ exports[`Header Component should apply values from theme 1`] = `
       "paddingTop": 20,
     }
   }
-  testID="headerContainer"
-  updateTheme={[Function]}
 >
+  <Image
+    style={
+      Array [
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        Object {
+          "height": 64,
+          "width": undefined,
+        },
+        undefined,
+      ]
+    }
+    testID="headerContainer"
+    updateTheme={[Function]}
+  />
   <View
     style={
       Object {
@@ -46,7 +64,7 @@ exports[`Header Component should apply values from theme 1`] = `
 `;
 
 exports[`Header Component should render center component by passing a config through props 1`] = `
-<Component
+<ImageBackground
   style={
     Object {
       "alignItems": "center",
@@ -92,11 +110,11 @@ exports[`Header Component should render center component by passing a config thr
       }
     }
   />
-</Component>
+</ImageBackground>
 `;
 
 exports[`Header Component should render left component by passing a component through props 1`] = `
-<Component
+<ImageBackground
   style={
     Object {
       "alignItems": "center",
@@ -145,11 +163,11 @@ exports[`Header Component should render left component by passing a component th
       }
     }
   />
-</Component>
+</ImageBackground>
 `;
 
 exports[`Header Component should render left component by passing a config through props 1`] = `
-<Component
+<ImageBackground
   style={
     Object {
       "alignItems": "center",
@@ -195,11 +213,11 @@ exports[`Header Component should render left component by passing a config throu
       }
     }
   />
-</Component>
+</ImageBackground>
 `;
 
 exports[`Header Component should render right component by passing a component through props 1`] = `
-<Component
+<ImageBackground
   style={
     Object {
       "alignItems": "center",
@@ -248,11 +266,11 @@ exports[`Header Component should render right component by passing a component t
       title="Test button"
     />
   </Children>
-</Component>
+</ImageBackground>
 `;
 
 exports[`Header Component should render right component by passing a config through props 1`] = `
-<Component
+<ImageBackground
   style={
     Object {
       "alignItems": "center",
@@ -298,11 +316,11 @@ exports[`Header Component should render right component by passing a config thro
   >
     <Component />
   </Children>
-</Component>
+</ImageBackground>
 `;
 
 exports[`Header Component should render without issues 1`] = `
-<Component
+<ImageBackground
   style={
     Object {
       "alignItems": "center",
@@ -346,5 +364,5 @@ exports[`Header Component should render without issues 1`] = `
       }
     }
   />
-</Component>
+</ImageBackground>
 `;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -877,6 +877,11 @@ export interface HeaderProps extends ViewProperties {
   backgroundColor?: string;
 
   /**
+   * Background image source
+   */
+  backgroundImage?: ImageURISource;
+
+  /**
    * Determines the alignment of the title
    *
    * @default 'center'

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -882,6 +882,11 @@ export interface HeaderProps extends ViewProperties {
   backgroundImage?: ImageURISource;
 
   /**
+   * Styles for the background image in the container
+   */
+  backgroundImageStyle?: ImageStyle;
+
+  /**
    * Determines the alignment of the title
    *
    * @default 'center'


### PR DESCRIPTION
Issue: #1551 
Added possibility to pass `backgroundImage` prop which is simply `source` prop like in `Image` component :) e.g. :
```
source={{ uri: 'http://google.com' }}
```
![img_4187](https://user-images.githubusercontent.com/11634131/47994108-a54fa300-e0f1-11e8-83bf-f369ece1ac3d.jpeg)
