### PR TITLE
Add instruction for applying legacy styles

### DIFF
--- a/docs/listitem.md
+++ b/docs/listitem.md
@@ -5,6 +5,8 @@ title: ListItem
 
 ![Lists](/react-native-elements/img/lists.png)
 
+*Note: if you want to use the list styling that was applied in versions prior to v1.0, see [this example](https://github.com/react-native-training/react-native-elements/issues/1565).*
+
 #### Using Map Function. Implemented with avatar.
 
 ```js


### PR DESCRIPTION
Anyone upgrading this lib to v1 will lose all their list styles.  It's a significant headache to figure out there are no styles anymore and then recreate them.

This comment or a similar one will help a lot of people I expect, whether they are upgrading or just new to the library and want some sane list styles out of the box.

See issue: https://github.com/react-native-training/react-native-elements/issues/1565

Thanks!