### PR TITLE
Check to make sure that the SearchBar is really empty

### DIFF
--- a/src/searchbar/SearchBar-android.js
+++ b/src/searchbar/SearchBar-android.js
@@ -77,7 +77,7 @@ class SearchBar extends Component {
     super(props);
     this.state = {
       hasFocus: false,
-      isEmpty: true,
+      isEmpty: props.value ? props.value === "" : true
     };
   }
 

--- a/src/searchbar/SearchBar-default.js
+++ b/src/searchbar/SearchBar-default.js
@@ -26,7 +26,7 @@ class SearchBar extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      isEmpty: true,
+      isEmpty: props.value ? props.value === "" : true
     };
   }
 

--- a/src/searchbar/SearchBar-ios.js
+++ b/src/searchbar/SearchBar-ios.js
@@ -34,7 +34,7 @@ class SearchBar extends Component {
     super(props);
     this.state = {
       hasFocus: false,
-      isEmpty: true,
+      isEmpty: props.value ? props.value === "" : true,
       cancelButtonWidth: 0,
       cancelButtonTransform: 0,
     };


### PR DESCRIPTION
Changed the code to take into account when a value has been set on the props of the SearchBar.

Fix for this issue https://github.com/react-native-training/react-native-elements/issues/1247