### PR TITLE
feat: Add Image component

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -1,0 +1,88 @@
+---
+id: image
+title: Image
+---
+
+Drop-in replacement for the standard React Native Image component that displays
+images with a placeholder and smooth image load transitioning.
+
+<div class="component-preview component-preview--single margin-none">
+  <img src="https://user-images.githubusercontent.com/5962998/48658581-f4170a00-ea1a-11e8-866c-df4f42f21947.gif" alt="Image Component" />
+</div>
+
+## Usage
+
+```js
+import { ActivityIndicator } from 'react-native';
+import { Image } from 'react-native-elements';
+
+// Standard Image
+<Image
+  source={{ uri: image }}
+  style={{ width: 200, height: 200 }}
+/>
+
+
+// Image with custom placeholder content
+<Image
+  source={{ uri: image }}
+  style={{ width: 200, height: 200 }}
+  PlaceholderContent={<ActivityIndicator />}
+/>
+```
+
+---
+
+## Props
+
+> Also receives all
+> [Image](https://facebook.github.io/react-native/docs/image#props) props
+
+* [`containerStyle`](#containerstyle)
+* [`placeholderStyle`](#placeholderstyle)
+* [`PlaceholderContent`](#placeholdercontent)
+* [`ImageComponent`](#imagecomponent)
+
+---
+
+## Reference
+
+### `containerStyle`
+
+Additional styling for the container (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| View style (object) |  none   |
+
+---
+
+### `placeholderStyle`
+
+Additional styling for the placeholder container (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| View style (object) |  none   |
+
+---
+
+### `PlaceholderContent`
+
+Content to render when image is loading.
+
+|   Type    | Default |
+| :-------: | :-----: |
+| component |  none   |
+
+---
+
+### `ImageComponent`
+
+Specify a different component as the Image component.
+
+|          Type          | Default |
+| :--------------------: | :-----: |
+| React Native Component |  Image  |
+
+---

--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -1,0 +1,123 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Animated,
+  Image as RNImage,
+  Platform,
+  StyleSheet,
+  View,
+} from 'react-native';
+
+import { nodeType } from '../helpers';
+import { ViewPropTypes, withTheme } from '../config';
+
+class Image extends React.PureComponent {
+  placeholderContainerOpacity = new Animated.Value(1);
+
+  onLoadEnd = () => {
+    /* Images finish loading in the same frame for some reason,
+        the images will fade in separately with staggerNonce */
+    const minimumWait = 100;
+    const staggerNonce = 200 * Math.random();
+
+    setTimeout(
+      () =>
+        Animated.timing(this.placeholderContainerOpacity, {
+          toValue: 0,
+          duration: 350,
+          useNativeDriver: true,
+        }).start(),
+      minimumWait + staggerNonce
+    );
+  };
+
+  render() {
+    const {
+      placeholderStyle,
+      PlaceholderContent,
+      containerStyle,
+      style,
+      ImageComponent,
+      ...attributes
+    } = this.props;
+
+    return (
+      <View style={StyleSheet.flatten([styles.container, containerStyle])}>
+        {Platform.OS === 'ios' ? (
+          <React.Fragment>
+            <ImageComponent
+              {...attributes}
+              onLoadEnd={this.onLoadEnd}
+              style={style}
+            />
+
+            <Animated.View
+              style={StyleSheet.flatten([
+                styles.placeholderContainer,
+                { opacity: this.placeholderContainerOpacity },
+              ])}
+            >
+              <View
+                testID="RNE__Image__placeholder"
+                style={StyleSheet.flatten([
+                  style,
+                  styles.placeholder,
+                  placeholderStyle,
+                ])}
+              >
+                {PlaceholderContent}
+              </View>
+            </Animated.View>
+          </React.Fragment>
+        ) : (
+          <React.Fragment>
+            <View style={styles.placeholderContainer}>
+              <View
+                testID="RNE__Image__placeholder"
+                style={StyleSheet.flatten([
+                  style,
+                  styles.placeholder,
+                  placeholderStyle,
+                ])}
+              >
+                {PlaceholderContent}
+              </View>
+            </View>
+
+            <ImageComponent {...attributes} style={style} />
+          </React.Fragment>
+        )}
+      </View>
+    );
+  }
+}
+
+const styles = {
+  container: {
+    backgroundColor: 'transparent',
+    position: 'relative',
+  },
+  placeholderContainer: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  placeholder: {
+    backgroundColor: '#bdbdbd',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+};
+
+Image.propTypes = {
+  ...RNImage.propTypes,
+  ImageComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  PlaceholderContent: nodeType,
+  containerStyle: ViewPropTypes.style,
+  placeholderStyle: RNImage.propTypes.style,
+};
+
+Image.defaultProps = {
+  ImageComponent: RNImage,
+};
+
+export { Image };
+export default withTheme(Image, 'Image');

--- a/src/image/__tests__/Image.js
+++ b/src/image/__tests__/Image.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import { create } from 'react-test-renderer';
+
+import { ThemeProvider } from '../../config';
+import ThemedImage, { Image } from '../Image';
+
+jest.useFakeTimers();
+
+describe('Image Component', () => {
+  beforeEach(() => {
+    // useNativeDriver isn't available in jest, so just silencing the warning
+    global.console.warn = () => null;
+  });
+
+  it('should render on ios', () => {
+    const component = shallow(
+      <Image source={{ uri: 'https://i.imgur.com/0y8Ftya.jpg' }} />
+    );
+
+    component.instance().onLoadEnd();
+    jest.runOnlyPendingTimers();
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should render on android', () => {
+    jest.mock('Platform', () => ({
+      OS: 'android',
+      Version: 25,
+      select: function() {},
+    }));
+
+    const component = shallow(
+      <Image source={{ uri: 'https://i.imgur.com/0y8Ftya.jpg' }} />
+    );
+
+    component.instance().onLoadEnd();
+    jest.runOnlyPendingTimers();
+
+    expect(component.length).toBe(1);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it('should apply values from theme', () => {
+    const theme = {
+      Image: {
+        placeholderStyle: {
+          backgroundColor: 'red',
+        },
+      },
+    };
+
+    const component = create(
+      <ThemeProvider theme={theme}>
+        <ThemedImage source={{ uri: 'https://i.imgur.com/0y8Ftya.jpg' }} />
+      </ThemeProvider>
+    );
+
+    expect(
+      component.root.findByProps({ testID: 'RNE__Image__placeholder' }).props
+        .style.backgroundColor
+    ).toBe('red');
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/image/__tests__/__snapshots__/Image.js.snap
+++ b/src/image/__tests__/__snapshots__/Image.js.snap
@@ -1,0 +1,153 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Image Component should apply values from theme 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "position": "relative",
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "red",
+          "justifyContent": "center",
+        }
+      }
+      testID="RNE__Image__placeholder"
+    />
+  </View>
+  <Image
+    source={
+      Object {
+        "uri": "https://i.imgur.com/0y8Ftya.jpg",
+      }
+    }
+    theme={
+      Object {
+        "Image": Object {
+          "placeholderStyle": Object {
+            "backgroundColor": "red",
+          },
+        },
+        "colors": Object {
+          "disabled": "hsl(208, 8%, 90%)",
+          "divider": "#bcbbc1",
+          "error": "#ff190c",
+          "grey0": "#393e42",
+          "grey1": "#43484d",
+          "grey2": "#5e6977",
+          "grey3": "#86939e",
+          "grey4": "#bdc6cf",
+          "grey5": "#e1e8ee",
+          "greyOutline": "#bbb",
+          "primary": "#2089dc",
+          "searchBg": "#303337",
+          "secondary": "#8F0CE8",
+          "success": "#52c41a",
+          "warning": "#faad14",
+        },
+      }
+    }
+    updateTheme={[Function]}
+  />
+</View>
+`;
+
+exports[`Image Component should render on android 1`] = `
+<Component
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "position": "relative",
+    }
+  }
+>
+  <Component
+    style={
+      Object {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <Component
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#bdbdbd",
+          "justifyContent": "center",
+        }
+      }
+      testID="RNE__Image__placeholder"
+    />
+  </Component>
+  <Image
+    source={
+      Object {
+        "uri": "https://i.imgur.com/0y8Ftya.jpg",
+      }
+    }
+  />
+</Component>
+`;
+
+exports[`Image Component should render on ios 1`] = `
+<Component
+  style={
+    Object {
+      "backgroundColor": "transparent",
+      "position": "relative",
+    }
+  }
+>
+  <Image
+    onLoadEnd={[Function]}
+    source={
+      Object {
+        "uri": "https://i.imgur.com/0y8Ftya.jpg",
+      }
+    }
+  />
+  <AnimatedComponent
+    style={
+      Object {
+        "bottom": 0,
+        "left": 0,
+        "opacity": 1,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <Component
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#bdbdbd",
+          "justifyContent": "center",
+        }
+      }
+      testID="RNE__Image__placeholder"
+    />
+  </AnimatedComponent>
+</Component>
+`;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1557,7 +1557,7 @@ export interface SliderProps {
 
   /**
    * Choose the orientation
-   * 
+   *
    * @default horizontal
    */
   orientation?: 'horizontal' | 'vertical';
@@ -1909,6 +1909,35 @@ export interface TileProps {
  */
 export class Tile extends React.Component<TileProps, any> {}
 
+export interface ImageProps extends ImageProperties {
+  /**
+   * Specify a different component as the Image component.
+   *
+   * @default Image
+   */
+  ImageComponent?: React.ComponentClass<any>;
+
+  /**
+   * Content to render when image is loading
+   */
+  PlaceholderContent?: React.ComponentType<any>;
+
+  /**
+   * Additional styling for the container
+   */
+  containerStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * Additional styling for the placeholder container
+   */
+  placeholderStyle?: StyleProp<ViewStyle>;
+}
+
+/**
+ * Image component
+ */
+export class Image extends React.Component<ImageProps> {}
+
 /**
  * Colors
  */
@@ -1962,6 +1991,7 @@ export interface FullTheme {
   Divider: Partial<DividerProps>;
   Header: Partial<HeaderProps>;
   Icon: Partial<IconProps>;
+  Image: Partial<ImageProps>;
   Input: Partial<InputProps>;
   ListItem: Partial<ListItemProps>;
   Overlay: Partial<OverlayProps>;

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import CheckBox from './checkbox/CheckBox';
 import Divider from './divider/Divider';
 import Slider from './slider/Slider';
 import ButtonGroup from './buttons/ButtonGroup';
+import Image from './image/Image';
 
 // Productivity
 import Card from './card/Card';
@@ -63,4 +64,5 @@ export {
   ThemeProvider,
   ThemeConsumer,
   withTheme,
+  Image,
 };

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -45,6 +45,9 @@
       "icon": {
         "title": "Icon"
       },
+      "image": {
+        "title": "Image"
+      },
       "input": {
         "title": "Input"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -16,6 +16,7 @@
       "divider",
       "header",
       "icon",
+      "image",
       "input",
       "listitem",
       "overlay",

--- a/website/static/css/components.css
+++ b/website/static/css/components.css
@@ -16,7 +16,11 @@
 }
 
 @media (min-width: 500px) {
-  .component-preview {
+  .component-preview:not(.component-preview--single) {
     grid-template-columns: 1fr 1fr 1fr;
   }
+}
+
+.margin-none {
+  margin: 0;
 }


### PR DESCRIPTION
Implements #1478 

## Motivation
Adds Image component that has support for placeholders. Basically takes out the FadeInImage component that @martinezguillaume wrote in https://github.com/react-native-training/react-native-elements/commit/f8af41c1959625c1d3679a88ad9437059abe39aa and splits it into it's own component.

A follow-up PR will let the Avatar component use this.

## API
```js
import { ActivityIndicator } from 'react-native';
import { Image } from 'react-native-elements';

// Standard Image
<Image
  source={{ uri: image }}
  style={{ width: 200, height: 200 }}
/>


// Image with custom placeholder content
<Image
  source={{ uri: image }}
  style={{ width: 200, height: 200 }}
  PlaceholderContent={<ActivityIndicator />}
/>
```

## Screenshots
![img](https://user-images.githubusercontent.com/5962998/48658581-f4170a00-ea1a-11e8-866c-df4f42f21947.gif)

