### PR TITLE
feat(Overlay): Support RNW with iOS style as default

### DIFF
--- a/src/overlay/Overlay.js
+++ b/src/overlay/Overlay.js
@@ -104,13 +104,13 @@ const styles = StyleSheet.create({
     borderRadius: 5,
     padding: 10,
     ...Platform.select({
-      ios: {
+      android: {
+        elevation: 2,
+      },
+      default: {
         shadowColor: 'rgba(0, 0, 0, .3)',
         shadowOffset: { width: 0, height: 1 },
         shadowRadius: 4,
-      },
-      android: {
-        elevation: 2,
       },
     }),
   },


### PR DESCRIPTION
Currently there is no consistent style applied to components for `react-native-web` (platform `web`), electron (platform `desktop`) and all others expect `ios` and `android`.

`react-native` supports the platform `default` which means it takes the value default if its not overridden by a specific platform.

This PR sets iOS as default style for `Overlay`.