### PR TITLE
feat(SocialIcon): Support RNW with iOS style as default

### DIFF
--- a/src/social/SocialIcon.js
+++ b/src/social/SocialIcon.js
@@ -183,14 +183,14 @@ const styles = StyleSheet.create({
   },
   raised: {
     ...Platform.select({
-      ios: {
+      android: {
+        elevation: 2,
+      },
+      default: {
         shadowColor: 'rgba(0,0,0, .4)',
         shadowOffset: { height: 1, width: 1 },
         shadowOpacity: 1,
         shadowRadius: 1,
-      },
-      android: {
-        elevation: 2,
       },
     }),
   },
@@ -203,11 +203,11 @@ const styles = StyleSheet.create({
     color: 'white',
     marginLeft: 15,
     ...Platform.select({
-      ios: {
-        fontWeight: 'bold',
-      },
       android: {
         ...fonts.android.black,
+      },
+      default: {
+        fontWeight: 'bold',
       },
     }),
   },


### PR DESCRIPTION
Currently there is no consistent style applied to components for `react-native-web` (platform `web`), electron (platform `desktop`) and all others expect `ios` and `android`.

`react-native` supports the platform `default` which means it takes the value default if its not overridden by a specific platform.

This PR sets iOS as default style for `SocialIcon`.