### PR TITLE
feat(Button&ButtonGroup): Support RNW with iOS style as default

### DIFF
--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -181,8 +181,10 @@ Button.propTypes = {
 Button.defaultProps = {
   title: '',
   iconRight: false,
-  TouchableComponent:
-    Platform.OS === 'android' ? TouchableNativeFeedback : TouchableOpacity,
+  TouchableComponent: Platform.select({
+    android: TouchableNativeFeedback,
+    default: TouchableOpacity,
+  }),
   onPress: () => console.log('Please attach a method to this component'),
   type: 'solid',
   buttonStyle: {
@@ -225,11 +227,11 @@ const styles = {
     paddingTop: 2,
     paddingBottom: 1,
     ...Platform.select({
-      ios: {
-        fontSize: 18,
-      },
       android: {
         fontFamily: 'sans-serif-medium',
+      },
+      default: {
+        fontSize: 18,
       },
     }),
   }),
@@ -240,14 +242,14 @@ const styles = {
     type !== 'clear' && {
       backgroundColor: '#fff',
       ...Platform.select({
-        ios: {
+        android: {
+          elevation: 4,
+        },
+        default: {
           shadowColor: 'rgba(0,0,0, .4)',
           shadowOffset: { height: 1, width: 1 },
           shadowOpacity: 1,
           shadowRadius: 1,
-        },
-        android: {
-          elevation: 4,
         },
       }),
     },

--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -183,7 +183,8 @@ const styles = {
     fontSize: normalizeText(13),
     color: theme.colors.grey2,
     ...Platform.select({
-      ios: {
+      android: {},
+      default: {
         fontWeight: '500',
       },
     }),
@@ -242,7 +243,10 @@ ButtonGroup.defaultProps = {
   selectMultiple: false,
   containerBorderRadius: 3,
   disabled: false,
-  Component: Platform.OS === 'ios' ? TouchableOpacity : TouchableNativeFeedback,
+  Component: Platform.select({
+    android: TouchableNativeFeedback,
+    default: TouchableOpacity,
+  }),
   onPress: () => null,
 };
 


### PR DESCRIPTION
Currently there is no consistent style applied to components for `react-native-web` (platform `web`), electron (platform `desktop`) and all others expect `ios` and `android`.

`react-native` supports the platform `default` which means it takes the value default if its not overridden by a specific platform.

This PR sets iOS as default style for `Button` and `ButtonGroup`.