### PR TITLE
feat(Header): Support RNW with iOS style as default

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lodash.times": "^4.3.2",
     "opencollective-postinstall": "^2.0.0",
     "prop-types": "^15.5.8",
-    "react-native-status-bar-height": "^2.1.0"
+    "react-native-status-bar-height": "^2.2.0"
   },
   "devDependencies": {
     "@types/react": "^16.4.16",

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -83,7 +83,10 @@ const Header = ({
       style={StyleSheet.flatten([
         styles.centerContainer,
         placement !== 'center' && {
-          paddingHorizontal: Platform.OS === 'ios' ? 15 : 16,
+          paddingHorizontal: Platform.select({
+            android: 16,
+            default: 15,
+          }),
         },
         centerContainerStyle,
       ])}
@@ -138,7 +141,10 @@ const styles = {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    height: (Platform.OS === 'ios' ? 44 : 56) + getStatusBarHeight(),
+    height: (Platform.select({
+      android: 56,
+      default: 44
+    })) + getStatusBarHeight(),
   }),
   centerContainer: {
     flex: 3,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8290,10 +8290,10 @@ react-is@^16.6.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.0.tgz#456645144581a6e99f6816ae2bd24ee94bdd0c01"
   integrity sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g==
 
-react-native-status-bar-height@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-status-bar-height/-/react-native-status-bar-height-2.1.0.tgz#cb70fcdbb8dfdf0b9140d77625d27e4ea32fd7f4"
-  integrity sha512-bkI12izmSaNjYDoPh/6MYQtxcpd3QnQn5/bvE8Rzk93DeyJas4d7QIbIoHf9PL1GUPXwvNW3ooH8WuB4fpSQ6w==
+react-native-status-bar-height@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-status-bar-height/-/react-native-status-bar-height-2.2.0.tgz#3bd51de134660efc5f5ad136ca573c7d5790f7ed"
+  integrity sha512-4WJpyZirzeMHyZiyNEy4LnSPOtuLRVy3+28Rhz7ffrjCVcc5RFcC0HVjFnkwfuhcTyXIDtzPG6canJkXzbTtBA==
 
 react-native-vector-icons@^6.0.2:
   version "6.0.2"


### PR DESCRIPTION
Currently there is no consistent style applied to components for `react-native-web` (platform `web`), electron (platform `desktop`) and all others expect `ios` and `android`.

`react-native` supports the platform `default` which means it takes the value default if its not overridden by a specific platform.

This PR sets iOS as default style for `Header`. (44px header size looks nice)