### PR TITLE
feat(Image): Support RNW with iOS style as default 

### DIFF
--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -43,61 +43,64 @@ class Image extends React.PureComponent {
 
     return (
       <View style={StyleSheet.flatten([styles.container, containerStyle])}>
-        {Platform.OS === 'ios' ? (
-          <React.Fragment>
-            <ImageComponent
-              {...attributes}
-              onLoadEnd={this.onLoadEnd}
-              style={style}
-            />
-
-            <Animated.View
-              style={StyleSheet.flatten([
-                styles.placeholderContainer,
-                { opacity: this.placeholderContainerOpacity },
-              ])}
-            >
-              <View
-                testID="RNE__Image__placeholder"
-                style={StyleSheet.flatten([
-                  style,
-                  styles.placeholder,
-                  placeholderStyle,
-                ])}
-              >
-                {PlaceholderContent}
+        {Platform.select({
+          android: (
+            <React.Fragment>
+              <View style={styles.placeholderContainer}>
+                <Animated.View
+                  testID="RNE__Image__placeholder"
+                  style={StyleSheet.flatten([
+                    style,
+                    styles.placeholder,
+                    {
+                      backgroundColor: this.placeholderContainerOpacity.interpolate(
+                        {
+                          inputRange: [0, 1],
+                          outputRange: [
+                            styles.placeholder.backgroundColor,
+                            'transparent',
+                          ],
+                        }
+                      ),
+                    },
+                    placeholderStyle,
+                  ])}
+                >
+                  {PlaceholderContent}
+                </Animated.View>
               </View>
-            </Animated.View>
-          </React.Fragment>
-        ) : (
-          <React.Fragment>
-            <View style={styles.placeholderContainer}>
+
+              <ImageComponent {...attributes} style={style} />
+            </React.Fragment>
+          ),
+          default: (
+            <React.Fragment>
+              <ImageComponent
+                {...attributes}
+                onLoadEnd={this.onLoadEnd}
+                style={style}
+              />
+
               <Animated.View
-                testID="RNE__Image__placeholder"
                 style={StyleSheet.flatten([
-                  style,
-                  styles.placeholder,
-                  {
-                    backgroundColor: this.placeholderContainerOpacity.interpolate(
-                      {
-                        inputRange: [0, 1],
-                        outputRange: [
-                          styles.placeholder.backgroundColor,
-                          'transparent',
-                        ],
-                      }
-                    ),
-                  },
-                  placeholderStyle,
+                  styles.placeholderContainer,
+                  { opacity: this.placeholderContainerOpacity },
                 ])}
               >
-                {PlaceholderContent}
+                <View
+                  testID="RNE__Image__placeholder"
+                  style={StyleSheet.flatten([
+                    style,
+                    styles.placeholder,
+                    placeholderStyle,
+                  ])}
+                >
+                  {PlaceholderContent}
+                </View>
               </Animated.View>
-            </View>
-
-            <ImageComponent {...attributes} style={style} />
-          </React.Fragment>
-        )}
+            </React.Fragment>
+          ),
+        })}
       </View>
     );
   }

--- a/src/image/__tests__/Image.js
+++ b/src/image/__tests__/Image.js
@@ -30,7 +30,9 @@ describe('Image Component', () => {
     jest.mock('Platform', () => ({
       OS: 'android',
       Version: 25,
-      select: function() {},
+      select: function(obj) {
+        return obj.android;
+      },
     }));
 
     const component = shallow(


### PR DESCRIPTION
Currently there is no consistent style applied to components for react-native-web (platform web), electron (platform desktop) and all others expect ios and android.

react-native supports the platform default which means it takes the value default if its not overridden by a specific platform.

This PR sets iOS as default style for Image.

This fixed the currently not working fade in animation.