### PR TITLE
feat(config/fonts): Support RNW with empty defailt fonts

### DIFF
--- a/src/config/fonts.js
+++ b/src/config/fonts.js
@@ -1,5 +1,4 @@
 export default {
-  ios: {},
   android: {
     regular: {
       fontFamily: 'sans-serif',
@@ -31,4 +30,5 @@ export default {
       fontWeight: 'bold',
     },
   },
+  default: {},
 };


### PR DESCRIPTION
This PR fixed possible null pointers for platforms other than `android` and `ios`. It returns an empty object as default fonts value.