### PR TITLE
fix(SearchBar): Switch from material-community to material

### DIFF
--- a/src/searchbar/SearchBar-android.js
+++ b/src/searchbar/SearchBar-android.js
@@ -18,24 +18,24 @@ const SCREEN_WIDTH = Dimensions.get('window').width;
 const ANDROID_GRAY = 'rgba(0, 0, 0, 0.54)';
 
 const defaultSearchIcon = {
-  type: 'material-community',
+  type: 'material',
   size: 25,
   color: ANDROID_GRAY,
-  name: 'magnify',
+  name: 'search',
 };
 
 const defaultCancelIcon = {
-  type: 'material-community',
+  type: 'material',
   size: 25,
   color: ANDROID_GRAY,
-  name: 'arrow-left',
+  name: 'arrow-back',
 };
 
 const defaultClearIcon = {
-  type: 'material-community',
-  name: 'close',
+  type: 'material',
   size: 25,
   color: ANDROID_GRAY,
+  name: 'clear',
 };
 
 class SearchBar extends Component {

--- a/src/searchbar/SearchBar-default.js
+++ b/src/searchbar/SearchBar-default.js
@@ -9,16 +9,16 @@ import Input from '../input/Input';
 import Icon from '../icons/Icon';
 
 const defaultSearchIcon = theme => ({
-  type: 'material-community',
+  type: 'material',
   size: 18,
-  name: 'magnify',
+  name: 'search',
   color: theme.colors.grey3,
 });
 
 const defaultClearIcon = theme => ({
-  type: 'material-community',
+  type: 'material',
   size: 18,
-  name: 'close',
+  name: 'clear',
   color: theme.colors.grey3,
 });
 

--- a/src/searchbar/__tests__/__snapshots__/SearchBar-android.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar-android.js.snap
@@ -27,9 +27,9 @@ exports[`Android SearchBar component should render with a custom cancel icon 1`]
     leftIcon={
       <Themed.Icon
         color="rgba(0, 0, 0, 0.54)"
-        name="magnify"
+        name="search"
         size={25}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={
@@ -110,9 +110,9 @@ exports[`Android SearchBar component should render with a custom cancel icon com
     leftIcon={
       <Themed.Icon
         color="rgba(0, 0, 0, 0.54)"
-        name="magnify"
+        name="search"
         size={25}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={
@@ -193,9 +193,9 @@ exports[`Android SearchBar component should render with a custom clear icon 1`] 
     leftIcon={
       <Themed.Icon
         color="rgba(0, 0, 0, 0.54)"
-        name="magnify"
+        name="search"
         size={25}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={
@@ -276,9 +276,9 @@ exports[`Android SearchBar component should render with a custom clear icon comp
     leftIcon={
       <Themed.Icon
         color="rgba(0, 0, 0, 0.54)"
-        name="magnify"
+        name="search"
         size={25}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={
@@ -359,9 +359,9 @@ exports[`Android SearchBar component should render with a custom methods 1`] = `
     leftIcon={
       <Themed.Icon
         color="rgba(0, 0, 0, 0.54)"
-        name="magnify"
+        name="search"
         size={25}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={
@@ -442,9 +442,9 @@ exports[`Android SearchBar component should render with a custom search icon 1`]
     leftIcon={
       <Themed.Icon
         color="rgba(0, 0, 0, 0.54)"
-        name="magnify"
+        name="search"
         size={50}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={
@@ -601,9 +601,9 @@ exports[`Android SearchBar component should render with loading 1`] = `
     leftIcon={
       <Themed.Icon
         color="rgba(0, 0, 0, 0.54)"
-        name="magnify"
+        name="search"
         size={25}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={
@@ -697,9 +697,9 @@ exports[`Android SearchBar component should render without cancel icon 1`] = `
     leftIcon={
       <Themed.Icon
         color="rgba(0, 0, 0, 0.54)"
-        name="magnify"
+        name="search"
         size={25}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={
@@ -780,9 +780,9 @@ exports[`Android SearchBar component should render without clear icon 1`] = `
     leftIcon={
       <Themed.Icon
         color="rgba(0, 0, 0, 0.54)"
-        name="magnify"
+        name="search"
         size={25}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={
@@ -863,9 +863,9 @@ exports[`Android SearchBar component should render without issues 1`] = `
     leftIcon={
       <Themed.Icon
         color="rgba(0, 0, 0, 0.54)"
-        name="magnify"
+        name="search"
         size={25}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={

--- a/src/searchbar/__tests__/__snapshots__/SearchBar-default.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar-default.js.snap
@@ -36,9 +36,9 @@ exports[`Default SearchBar component should render with a custom clear icon 1`] 
     leftIcon={
       <Themed.Icon
         color="#86939e"
-        name="magnify"
+        name="search"
         size={18}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={
@@ -105,9 +105,9 @@ exports[`Default SearchBar component should render with a custom clear icon comp
     leftIcon={
       <Themed.Icon
         color="#86939e"
-        name="magnify"
+        name="search"
         size={18}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={
@@ -174,9 +174,9 @@ exports[`Default SearchBar component should render with a custom methods 1`] = `
     leftIcon={
       <Themed.Icon
         color="#86939e"
-        name="magnify"
+        name="search"
         size={18}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={
@@ -243,9 +243,9 @@ exports[`Default SearchBar component should render with a custom search icon 1`]
     leftIcon={
       <Themed.Icon
         color="#86939e"
-        name="magnify"
+        name="search"
         size={50}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={
@@ -375,9 +375,9 @@ exports[`Default SearchBar component should render with icons 1`] = `
     leftIcon={
       <Themed.Icon
         color="#86939e"
-        name="magnify"
+        name="search"
         size={18}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={
@@ -457,9 +457,9 @@ exports[`Default SearchBar component should render without clear icon 1`] = `
     leftIcon={
       <Themed.Icon
         color="#86939e"
-        name="magnify"
+        name="search"
         size={18}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={
@@ -526,9 +526,9 @@ exports[`Default SearchBar component should render without issues 1`] = `
     leftIcon={
       <Themed.Icon
         color="#86939e"
-        name="magnify"
+        name="search"
         size={18}
-        type="material-community"
+        type="material"
       />
     }
     leftIconContainerStyle={

--- a/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
@@ -94,7 +94,7 @@ exports[`SearchBar wrapper component should apply values from theme 1`] = `
                     "backgroundColor": "transparent",
                   },
                   Object {
-                    "fontFamily": "Material Design Icons",
+                    "fontFamily": "Material Icons",
                     "fontStyle": "normal",
                     "fontWeight": "normal",
                   },
@@ -103,7 +103,7 @@ exports[`SearchBar wrapper component should apply values from theme 1`] = `
               }
               testID="iconIcon"
             >
-              
+              
             </Text>
           </View>
         </View>
@@ -177,17 +177,17 @@ exports[`SearchBar wrapper component should render an Android SearchBar 1`] = `
   cancelIcon={
     Object {
       "color": "rgba(0, 0, 0, 0.54)",
-      "name": "arrow-left",
+      "name": "arrow-back",
       "size": 25,
-      "type": "material-community",
+      "type": "material",
     }
   }
   clearIcon={
     Object {
       "color": "rgba(0, 0, 0, 0.54)",
-      "name": "close",
+      "name": "clear",
       "size": 25,
-      "type": "material-community",
+      "type": "material",
     }
   }
   loadingProps={Object {}}
@@ -200,9 +200,9 @@ exports[`SearchBar wrapper component should render an Android SearchBar 1`] = `
   searchIcon={
     Object {
       "color": "rgba(0, 0, 0, 0.54)",
-      "name": "magnify",
+      "name": "search",
       "size": 25,
-      "type": "material-community",
+      "type": "material",
     }
   }
   showLoading={false}


### PR DESCRIPTION
This PR changes the `SearchBar` icons from `material-community` to `material`.

The default icon is `material`. We should use it here too, so RNW does not have to load two fonts just because the `SearchBar` uses another one than the default.

This increases the performance of the app and needs less network traffic, because only one font is needed by default.

Question: Do we need it and should we change it in SearchBar.android too?