### PR TITLE
Remove unnecessary props from Card

### DIFF
--- a/docs/card.md
+++ b/docs/card.md
@@ -83,7 +83,6 @@ import { Card, ListItem, Button, Icon } from 'react-native-elements'
 - [`featuredSubtitleStyle`](#featuredsubtitlestyle)
 - [`featuredTitle`](#featuredtitle)
 - [`featuredTitleStyle`](#featuredtitlestyle)
-- [`flexDirection`](#flexdirection)
 - [`image`](#image)
 - [`imageProps`](#imageprops)
 - [`imageStyle`](#imagestyle)
@@ -154,16 +153,6 @@ styling for featured title
 |      Type      | Default |
 | :------------: | :-----: |
 | object (style) |  none   |
-
----
-
-### `flexDirection`
-
-flex direction (row or column) (optional)
-
-|  Type  | Default |
-| :----: | :-----: |
-| string | column  |
 
 ---
 

--- a/docs/card.md
+++ b/docs/card.md
@@ -84,7 +84,6 @@ import { Card, ListItem, Button, Icon } from 'react-native-elements'
 - [`featuredTitle`](#featuredtitle)
 - [`featuredTitleStyle`](#featuredtitlestyle)
 - [`flexDirection`](#flexdirection)
-- [`fontFamily`](#fontfamily)
 - [`image`](#image)
 - [`imageProps`](#imageprops)
 - [`imageStyle`](#imagestyle)
@@ -165,16 +164,6 @@ flex direction (row or column) (optional)
 |  Type  | Default |
 | :----: | :-----: |
 | string | column  |
-
----
-
-### `fontFamily`
-
-specify different font family
-
-|  Type  |                      Default                      |
-| :----: | :-----------------------------------------------: |
-| string | System font bold (iOS), Sans Serif Bold (android) |
 
 ---
 

--- a/src/card/Card.js
+++ b/src/card/Card.js
@@ -31,7 +31,6 @@ const Card = props => {
     dividerStyle,
     image,
     imageStyle,
-    fontFamily,
     imageProps,
     theme,
     ...attributes
@@ -64,12 +63,12 @@ const Card = props => {
                     styles.cardTitle(theme),
                     image && styles.imageCardTitle,
                     titleStyle && titleStyle,
-                    fontFamily && { fontFamily },
                   ])}
                   numberOfLines={titleNumberOfLines}
                 >
                   {title}
                 </Text>
+
                 {!image && (
                   <Divider
                     style={StyleSheet.flatten([
@@ -80,6 +79,7 @@ const Card = props => {
                 )}
               </View>
             )}
+
         {image && (
           <View style={imageWrapperStyle && imageWrapperStyle}>
             <BackgroundImage
@@ -112,6 +112,7 @@ const Card = props => {
                 </View>
               )}
             </BackgroundImage>
+
             <View
               style={StyleSheet.flatten([
                 { padding: 10 },
@@ -122,6 +123,7 @@ const Card = props => {
             </View>
           </View>
         )}
+
         {!image && children}
       </View>
     </View>
@@ -147,7 +149,6 @@ Card.propTypes = {
   image: Image.propTypes.source,
   imageStyle: ViewPropTypes.style,
   imageWrapperStyle: ViewPropTypes.style,
-  fontFamily: PropTypes.string,
   imageProps: PropTypes.object,
   titleNumberOfLines: PropTypes.number,
   theme: PropTypes.object,

--- a/src/card/Card.js
+++ b/src/card/Card.js
@@ -17,7 +17,6 @@ import Divider from '../divider/Divider';
 const Card = props => {
   const {
     children,
-    flexDirection,
     containerStyle,
     wrapperStyle,
     imageWrapperStyle,
@@ -49,7 +48,6 @@ const Card = props => {
         style={StyleSheet.flatten([
           styles.wrapper,
           wrapperStyle && wrapperStyle,
-          flexDirection && { flexDirection },
         ])}
       >
         {title === '' || React.isValidElement(title)
@@ -135,7 +133,6 @@ Card.propTypes = {
     PropTypes.element,
     PropTypes.arrayOf(PropTypes.element),
   ]),
-  flexDirection: PropTypes.string,
   containerStyle: ViewPropTypes.style,
   wrapperStyle: ViewPropTypes.style,
   overlayStyle: ViewPropTypes.style,

--- a/src/card/__tests__/Card.js
+++ b/src/card/__tests__/Card.js
@@ -23,7 +23,6 @@ describe('Card Component', () => {
         theme={theme}
         title="Card Title"
         containerStyle={{ backgroundColor: 'red' }}
-        fontFamily="arial"
         dividerStyle={{ backgroundColor: 'red' }}
         flexDirection="row"
       />
@@ -44,7 +43,6 @@ describe('Card Component', () => {
         }}
         containerStyle={{ backgroundColor: 'red' }}
         titleStyle={{ backgroundColor: 'red' }}
-        fontFamily="arial"
       />
     );
 

--- a/src/card/__tests__/Card.js
+++ b/src/card/__tests__/Card.js
@@ -24,7 +24,6 @@ describe('Card Component', () => {
         title="Card Title"
         containerStyle={{ backgroundColor: 'red' }}
         dividerStyle={{ backgroundColor: 'red' }}
-        flexDirection="row"
       />
     );
 

--- a/src/card/__tests__/__snapshots__/Card.js.snap
+++ b/src/card/__tests__/__snapshots__/Card.js.snap
@@ -199,7 +199,6 @@ exports[`Card Component should have Card title without image 1`] = `
     style={
       Object {
         "backgroundColor": "transparent",
-        "flexDirection": "row",
       }
     }
   >

--- a/src/card/__tests__/__snapshots__/Card.js.snap
+++ b/src/card/__tests__/__snapshots__/Card.js.snap
@@ -134,7 +134,6 @@ exports[`Card Component should have Card title with image 1`] = `
           Object {
             "backgroundColor": "red",
             "color": "#43484d",
-            "fontFamily": "arial",
             "fontSize": 17.5,
             "fontWeight": "bold",
             "marginBottom": 15,
@@ -209,7 +208,6 @@ exports[`Card Component should have Card title without image 1`] = `
         style={
           Object {
             "color": "#43484d",
-            "fontFamily": "arial",
             "fontSize": 17.5,
             "fontWeight": "bold",
             "marginBottom": 15,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -468,13 +468,6 @@ export interface CardProps {
   dividerStyle?: StyleProp<ViewStyle>;
 
   /**
-   * Specify different font family
-   *
-   * @default System font bold (iOS), Sans Serif Bold (android)
-   */
-  fontFamily?: string;
-
-  /**
    * Specify image styling if image is provided
    */
   imageStyle?: ImageStyle;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -413,13 +413,6 @@ export function withBadge(
 
 export interface CardProps {
   /**
-   * Flex direction (row or column)
-   *
-   * @default 'column'
-   */
-  flexDirection?: 'column' | 'row';
-
-  /**
    * Outer container style
    */
   containerStyle?: StyleProp<ViewStyle>;
@@ -492,7 +485,7 @@ export interface CardProps {
  * Card component
  *
  */
-export class Card extends React.Component<CardProps, any> {}
+export class Card extends React.Component<CardProps> {}
 
 /**
  * Set the buttons within a Group.


### PR DESCRIPTION
Deprecates two props:
`fontFamily` - Can be set through `titleStyle`
`flexDirection` - Can be set through `wrapperStyle`