### PR TITLE
refactor(Text): Deprecate fontFamily prop

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -20,7 +20,6 @@ Text displays words and characters at various sizes.
 
 ## Props
 
-- [`fontFamily`](#fontfamily)
 - [`h1`](#h1)
 - [`h2`](#h2)
 - [`h3`](#h3)
@@ -30,16 +29,6 @@ Text displays words and characters at various sizes.
 ---
 
 ## Reference
-
-### `fontFamily`
-
-font family name (optional)
-
-|  Type  | Default |
-| :----: | :-----: |
-| string |  none   |
-
----
 
 ### `h1`
 
@@ -85,6 +74,6 @@ font size 22 (optional)
 
 add additional styling for Text (optional)
 
-|      Type      | Default |
-| :------------: | :-----: |
-| object (style) |  none   |
+|        Type         | Default |
+| :-----------------: | :-----: |
+| Text style (object) |  none   |

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -72,11 +72,6 @@ export interface TextProps extends TextProperties {
   h4?: boolean;
 
   /**
-   * font family name
-   */
-  fontFamily?: string;
-
-  /**
    * Additional styling for Text
    */
   style?: StyleProp<TextStyle>;

--- a/src/text/Text.js
+++ b/src/text/Text.js
@@ -20,7 +20,6 @@ const TextElement = props => {
         h2 && styles.bold,
         h3 && styles.bold,
         h4 && styles.bold,
-        fontFamily && { fontFamily },
         style && style,
       ])}
       {...rest}
@@ -36,7 +35,6 @@ TextElement.propTypes = {
   h2: PropTypes.bool,
   h3: PropTypes.bool,
   h4: PropTypes.bool,
-  fontFamily: PropTypes.string,
   children: PropTypes.node,
 };
 
@@ -46,7 +44,6 @@ TextElement.defaultProps = {
   h3: false,
   h4: false,
   style: {},
-  fontFamily: null,
 };
 
 const styles = StyleSheet.create({

--- a/src/text/__tests__/Text.js
+++ b/src/text/__tests__/Text.js
@@ -48,17 +48,6 @@ describe('Text Component', () => {
     expect(component.props().children).toBe('Children Text');
   });
 
-  it('should render fontFamily and style', () => {
-    const component = shallow(
-      <Text fontFamily="comic-sans" style={{ color: 'red' }}>
-        Children Text
-      </Text>
-    );
-
-    expect(component.length).toBe(1);
-    expect(toJson(component)).toMatchSnapshot();
-  });
-
   it('should use values from the theme', () => {
     const theme = {
       Text: {

--- a/src/text/__tests__/__snapshots__/Text.js.snap
+++ b/src/text/__tests__/__snapshots__/Text.js.snap
@@ -1,21 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Text Component should render fontFamily and style 1`] = `
-<Text
-  accessible={true}
-  allowFontScaling={true}
-  ellipsizeMode="tail"
-  style={
-    Object {
-      "color": "red",
-      "fontFamily": "comic-sans",
-    }
-  }
->
-  Children Text
-</Text>
-`;
-
 exports[`Text Component should render without issues 1`] = `
 <Text
   accessible={true}


### PR DESCRIPTION
BREAKING CHANGE:
Prop is redundant and can be set through the style prop.

Also if using a custom font, this probably won't work as they'll have to set font-weight:400 for it to show so they'll end up using the `style` prop anyway.