### PR TITLE
fix(Text): Allow local props to override theme set font size

### DIFF
--- a/src/text/Text.js
+++ b/src/text/Text.js
@@ -12,6 +12,7 @@ const TextElement = props => {
     <Text
       style={StyleSheet.flatten([
         styles.text,
+        style && style,
         h1 && { fontSize: normalize(40) },
         h2 && { fontSize: normalize(34) },
         h3 && { fontSize: normalize(28) },
@@ -20,7 +21,6 @@ const TextElement = props => {
         h2 && styles.bold,
         h3 && styles.bold,
         h4 && styles.bold,
-        style && style,
       ])}
       {...rest}
     >

--- a/src/text/__tests__/Text.js
+++ b/src/text/__tests__/Text.js
@@ -66,4 +66,26 @@ describe('Text Component', () => {
     );
     expect(component.toJSON()).toMatchSnapshot();
   });
+
+  it('local props should override style props on theme', () => {
+    const theme = {
+      Text: {
+        style: {
+          fontSize: 14,
+        },
+      },
+    };
+
+    const component = renderer.create(
+      <ThemeProvider theme={theme}>
+        <TextThemed h2>Hey</TextThemed>
+      </ThemeProvider>
+    );
+
+    expect(
+      component.root.findByType(TextThemed).children[0].children[0].props.style
+        .fontSize
+    ).toBe(42.5);
+    expect(component.toJSON()).toMatchSnapshot();
+  });
 });

--- a/src/text/__tests__/__snapshots__/Text.js.snap
+++ b/src/text/__tests__/__snapshots__/Text.js.snap
@@ -1,5 +1,63 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Text Component local props should override style props on theme 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  style={
+    Object {
+      "fontSize": 42.5,
+    }
+  }
+  theme={
+    Object {
+      "Text": Object {
+        "style": Object {
+          "fontSize": 14,
+        },
+      },
+      "colors": Object {
+        "disabled": "hsl(208, 8%, 90%)",
+        "divider": "#bcbbc1",
+        "error": "#ff190c",
+        "grey0": "#393e42",
+        "grey1": "#43484d",
+        "grey2": "#5e6977",
+        "grey3": "#86939e",
+        "grey4": "#bdc6cf",
+        "grey5": "#e1e8ee",
+        "greyOutline": "#bbb",
+        "platform": Object {
+          "android": Object {
+            "error": "#f44336",
+            "primary": "#2196f3",
+            "secondary": "#9C27B0",
+            "success": "#4caf50",
+            "warning": "#ffeb3b",
+          },
+          "ios": Object {
+            "error": "#ff3b30",
+            "primary": "#007aff",
+            "secondary": "#5856d6",
+            "success": "#4cd964",
+            "warning": "#ffcc00",
+          },
+        },
+        "primary": "#2089dc",
+        "searchBg": "#303337",
+        "secondary": "#8F0CE8",
+        "success": "#52c41a",
+        "warning": "#faad14",
+      },
+    }
+  }
+  updateTheme={[Function]}
+>
+  Hey
+</Text>
+`;
+
 exports[`Text Component should render without issues 1`] = `
 <Text
   accessible={true}


### PR DESCRIPTION
Props like h1, h2 not working if the the font size in the theme was set.
This is because of the order in which the styles were applied. To fix
this we should apply the style prop first then the other props like h1,
h2 etc.

Closes #1663