### PR TITLE
Fix type of Input's inputComponent.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -748,7 +748,7 @@ export interface InputProps extends TextInputProperties {
   /**
    * Renders component in place of the React Native `TextInput` (optional)
    */
-  inputComponent?: React.ComponentClass<any>;
+  inputComponent?: React.ComponentType<any>;
 
   /**
    * 	Adds styling to input component (optional)


### PR DESCRIPTION
This was React.ComponentClass, but should be React.ComponentType given
how it's used.