### PR TITLE
fix(types): Fix ListItem checkBox props typo

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1122,7 +1122,7 @@ export interface ListItemProps {
   switch?: SwitchProperties;
   input?: InputProps;
   buttonGroup?: ButtonGroupProps;
-  checkbox?: CheckBoxProps;
+  checkBox?: CheckBoxProps;
   badge?: BadgeProps;
   disabled?: boolean;
   disabledStyle?: StyleProp<ViewStyle>;


### PR DESCRIPTION
`ListItem`'s `checkBox` props in `index.d.ts` is misspelled. It should be [`checkBox`](https://github.com/react-native-training/react-native-elements/blob/master/src/list/ListItem.js#L332) not [`checkbox`](https://github.com/react-native-training/react-native-elements/blob/master/src/index.d.ts#L1049).