### PR TITLE
fix(SearchBar Android): Allow margins to be added to containerStyle

### DIFF
--- a/src/searchbar/SearchBar-android.js
+++ b/src/searchbar/SearchBar-android.js
@@ -1,12 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import {
-  Dimensions,
-  StyleSheet,
-  View,
-  ActivityIndicator,
-  Text,
-} from 'react-native';
+import { StyleSheet, View, ActivityIndicator, Text } from 'react-native';
 
 import { ViewPropTypes } from '../config';
 import { nodeType, renderNode } from '../helpers';
@@ -14,7 +8,6 @@ import { nodeType, renderNode } from '../helpers';
 import Input from '../input/Input';
 import Icon from '../icons/Icon';
 
-const SCREEN_WIDTH = Dimensions.get('window').width;
 const ANDROID_GRAY = 'rgba(0, 0, 0, 0.54)';
 
 const defaultSearchIcon = {
@@ -191,7 +184,6 @@ SearchBar.defaultProps = {
 const styles = StyleSheet.create({
   container: {
     backgroundColor: 'white',
-    width: SCREEN_WIDTH,
     paddingTop: 8,
     paddingBottom: 8,
   },
@@ -201,7 +193,7 @@ const styles = StyleSheet.create({
   },
   inputContainer: {
     borderBottomWidth: 0,
-    width: SCREEN_WIDTH,
+    width: '100%',
   },
   rightIconContainerStyle: {
     marginRight: 8,

--- a/src/searchbar/__tests__/__snapshots__/SearchBar-android.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar-android.js.snap
@@ -7,7 +7,6 @@ exports[`Android SearchBar component Props cancel button Disabled cancelButtonPr
       "backgroundColor": "white",
       "paddingBottom": 8,
       "paddingTop": 8,
-      "width": 750,
     }
   }
 >
@@ -25,7 +24,7 @@ exports[`Android SearchBar component Props cancel button Disabled cancelButtonPr
     inputContainerStyle={
       Object {
         "borderBottomWidth": 0,
-        "width": 750,
+        "width": "100%",
       }
     }
     inputStyle={
@@ -116,7 +115,6 @@ exports[`Android SearchBar component Props cancel button Disabled cancelButtonPr
       "backgroundColor": "white",
       "paddingBottom": 8,
       "paddingTop": 8,
-      "width": 750,
     }
   }
 >
@@ -140,7 +138,7 @@ exports[`Android SearchBar component Props cancel button Disabled cancelButtonPr
     inputContainerStyle={
       Object {
         "borderBottomWidth": 0,
-        "width": 750,
+        "width": "100%",
       }
     }
     inputStyle={
@@ -231,7 +229,6 @@ exports[`Android SearchBar component Props cancel button Enabled cancelButtonPro
       "backgroundColor": "white",
       "paddingBottom": 8,
       "paddingTop": 8,
-      "width": 750,
     }
   }
 >
@@ -255,7 +252,7 @@ exports[`Android SearchBar component Props cancel button Enabled cancelButtonPro
     inputContainerStyle={
       Object {
         "borderBottomWidth": 0,
-        "width": 750,
+        "width": "100%",
       }
     }
     inputStyle={
@@ -346,7 +343,6 @@ exports[`Android SearchBar component Props cancel button Enabled cancelButtonTit
       "backgroundColor": "white",
       "paddingBottom": 8,
       "paddingTop": 8,
-      "width": 750,
     }
   }
 >
@@ -360,7 +356,7 @@ exports[`Android SearchBar component Props cancel button Enabled cancelButtonTit
     inputContainerStyle={
       Object {
         "borderBottomWidth": 0,
-        "width": 750,
+        "width": "100%",
       }
     }
     inputStyle={
@@ -451,7 +447,6 @@ exports[`Android SearchBar component Props clearIcon and without clearIcon 1`] =
       "backgroundColor": "white",
       "paddingBottom": 8,
       "paddingTop": 8,
-      "width": 750,
     }
   }
 >
@@ -464,7 +459,7 @@ exports[`Android SearchBar component Props clearIcon and without clearIcon 1`] =
     inputContainerStyle={
       Object {
         "borderBottomWidth": 0,
-        "width": 750,
+        "width": "100%",
       }
     }
     inputStyle={
@@ -555,7 +550,6 @@ exports[`Android SearchBar component Props clearIcon and without custom clearIco
       "backgroundColor": "white",
       "paddingBottom": 8,
       "paddingTop": 8,
-      "width": 750,
     }
   }
 >
@@ -568,7 +562,7 @@ exports[`Android SearchBar component Props clearIcon and without custom clearIco
     inputContainerStyle={
       Object {
         "borderBottomWidth": 0,
-        "width": 750,
+        "width": "100%",
       }
     }
     inputStyle={
@@ -659,7 +653,6 @@ exports[`Android SearchBar component Props clearIcon and without no clearIcon 1`
       "backgroundColor": "white",
       "paddingBottom": 8,
       "paddingTop": 8,
-      "width": 750,
     }
   }
 >
@@ -672,7 +665,7 @@ exports[`Android SearchBar component Props clearIcon and without no clearIcon 1`
     inputContainerStyle={
       Object {
         "borderBottomWidth": 0,
-        "width": 750,
+        "width": "100%",
       }
     }
     inputStyle={
@@ -763,7 +756,6 @@ exports[`Android SearchBar component Props searchIcon and without custom searchI
       "backgroundColor": "white",
       "paddingBottom": 8,
       "paddingTop": 8,
-      "width": 750,
     }
   }
 >
@@ -776,7 +768,7 @@ exports[`Android SearchBar component Props searchIcon and without custom searchI
     inputContainerStyle={
       Object {
         "borderBottomWidth": 0,
-        "width": 750,
+        "width": "100%",
       }
     }
     inputStyle={
@@ -861,7 +853,6 @@ exports[`Android SearchBar component Props searchIcon and without no searchIcon 
       "backgroundColor": "white",
       "paddingBottom": 8,
       "paddingTop": 8,
-      "width": 750,
     }
   }
 >
@@ -874,7 +865,7 @@ exports[`Android SearchBar component Props searchIcon and without no searchIcon 
     inputContainerStyle={
       Object {
         "borderBottomWidth": 0,
-        "width": 750,
+        "width": "100%",
       }
     }
     inputStyle={
@@ -958,7 +949,6 @@ exports[`Android SearchBar component Props searchIcon and without searchIcon 1`]
       "backgroundColor": "white",
       "paddingBottom": 8,
       "paddingTop": 8,
-      "width": 750,
     }
   }
 >
@@ -971,7 +961,7 @@ exports[`Android SearchBar component Props searchIcon and without searchIcon 1`]
     inputContainerStyle={
       Object {
         "borderBottomWidth": 0,
-        "width": 750,
+        "width": "100%",
       }
     }
     inputStyle={
@@ -1064,7 +1054,6 @@ exports[`Android SearchBar component Props showLoading, loadingProps 1`] = `
       "height": 70,
       "paddingBottom": 8,
       "paddingTop": 8,
-      "width": 750,
     }
   }
 >
@@ -1077,7 +1066,7 @@ exports[`Android SearchBar component Props showLoading, loadingProps 1`] = `
     inputContainerStyle={
       Object {
         "borderBottomWidth": 0,
-        "width": 750,
+        "width": "100%",
       }
     }
     inputStyle={
@@ -1181,7 +1170,6 @@ exports[`Android SearchBar component should render with a preset value 1`] = `
       "backgroundColor": "white",
       "paddingBottom": 8,
       "paddingTop": 8,
-      "width": 750,
     }
   }
 >
@@ -1194,7 +1182,7 @@ exports[`Android SearchBar component should render with a preset value 1`] = `
     inputContainerStyle={
       Object {
         "borderBottomWidth": 0,
-        "width": 750,
+        "width": "100%",
       }
     }
     inputStyle={
@@ -1293,7 +1281,6 @@ exports[`Android SearchBar component should render without issues 1`] = `
       "backgroundColor": "white",
       "paddingBottom": 8,
       "paddingTop": 8,
-      "width": 750,
     }
   }
 >
@@ -1306,7 +1293,7 @@ exports[`Android SearchBar component should render without issues 1`] = `
     inputContainerStyle={
       Object {
         "borderBottomWidth": 0,
-        "width": 750,
+        "width": "100%",
       }
     }
     inputStyle={

--- a/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
@@ -7,7 +7,6 @@ exports[`SearchBar wrapper component should apply values from theme 1`] = `
       "backgroundColor": "white",
       "paddingBottom": 8,
       "paddingTop": 8,
-      "width": 750,
     }
   }
 >
@@ -31,7 +30,7 @@ exports[`SearchBar wrapper component should apply values from theme 1`] = `
               "translateX": 0,
             },
           ],
-          "width": 750,
+          "width": "100%",
         }
       }
     >


### PR DESCRIPTION
Before the searchbar was using a static width of the screen. Even when overriding this width to auto or 100% - margins being applied to the container would never show.

Closes #1699

### Before with align-items center on parent
```jsx
<View
  style={{
    flex: 1,
    backgroundColor: 'pink',
    alignItems: 'center',
    justifyContent: 'center',
  }}
>
  <SearchBar
    platform="android"
    containerStyle={{ marginHorizontal: 30 }}
    showLoading
  />
</View>
```

![image](https://user-images.githubusercontent.com/5962998/50564192-6b69da00-0cf9-11e9-9409-5688d5100201.jpeg)

### Before without align-items center on parent
You can see there the loader is off the screen
```jsx
<View
  style={{
    flex: 1,
    backgroundColor: 'pink',
    justifyContent: 'center',
  }}
>
  <SearchBar
    platform="android"
    containerStyle={{ marginHorizontal: 30 }}
    showLoading
  />
</View>
```
![image](https://user-images.githubusercontent.com/5962998/50564210-9a804b80-0cf9-11e9-8a6b-dcd0b0fe1b86.jpeg)


It's only by setting `width: null` on both the `containerStyle` and `inputContainerStyle` that this can be achieved.

```jsx
<View
  style={{
    flex: 1,
    backgroundColor: 'pink',
    justifyContent: 'center',
  }}
>
  <SearchBar
    platform="android"
    containerStyle={{ marginHorizontal: 30, width: null }}
    inputContainerStyle={{ width: null }}
    showLoading
  />
</View>
```

![screen shot 2018-12-31 at 12 45 37 pm](https://user-images.githubusercontent.com/5962998/50564287-2a25fa00-0cfa-11e9-98c6-fc63eb71f228.jpg)

### After
With the changes in this PR all that is required is setting the margin as a user would expect. This works regardless if the parent has align-items center or not.

```jsx
<SearchBar
  platform="android"
  containerStyle={{ marginHorizontal: 30 }}
  showLoading
/>
```
