### PR TITLE
fix(tooltip): proper calculation of tooltip position based on visible element width

### DIFF
--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -6,7 +6,7 @@ import { ViewPropTypes, withTheme } from '../config/';
 import { ScreenWidth, ScreenHeight, isIOS } from '../helpers';
 
 import Triangle from './Triangle';
-import getTooltipCoordinate from './getTooltipCoordinate';
+import getTooltipCoordinate, { getElementVisibleWidth } from './getTooltipCoordinate';
 
 class Tooltip extends React.PureComponent {
   state = {
@@ -93,7 +93,7 @@ class Tooltip extends React.PureComponent {
         style={{
           position: 'absolute',
           top: pastMiddleLine ? yOffset - 13 : yOffset + elementHeight - 2,
-          left: xOffset + elementWidth / 2 - 7.5,
+          left: xOffset + getElementVisibleWidth(elementWidth, xOffset, ScreenWidth) / 2 - 7.5,
         }}
       >
         <Triangle

--- a/src/tooltip/getTooltipCoordinate.js
+++ b/src/tooltip/getTooltipCoordinate.js
@@ -3,6 +3,19 @@ const getArea = (a, b) => a * b;
 const getPointDistance = (a, b) =>
   Math.sqrt(Math.pow(a[0] - b[0], 2) + Math.pow(a[1] - b[1], 2));
 
+export const getElementVisibleWidth = (elementWidth, xOffset, ScreenWidth) => {
+  // Element is fully visible OR scrolled right
+  if (xOffset >= 0) {
+    return (xOffset + elementWidth) <= ScreenWidth // is element fully visible?
+      ? elementWidth // element is fully visible;
+      : (ScreenWidth - xOffset) // calculate visible width of scrolled element
+  } 
+  // Element is scrolled LEFT
+  else {
+    return elementWidth - xOffset; // calculate visible width of scrolled element
+  }
+};
+
 /*
 type Coord = {
   x: number,
@@ -37,7 +50,7 @@ const getTooltipCoordinate = (
   withPointer,
 ) => {
   // The following are point coordinates: [x, y]
-  const center = [x + width / 2, y + height / 2];
+  const center = [x + getElementVisibleWidth(width, x, ScreenWidth) / 2, y + height / 2];
   const pOne = [center[0], 0];
   const pTwo = [ScreenWidth, center[1]];
   const pThree = [center[0], ScreenHeight];


### PR DESCRIPTION
This merge request fixes tooltip position calculations. Now we use visible width of wrapped element for tooltip placement. Fixes [#1710](https://github.com/react-native-training/react-native-elements/issues/1710)