### PR TITLE
fix(SearchBar|Input): Allow height on fields to scale with fontSize

### DIFF
--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -188,7 +188,7 @@ const styles = {
     color: 'black',
     fontSize: 18,
     flex: 1,
-    height: 40,
+    minHeight: 40,
   },
   error: theme => ({
     margin: 5,

--- a/src/input/__tests__/__snapshots__/Input.js.snap
+++ b/src/input/__tests__/__snapshots__/Input.js.snap
@@ -32,7 +32,7 @@ exports[`Input component Props containerStyle 1`] = `
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
         }
       }
       testID="RNE__Input__text-input"
@@ -74,7 +74,7 @@ exports[`Input component Props errorMessage and style errorMessage 1`] = `
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
         }
       }
       testID="RNE__Input__text-input"
@@ -130,7 +130,7 @@ exports[`Input component Props errorMessage and style errorStyle 1`] = `
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
         }
       }
       testID="RNE__Input__text-input"
@@ -186,7 +186,7 @@ exports[`Input component Props inputComponent 1`] = `
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
         }
       }
       testID="RNE__Input__text-input"
@@ -229,7 +229,7 @@ exports[`Input component Props inputContainerStyle 1`] = `
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
         }
       }
       testID="RNE__Input__text-input"
@@ -271,7 +271,7 @@ exports[`Input component Props inputStyle 1`] = `
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
           "width": 200,
         }
       }
@@ -328,7 +328,7 @@ exports[`Input component Props label and styles label 1`] = `
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
         }
       }
       testID="RNE__Input__text-input"
@@ -377,7 +377,7 @@ exports[`Input component Props label and styles label as component 1`] = `
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
         }
       }
       testID="RNE__Input__text-input"
@@ -434,7 +434,7 @@ exports[`Input component Props label and styles labelStyle 1`] = `
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
         }
       }
       testID="RNE__Input__text-input"
@@ -491,7 +491,7 @@ exports[`Input component Props leftIcon and styles leftIcon 1`] = `
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
         }
       }
       testID="RNE__Input__text-input"
@@ -549,7 +549,7 @@ exports[`Input component Props leftIcon and styles leftIconContainerStyle 1`] = 
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
         }
       }
       testID="RNE__Input__text-input"
@@ -592,7 +592,7 @@ exports[`Input component Props placeholder 1`] = `
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
         }
       }
       testID="RNE__Input__text-input"
@@ -634,7 +634,7 @@ exports[`Input component Props rightIcon and styles rightIcon 1`] = `
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
         }
       }
       testID="RNE__Input__text-input"
@@ -691,7 +691,7 @@ exports[`Input component Props rightIcon and styles rightIconContainerStyle 1`] 
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
         }
       }
       testID="RNE__Input__text-input"
@@ -750,7 +750,7 @@ exports[`Input component should apply values from theme 1`] = `
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
         }
       }
       testID="RNE__Input__text-input"
@@ -793,7 +793,7 @@ exports[`Input component should match snapshot 1`] = `
           "color": "black",
           "flex": 1,
           "fontSize": 18,
-          "height": 40,
+          "minHeight": 40,
         }
       }
       testID="RNE__Input__text-input"

--- a/src/searchbar/SearchBar-default.js
+++ b/src/searchbar/SearchBar-default.js
@@ -206,7 +206,7 @@ const styles = {
     borderBottomWidth: 0,
     borderRadius: 3,
     overflow: 'hidden',
-    height: 30,
+    minHeight: 30,
     backgroundColor: theme.colors.searchBg,
   }),
   inputContentContainerLight: theme => ({

--- a/src/searchbar/SearchBar-ios.js
+++ b/src/searchbar/SearchBar-ios.js
@@ -254,7 +254,7 @@ const styles = StyleSheet.create({
     borderBottomWidth: 0,
     backgroundColor: '#dcdce1',
     borderRadius: 9,
-    height: 36,
+    minHeight: 36,
     marginLeft: 8,
     marginRight: 8,
   },

--- a/src/searchbar/__tests__/__snapshots__/SearchBar-default.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar-default.js.snap
@@ -24,7 +24,7 @@ exports[`Default SearchBar component Props clearIcon and without clearIcon 1`] =
         "backgroundColor": "#303337",
         "borderBottomWidth": 0,
         "borderRadius": 3,
-        "height": 30,
+        "minHeight": 30,
         "overflow": "hidden",
       }
     }
@@ -96,7 +96,7 @@ exports[`Default SearchBar component Props clearIcon and without custom clearIco
         "backgroundColor": "#303337",
         "borderBottomWidth": 0,
         "borderRadius": 3,
-        "height": 30,
+        "minHeight": 30,
         "overflow": "hidden",
       }
     }
@@ -168,7 +168,7 @@ exports[`Default SearchBar component Props clearIcon and without no clearIcon 1`
         "backgroundColor": "#303337",
         "borderBottomWidth": 0,
         "borderRadius": 3,
-        "height": 30,
+        "minHeight": 30,
         "overflow": "hidden",
       }
     }
@@ -240,7 +240,7 @@ exports[`Default SearchBar component Props searchIcon and without custom searchI
         "backgroundColor": "#303337",
         "borderBottomWidth": 0,
         "borderRadius": 15,
-        "height": 30,
+        "minHeight": 30,
         "overflow": "hidden",
       }
     }
@@ -305,7 +305,7 @@ exports[`Default SearchBar component Props searchIcon and without no searchIcon 
         "backgroundColor": "#303337",
         "borderBottomWidth": 0,
         "borderRadius": 3,
-        "height": 30,
+        "minHeight": 30,
         "overflow": "hidden",
       }
     }
@@ -370,7 +370,7 @@ exports[`Default SearchBar component Props searchIcon and without searchIcon 1`]
         "backgroundColor": "#bdc6cf",
         "borderBottomWidth": 0,
         "borderRadius": 3,
-        "height": 30,
+        "minHeight": 30,
         "overflow": "hidden",
       }
     }
@@ -443,7 +443,7 @@ exports[`Default SearchBar component Props showLoading, loadingProps 1`] = `
         "backgroundColor": "#303337",
         "borderBottomWidth": 0,
         "borderRadius": 3,
-        "height": 30,
+        "minHeight": 30,
         "overflow": "hidden",
       }
     }
@@ -528,7 +528,7 @@ exports[`Default SearchBar component should render with a preset value 1`] = `
         "backgroundColor": "#303337",
         "borderBottomWidth": 0,
         "borderRadius": 3,
-        "height": 30,
+        "minHeight": 30,
         "overflow": "hidden",
       }
     }
@@ -608,7 +608,7 @@ exports[`Default SearchBar component should render without issues 1`] = `
         "backgroundColor": "#303337",
         "borderBottomWidth": 0,
         "borderRadius": 3,
-        "height": 30,
+        "minHeight": 30,
         "overflow": "hidden",
       }
     }

--- a/src/searchbar/__tests__/__snapshots__/SearchBar-ios.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar-ios.js.snap
@@ -24,9 +24,9 @@ exports[`iOS SearchBar component Props cancel button Disabled cancelButtonProps 
         "backgroundColor": "#dcdce1",
         "borderBottomWidth": 0,
         "borderRadius": 9,
-        "height": 36,
         "marginLeft": 8,
         "marginRight": 8,
+        "minHeight": 36,
       }
     }
     inputStyle={
@@ -184,9 +184,9 @@ exports[`iOS SearchBar component Props cancel button Disabled cancelButtonProps 
         "backgroundColor": "#dcdce1",
         "borderBottomWidth": 0,
         "borderRadius": 9,
-        "height": 36,
         "marginLeft": 8,
         "marginRight": 8,
+        "minHeight": 36,
       }
     }
     inputStyle={
@@ -346,9 +346,9 @@ exports[`iOS SearchBar component Props cancel button Enabled cancelButtonProps 1
         "backgroundColor": "#dcdce1",
         "borderBottomWidth": 0,
         "borderRadius": 9,
-        "height": 36,
         "marginLeft": 8,
         "marginRight": 8,
+        "minHeight": 36,
       }
     }
     inputStyle={
@@ -508,9 +508,9 @@ exports[`iOS SearchBar component Props cancel button Enabled cancelButtonTitle 1
         "backgroundColor": "#dcdce1",
         "borderBottomWidth": 0,
         "borderRadius": 9,
-        "height": 36,
         "marginLeft": 8,
         "marginRight": 8,
+        "minHeight": 36,
       }
     }
     inputStyle={
@@ -664,9 +664,9 @@ exports[`iOS SearchBar component Props clearIcon and without clearIcon 1`] = `
         "backgroundColor": "#dcdce1",
         "borderBottomWidth": 0,
         "borderRadius": 9,
-        "height": 36,
         "marginLeft": 8,
         "marginRight": 8,
+        "minHeight": 36,
       }
     }
     inputStyle={
@@ -820,9 +820,9 @@ exports[`iOS SearchBar component Props clearIcon and without custom clearIcon 1`
         "backgroundColor": "#dcdce1",
         "borderBottomWidth": 0,
         "borderRadius": 9,
-        "height": 36,
         "marginLeft": 8,
         "marginRight": 8,
+        "minHeight": 36,
       }
     }
     inputStyle={
@@ -976,9 +976,9 @@ exports[`iOS SearchBar component Props clearIcon and without no clearIcon 1`] = 
         "backgroundColor": "#dcdce1",
         "borderBottomWidth": 0,
         "borderRadius": 9,
-        "height": 36,
         "marginLeft": 8,
         "marginRight": 8,
+        "minHeight": 36,
       }
     }
     inputStyle={
@@ -1132,9 +1132,9 @@ exports[`iOS SearchBar component Props searchIcon and without custom searchIcon 
         "backgroundColor": "#dcdce1",
         "borderBottomWidth": 0,
         "borderRadius": 9,
-        "height": 36,
         "marginLeft": 8,
         "marginRight": 8,
+        "minHeight": 36,
       }
     }
     inputStyle={
@@ -1282,9 +1282,9 @@ exports[`iOS SearchBar component Props searchIcon and without no searchIcon 1`] 
         "backgroundColor": "#dcdce1",
         "borderBottomWidth": 0,
         "borderRadius": 9,
-        "height": 36,
         "marginLeft": 8,
         "marginRight": 8,
+        "minHeight": 36,
       }
     }
     inputStyle={
@@ -1431,9 +1431,9 @@ exports[`iOS SearchBar component Props searchIcon and without searchIcon 1`] = `
         "backgroundColor": "#dcdce1",
         "borderBottomWidth": 0,
         "borderRadius": 9,
-        "height": 36,
         "marginLeft": 8,
         "marginRight": 8,
+        "minHeight": 36,
       }
     }
     inputStyle={
@@ -1589,9 +1589,9 @@ exports[`iOS SearchBar component Props showLoading, loadingProps 1`] = `
         "backgroundColor": "#dcdce1",
         "borderBottomWidth": 0,
         "borderRadius": 9,
-        "height": 36,
         "marginLeft": 8,
         "marginRight": 8,
+        "minHeight": 36,
       }
     }
     inputStyle={
@@ -1758,9 +1758,9 @@ exports[`iOS SearchBar component should render with a preset value 1`] = `
         "backgroundColor": "#dcdce1",
         "borderBottomWidth": 0,
         "borderRadius": 9,
-        "height": 36,
         "marginLeft": 8,
         "marginRight": 8,
+        "minHeight": 36,
       }
     }
     inputStyle={
@@ -1922,9 +1922,9 @@ exports[`iOS SearchBar component should render without issues 1`] = `
         "backgroundColor": "#dcdce1",
         "borderBottomWidth": 0,
         "borderRadius": 9,
-        "height": 36,
         "marginLeft": 8,
         "marginRight": 8,
+        "minHeight": 36,
       }
     }
     inputStyle={

--- a/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
@@ -139,9 +139,9 @@ exports[`SearchBar wrapper component should apply values from theme 1`] = `
             "color": "black",
             "flex": 1,
             "fontSize": 18,
-            "height": 40,
             "marginLeft": 24,
             "marginRight": 8,
+            "minHeight": 40,
           }
         }
         testID="searchInput"


### PR DESCRIPTION
Inputs were set a fixed height. Meaning if the developer increases the fontSize of the input, it would result in a scrollable area in the text field. Also if users had on display scaling for accessibility reasons, then they'd be unable to view the text.

This PR changes the fixed height to minHeight to allow scaling.

Fixes #1239

---

Examples below are with `inputStyle={{ fontSize: 100 }}`

### Before
![screenshot_1548038814](https://user-images.githubusercontent.com/5962998/51450417-0fe2a900-1d07-11e9-968d-ea8bdfe8d8bb.png)


### After
![screenshot_1548038556](https://user-images.githubusercontent.com/5962998/51450423-15d88a00-1d07-11e9-9554-04b3fecb4bee.png)



