### PR TITLE
Fix small typo in customization docs

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -150,7 +150,7 @@ const theme = {
 const App = () => {
   return (
     <ThemeProvider theme={theme}>
-      <Card title="My Button" titleStyle={{ color: 'pink' }} />
+      <Button title="My Button" titleStyle={{ color: 'pink' }} />
     </ThemeProvider>
   );
 };


### PR DESCRIPTION
## Proposed Change

There is a small typo in the [Customization](https://react-native-training.github.io/react-native-elements/docs/customization.html) docs. The docs talk about the precedence of styling components in React Native Elements. The example shows how theming a `<Button />` with props overrides the them set by the `<ThemeProvider />`. The typo lies in the fact that a `<Card />` is being styled instead of a `<Button />`. This fixes that. 😃 