### PR TITLE
Fix mix of import and module.exports

### DIFF
--- a/src/helpers/normalizeText.js
+++ b/src/helpers/normalizeText.js
@@ -92,4 +92,4 @@ const normalize = size => {
   return size;
 };
 
-module.exports = normalize; // eslint-disable-line no-undef
+export default normalize; // eslint-disable-line no-undef


### PR DESCRIPTION
Similar bug was fixed previously: https://github.com/react-native-training/react-native-elements/pull/448

eslint rule could be useful to prevent this in future.
