### PR TITLE
reduces yOffset by StatusBar.currentHeight on android devices

### DIFF
--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TouchableOpacity, Modal, View } from 'react-native';
+import { TouchableOpacity, Modal, View, StatusBar } from 'react-native';
 
 import { ViewPropTypes, withTheme } from '../config';
 import { ScreenWidth, ScreenHeight, isIOS } from '../helpers';
@@ -158,7 +158,7 @@ class Tooltip extends React.PureComponent {
         ) => {
           this.setState({
             xOffset: pageOffsetX,
-            yOffset: pageOffsetY,
+            yOffset: isIOS ? pageOffsetY : pageOffsetY - StatusBar.currentHeight,
             elementWidth: width,
             elementHeight: height,
           });


### PR DESCRIPTION
fixes issues #1744 #1743 

compensates for the StatusBar.currentHeight to position the active tooltip properly on android devices.