### PR TITLE
Fix PlaceholderContent type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1883,7 +1883,7 @@ export interface ImageProps extends ImageProperties {
   /**
    * Content to render when image is loading
    */
-  PlaceholderContent?: React.ComponentType<any>;
+  PlaceholderContent?: React.ReactElement<any>;
 
   /**
    * Additional styling for the container


### PR DESCRIPTION
[The docs](https://react-native-training.github.io/react-native-elements/docs/image.html) are accurate about the usage of this `PlaceholderContent` prop:

```js
<Image
  source={{ uri: image }}
  style={{ width: 200, height: 200 }}
  PlaceholderContent={<ActivityIndicator />}
/>
```

i.e. you provide a `ReactElement`, not a `ComponentType` as specified in the TypeScript definitions here.

[Examining the source](https://github.com/react-native-training/react-native-elements/blob/master/src/image/Image.js#L69) shows that it's used as a `ReactElement` too. i.e. rendered directly rather than a Component:

```js
>
  {PlaceholderContent}
</Animated.View>
```