### PR TITLE
Added divider color in TypeScript definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1930,6 +1930,7 @@ export interface Colors {
   readonly warning: string;
   readonly error: string;
   readonly disabled: string;
+  readonly divider: string;
   readonly platform: {
     ios: {
       primary: string;


### PR DESCRIPTION
From `src/config/colors.js`: https://github.com/react-native-training/react-native-elements/blob/next/src/config/colors.js#L19