### PR TITLE
Add ReactElement<{}> to ListItem.chevron and checkmark

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1099,8 +1099,8 @@ export interface ListItemProps {
   containerStyle?: StyleProp<ViewStyle>;
   contentContainerStyle?: StyleProp<ViewStyle>;
   rightContentContainerStyle?: StyleProp<ViewStyle>;
-  chevron?: boolean | Partial<IconProps>;
-  checkmark?: boolean | Partial<IconProps>;
+  chevron?: boolean | Partial<IconProps> | React.ReactElement<{}>;
+  checkmark?: boolean | Partial<IconProps> | React.ReactElement<{}>;
   title?: string | React.ReactElement<{}>;
   titleStyle?: StyleProp<TextStyle>;
   titleProps?: TextProperties;


### PR DESCRIPTION
`ListItem` props `chevron` and `checkmark` [are rendered](https://github.com/react-native-training/react-native-elements/blob/master/src/list/ListItem.js#L213):

```js
{renderNode(Icon, checkmark, checkmarkDefaultProps(theme))}
{renderNode(Icon, chevron, chevronDefaultProps)}
```

Using the [`renderNode` helper](https://github.com/react-native-training/react-native-elements/blob/master/src/helpers/renderNode.js), which includes the option of a `ReactElement`:

```js
const renderNode = (Component, content, defaultProps) => {
  if (content == null || content === false) {
    return null;
  }
  if (React.isValidElement(content)) {
    return content;
  }
```