### PR TITLE
fix: add underlayColor to SocialIconProps interface

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1775,7 +1775,7 @@ export interface SocialIconProps {
   /**
    * Specify underlayColor for TouchableHighlight
    *
-   * @default colors[type] || 'white'
+   * @default 'white' if `light` prop is true, otherwise defaults to icon color.
    */
   underlayColor?: string;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1771,6 +1771,13 @@ export interface SocialIconProps {
    * @default false
    */
   loading?: boolean;
+  
+  /**
+   * Specify underlayColor for TouchableHighlight
+   *
+   * @default colors[type] || 'white'
+   */
+  underlayColor?: string;
 }
 
 /**


### PR DESCRIPTION
Added `underlayColor` to the `SocialIconProps` interface.

I wasn't sure as for what to write as a default, since it is only white if the button is light and the default color varies according to the button type.