### PR TITLE
fix: Change merge library to deepmerge from lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "dependencies": {
     "color": "^3.1.0",
+    "deepmerge": "^3.1.0",
     "hoist-non-react-statics": "^3.1.0",
-    "lodash.merge": "^4.6.1",
     "opencollective-postinstall": "^2.0.0",
     "prop-types": "^15.5.8",
     "react-native-ratings": "^6.3.0",

--- a/src/config/ThemeProvider.js
+++ b/src/config/ThemeProvider.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import merge from 'lodash.merge';
+import deepmerge from 'deepmerge';
 
 import colors from './colors';
 
@@ -11,7 +11,7 @@ export default class ThemeProvider extends React.Component {
     super(props);
 
     this.state = {
-      theme: merge(
+      theme: deepmerge(
         {
           colors,
         },
@@ -22,7 +22,7 @@ export default class ThemeProvider extends React.Component {
 
   updateTheme = updates => {
     this.setState(({ theme }) => ({
-      theme: merge({}, theme, updates),
+      theme: deepmerge(theme, updates),
     }));
   };
 

--- a/src/config/withTheme.js
+++ b/src/config/withTheme.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import merge from 'lodash.merge';
+import deepmerge from 'deepmerge';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
 import { ThemeConsumer } from './ThemeProvider';
@@ -32,7 +32,7 @@ const withTheme = (WrappedComponent, themeKey) => {
             const props = {
               theme,
               updateTheme,
-              ...merge({}, themeKey && theme[themeKey], rest),
+              ...deepmerge((themeKey && theme[themeKey]) || {}, rest),
               children,
             };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3157,6 +3157,11 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deepmerge@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.1.0.tgz#a612626ce4803da410d77554bfd80361599c034d"
+  integrity sha512-/TnecbwXEdycfbsM2++O3eGiatEFHjjNciHEwJclM+T5Kd94qD1AP+2elP/Mq0L5b9VZJao5znR01Mz6eX8Seg==
+
 default-require-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
@@ -6736,11 +6741,6 @@ lodash.keys@^3.0.0:
     lodash._getnative "^3.0.0"
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
-
-lodash.merge@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
-  integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
 
 lodash.pad@^4.1.0:
   version "4.5.1"


### PR DESCRIPTION
While using ThemeProvider, some errors would be shown for some
components for arrays not having keys. This was due to the merge
algorithm in lodash.merge which happens to affect react's keys.

Switching to deepmerge instead of lodash.merge does not have this
issue but maintains expected behaviour.

Fixes #1735 #1517