### PR TITLE
feat(Text): Add style props to customize header props

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -24,6 +24,10 @@ Text displays words and characters at various sizes.
 - [`h2`](#h2)
 - [`h3`](#h3)
 - [`h4`](#h4)
+- [`h1Style`](#h1style)
+- [`h2Style`](#h2style)
+- [`h3Style`](#h3style)
+- [`h4Style`](#h4style)
 - [`style`](#style)
 
 ---
@@ -67,6 +71,46 @@ font size 22 (optional)
 |  Type   | Default |
 | :-----: | :-----: |
 | boolean |  none   |
+
+---
+
+### `h1Style`
+
+Styling for when `h1` is set (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| Text style (object) |  none   |
+
+---
+
+### `h2Style`
+
+Styling for when `h2` is set (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| Text style (object) |  none   |
+
+---
+
+### `h3Style`
+
+Styling for when `h3` is set (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| Text style (object) |  none   |
+
+---
+
+### `h4Style`
+
+Styling for when `h4` is set (optional)
+
+|        Type         | Default |
+| :-----------------: | :-----: |
+| Text style (object) |  none   |
 
 ---
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -74,6 +74,26 @@ export interface TextProps extends TextProperties {
   h4?: boolean;
 
   /**
+   * Styling for when `h1` is set
+   */
+  h1Style?: StyleProp<TextStyle>;
+
+  /**
+   * Styling for when `h2` is set
+   */
+  h2Style?: StyleProp<TextStyle>;
+
+  /**
+   * Styling for when `h3` is set
+   */
+  h3Style?: StyleProp<TextStyle>;
+
+  /**
+   * Styling for when `h4` is set
+   */
+  h4Style?: StyleProp<TextStyle>;
+
+  /**
    * Additional styling for Text
    */
   style?: StyleProp<TextStyle>;
@@ -685,7 +705,7 @@ export interface CheckBoxProps {
   title?: string | React.ReactElement<{}>;
 
   /**
-   * Additional props for the title 
+   * Additional props for the title
    */
   titleProps?: Partial<TextProperties>;
 

--- a/src/text/Text.js
+++ b/src/text/Text.js
@@ -6,17 +6,29 @@ import { fonts, withTheme } from '../config';
 import normalize from '../helpers/normalizeText';
 
 const TextElement = props => {
-  const { style, children, h1, h2, h3, h4, ...rest } = props;
+  const {
+    style,
+    children,
+    h1,
+    h2,
+    h3,
+    h4,
+    h1Style,
+    h2Style,
+    h3Style,
+    h4Style,
+    ...rest
+  } = props;
 
   return (
     <Text
       style={StyleSheet.flatten([
         styles.text,
         style && style,
-        h1 && { fontSize: normalize(40) },
-        h2 && { fontSize: normalize(34) },
-        h3 && { fontSize: normalize(28) },
-        h4 && { fontSize: normalize(22) },
+        h1 && StyleSheet.flatten([{ fontSize: normalize(40) }, h1Style]),
+        h2 && StyleSheet.flatten([{ fontSize: normalize(34) }, h2Style]),
+        h3 && StyleSheet.flatten([{ fontSize: normalize(28) }, h3Style]),
+        h4 && StyleSheet.flatten([{ fontSize: normalize(22) }, h4Style]),
         h1 && styles.bold,
         h2 && styles.bold,
         h3 && styles.bold,
@@ -35,6 +47,10 @@ TextElement.propTypes = {
   h2: PropTypes.bool,
   h3: PropTypes.bool,
   h4: PropTypes.bool,
+  h1Style: Text.propTypes.style,
+  h2Style: Text.propTypes.style,
+  h3Style: Text.propTypes.style,
+  h4Style: Text.propTypes.style,
   children: PropTypes.node,
 };
 
@@ -44,6 +60,11 @@ TextElement.defaultProps = {
   h3: false,
   h4: false,
   style: {},
+  h1Style: {},
+  h2Style: {},
+  h3Style: {},
+  h4Style: {},
+  children: '',
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Allows user to set the styling that should be applied when props
h1, h2, h3, h4 are used.

Implements #1754