### PR TITLE
Remove --save option from npm install

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -35,7 +35,7 @@ to do is install **react-native-elements**.
 ```
 yarn add react-native-elements
 # or with npm
-npm install --save react-native-elements
+npm install react-native-elements
 ```
 
 > **Note:** If you see the `UNMET PEER DEPENDENCY` warning for


### PR DESCRIPTION
"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358