### PR TITLE
The value of keyExtractor must be a string

### DIFF
--- a/docs/listitem.md
+++ b/docs/listitem.md
@@ -93,7 +93,7 @@ const list = [
   ... // more items
 ]
 
-keyExtractor = (item, index) => index
+keyExtractor = (item, index) => index.toString()
 
 renderItem = ({ item }) => (
   <ListItem
@@ -132,7 +132,7 @@ const list = [
   ... // more items
 ]
 
-keyExtractor = (item, index) => index
+keyExtractor = (item, index) => index.toString()
 
 renderItem = ({ item }) => (
   <ListItem


### PR DESCRIPTION
The value of keyExtractor must be a string. -[related issue](https://github.com/facebook/react-native/issues/18291)

Now the warning like below appeared.
```
Warning: Failed child context type: Invalid child context `virtualizedCell.cellKey` of type `number` supplied to `CellRenderer`, expected `string`.
```

