### PR TITLE
Update button.md

### DIFF
--- a/docs/button.md
+++ b/docs/button.md
@@ -334,7 +334,7 @@ import LinearGradient from 'react-native-linear-gradient';
 ...
 
 <Button
-  ViewComponent={LinearGradient} // Don't forget this!
+  ViewComponent={require('react-native-linear-gradient').default} // Don't forget this!
   linearGradientProps={{
     colors: ['red', 'pink'],
     start: { x: 0, y: 0.5 },


### PR DESCRIPTION
Previous method of accessing React Native Linear Gradient within the ViewComponent prop by ``ViewComponent={LinearGradient}`` no longer works in React Native Linear Gradient version 2.5.3.

This slight code change will allow users to successfully use React Native Linear Gradient in react-native-cli apps.