### PR TITLE
fix(Button-android): remove wrong color argument

### DIFF
--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -64,7 +64,7 @@ class Button extends Component {
     ) {
       if (Platform.Version >= 21) {
         attributes.background = TouchableNativeFeedback.Ripple(
-          'ThemeAttrAndroid',
+          undefined,
           false
         );
       } else {


### PR DESCRIPTION
The first argument of TouchableNativeFeedback.Ripple function takes a color as a string.
https://github.com/facebook/react-native/blob/master/Libraries/Components/Touchable/TouchableNativeFeedback.android.js#L169