### PR TITLE
fix: make ImageComponent a ComponentType

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1922,7 +1922,7 @@ export interface ImageProps extends ImageProperties {
    *
    * @default Image
    */
-  ImageComponent?: React.ComponentClass<any>;
+  ImageComponent?: React.ComponentType<any>;
 
   /**
    * Content to render when image is loading


### PR DESCRIPTION
This allows use to use a `FunctionComponent` and not just a class