### PR TITLE
Add `pointerEvents: "none"` when no `onPress`

### DIFF
--- a/src/icons/Icon.js
+++ b/src/icons/Icon.js
@@ -69,6 +69,7 @@ const Icon = props => {
             { backgroundColor: 'transparent' },
             iconStyle && iconStyle,
           ])}
+          pointerEvents={onPress ? "auto" : "none"}
           size={size}
           name={name}
           color={reverse ? reverseColor : color}


### PR DESCRIPTION
When icons are nested inside of `Button`s, it takes the touch event which prevents screen readers from reading the appropriate accessibility label. This makes for a poor user experience when using a screen reader.