### PR TITLE
Add isEmpty check to onFocus of the Search Bar

### DIFF
--- a/src/searchbar/SearchBar-android.js
+++ b/src/searchbar/SearchBar-android.js
@@ -53,7 +53,10 @@ class SearchBar extends Component {
 
   onFocus = () => {
     this.props.onFocus();
-    this.setState({ hasFocus: true });
+    this.setState({
+      hasFocus: true,
+      isEmpty: this.props.value === '',
+    });
   };
 
   onBlur = () => {

--- a/src/searchbar/SearchBar-default.js
+++ b/src/searchbar/SearchBar-default.js
@@ -47,6 +47,7 @@ class SearchBar extends React.Component {
 
   onFocus = () => {
     this.props.onFocus();
+    this.setState({ isEmpty: this.props.value === '' });
   };
 
   onBlur = () => {

--- a/src/searchbar/SearchBar-ios.js
+++ b/src/searchbar/SearchBar-ios.js
@@ -66,6 +66,7 @@ class SearchBar extends Component {
 
     this.setState({
       hasFocus: true,
+      isEmpty: this.props.value === '',
     });
   };
 


### PR DESCRIPTION
## What does this PR do?
- Updates the ```onFocus``` function in the Search Bar(iOS & Android) to set the state of the ```isEmpty``` prop to show the the Clear icon when the Search Bar becomes focused when an initial value is given.

## Any background or context you want to provide?
- The search bar only sets the ```isEmpty``` state in the constructor and in the```onChangeText``` function. We ran into an issue were a value is given to the Search Bar(via redux/prop passing) after the Search Bars has already mounted, the user would focused the Search Bar and the clear icon would not be displayed until they changed the text in the input.

## Expected vs Actual
- Expected: As a user when I'm taken to a new screen with the search text/value is presented in the new Search Bar, and when I focus the search bar and I can press the the clear icon to start a fresh search.
-Actual: The user focuses the search bar and no clear icon is present.

## Images & Gifs
- Before focus on a new search bar with a value give via props
![Screen Shot 2019-04-18 at 9 08 38 AM](https://user-images.githubusercontent.com/13804811/56366918-2becce00-61c2-11e9-8b50-08fc497fb68c.png)

- After focus on a new search bar with a value give via props(w/o pr changes)
![Screen Shot 2019-04-18 at 9 09 03 AM](https://user-images.githubusercontent.com/13804811/56366971-4161f800-61c2-11e9-9e01-dff60d21baa0.png)

- Expected After focus on a new search bar with a value give via props
![Screen Shot 2019-04-18 at 9 10 01 AM](https://user-images.githubusercontent.com/13804811/56367026-5e96c680-61c2-11e9-9c17-ac069547d3e4.png)

Fixes #1846