### PR TITLE
Add overlayColor prop to toolTip for users to set the background color

### DIFF
--- a/docs/tooltip.md
+++ b/docs/tooltip.md
@@ -29,12 +29,12 @@ import { Tooltip, Text } from 'react-native-elements';
 - [`highlightColor`](#highlightColor)
 - [`onClose`](#onClose)
 - [`onOpen`](#onOpen)
+- [`overlayColor`](#overlaycolor)
 - [`pointerColor`](#pointerColor)
 - [`popover`](#popover)
 - [`toggleOnPress`](#toggleOnPress)
 - [`width`](#width)
 - [`withOverlay`](#withoverlay)
-- [`overlaycolor`](#overlaycolor)
 - [`withPointer`](#withpointer)
 
 ---
@@ -103,6 +103,16 @@ function which gets called on opening the tooltip.
 
 ---
 
+### `overlayColor`
+
+Color of overlay shadow when tooltip is open.
+
+|  Type  |           Default           |
+| :----: | :-------------------------: |
+| string | 'rgba(250, 250, 250, 0.70)' |
+
+---
+
 ### `pointerColor`
 
 Color of tooltip pointer, it defaults to the
@@ -144,6 +154,8 @@ the container.
 | :----: | :-----: |
 | number |   150   |
 
+---
+
 ### `withOverlay`
 
 Flag to determine whether or not display overlay shadow when tooltip is open.
@@ -152,13 +164,7 @@ Flag to determine whether or not display overlay shadow when tooltip is open.
 | :-----: | :-----: |
 | boolean |  true   |
 
-### `overlaycolor`
-
-Color of overlay shadow when tooltip is open.
-
-|  Type  |           Default           |
-| :----: | :-------------------------: |
-| string | 'rgba(250, 250, 250, 0.70)' |
+---
 
 ### `withPointer`
 

--- a/docs/tooltip.md
+++ b/docs/tooltip.md
@@ -34,7 +34,7 @@ import { Tooltip, Text } from 'react-native-elements';
 - [`toggleOnPress`](#toggleOnPress)
 - [`width`](#width)
 - [`withOverlay`](#withoverlay)
-- [`overlayColor`](#overlayColor)
+- [`overlaycolor`](#overlaycolor)
 - [`withPointer`](#withpointer)
 
 ---
@@ -152,7 +152,7 @@ Flag to determine whether or not display overlay shadow when tooltip is open.
 | :-----: | :-----: |
 | boolean |  true   |
 
-### `overlayColor`
+### `overlaycolor`
 
 Color of overlay shadow when tooltip is open.
 

--- a/docs/tooltip.md
+++ b/docs/tooltip.md
@@ -34,6 +34,7 @@ import { Tooltip, Text } from 'react-native-elements';
 - [`toggleOnPress`](#toggleOnPress)
 - [`width`](#width)
 - [`withOverlay`](#withoverlay)
+- [`overlayColor`](#overlayColor)
 - [`withPointer`](#withpointer)
 
 ---
@@ -150,6 +151,14 @@ Flag to determine whether or not display overlay shadow when tooltip is open.
 |  Type   | Default |
 | :-----: | :-----: |
 | boolean |  true   |
+
+### `overlayColor`
+
+Color of overlay shadow when tooltip is open.
+
+|  Type  |           Default           |
+| :----: | :-------------------------: |
+| string | 'rgba(250, 250, 250, 0.70)' |
 
 ### `withPointer`
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1447,6 +1447,13 @@ export interface TooltipProps {
   withOverlay?: boolean;
 
   /**
+   *  Color of overlay shadow when tooltip is open.
+   *
+   * @default 'rgba(250, 250, 250, 0.70)'
+   */
+  overlayColor?: string;
+
+  /**
    * Flag to determine whether or not dislay pointer.
    */
   withPointer?: boolean;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1451,7 +1451,7 @@ export interface TooltipProps {
    *
    * @default 'rgba(250, 250, 250, 0.70)'
    */
-  overlayColor?: string;
+  overlaycolor?: string;
 
   /**
    * Flag to determine whether or not dislay pointer.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1451,7 +1451,7 @@ export interface TooltipProps {
    *
    * @default 'rgba(250, 250, 250, 0.70)'
    */
-  overlaycolor?: string;
+  overlayColor?: string;
 
   /**
    * Flag to determine whether or not dislay pointer.

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -170,7 +170,7 @@ class Tooltip extends React.PureComponent {
 
   render() {
     const { isVisible } = this.state;
-    const { onClose, withOverlay, onOpen } = this.props;
+    const { onClose, withOverlay, overlayColor, onOpen } = this.props;
 
     return (
       <View
@@ -189,7 +189,7 @@ class Tooltip extends React.PureComponent {
           onRequestClose={onClose}
         >
           <TouchableOpacity
-            style={styles.container(withOverlay)}
+            style={styles.container(withOverlay, overlayColor)}
             onPress={this.toggleTooltip}
             activeOpacity={1}
           >
@@ -212,6 +212,7 @@ Tooltip.propTypes = {
   pointerColor: PropTypes.string,
   onClose: PropTypes.func,
   onOpen: PropTypes.func,
+  overlayColor: PropTypes.string,
   withOverlay: PropTypes.bool,
   backgroundColor: PropTypes.string,
   highlightColor: PropTypes.string,
@@ -219,6 +220,7 @@ Tooltip.propTypes = {
 
 Tooltip.defaultProps = {
   withOverlay: true,
+  overlayColor: 'rgba(250, 250, 250, 0.70)',
   highlightColor: 'transparent',
   withPointer: true,
   toggleOnPress: true,
@@ -231,8 +233,8 @@ Tooltip.defaultProps = {
 };
 
 const styles = {
-  container: withOverlay => ({
-    backgroundColor: withOverlay ? 'rgba(250, 250, 250, 0.70)' : 'transparent',
+  container: (withOverlay, overlayColor) => ({
+    backgroundColor: withOverlay ? overlayColor : 'transparent',
     flex: 1,
   }),
 };


### PR DESCRIPTION
## What does this PR do?
- Adds a prop to the toolTip to change the overlay background color. If there is a prop to add an overlay, there should be a prop to change the color of that overlay. #1827

## Any background or context you want to provide?
- We are using the tool tip as a floating action button, on an app that our customers can theme(with their branding). Currently the users would only see the default white and this would cause issues. 

- Users can still change the opacity if they want

## Expected vs Actual
- Expected: If I change the color of the overlay color to red the user will see a red background/shadow to the overlay.
- Actual: We(library users) can't change the color so we are stuck with the default white.

## Images & Gifs
![Simulator Screen Shot - iPhone XS - 2019-04-18 at 10 40 57](https://user-images.githubusercontent.com/13804811/56368966-753f1c80-61c6-11e9-8828-c4618c20ecee.png)
