### PR TITLE
Update header.md

### DIFF
--- a/docs/header.md
+++ b/docs/header.md
@@ -75,9 +75,7 @@ function that returns a React Element is valid too.
 
 ### Component precedence
 
-Components defined through props take precedence over components passed in as
-children, so in this case only the left component with icon set to menu will be
-rendered.
+Components defined through children take precedence over components passed in as props, so in this case `<MyCustomLeftComponent>` will be rendered instead of `leftComponent={{ icon: 'menu' }}`.
 
 ```js
 <Header leftComponent={{ icon: 'menu' }}>

--- a/docs/header.md
+++ b/docs/header.md
@@ -76,7 +76,7 @@ function that returns a React Element is valid too.
 ### Component precedence
 
 Components defined through props take precedence over components passed in as
-children, so in this case only the left component with icon set to home will be
+children, so in this case only the left component with icon set to menu will be
 rendered.
 
 ```js


### PR DESCRIPTION
Section says

> Component precedence
> Components defined through props take precedence over components passed in as children, so in this case only the left component with icon set to **home** will be rendered.

but example shows 

```
<Header leftComponent={{ icon: 'menu' }}>
  <MyCustomLeftComponent />
  <MyCustomCenterComponent />
  <MyCustomRightComponent />
</Header>
```