### PR TITLE
Update Social icons since google+ is dead

### DIFF
--- a/src/social/SocialIcon.js
+++ b/src/social/SocialIcon.js
@@ -21,7 +21,7 @@ const log = () => {
 
 const colors = {
   'github-alt': '#000000',
-  'google-plus-official': '#dd4b39',
+  'google': '#dd4b39',
   'reddit-alien': '#fc461e',
   'stack-overflow': '#f27f33',
   angellist: '#1c4082',


### PR DESCRIPTION
Updating the social icon to just be google since google+ is shutting down: https://support.google.com/plus/answer/9195133?hl=en&ref_topic=9259565
