### PR TITLE
[TS] export type definition RecursivePartial<T>

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2014,7 +2014,7 @@ export function normalize(size: number): number;
  */
 export function registerCustomIconType(id: string, font: any): void;
 
-type RecursivePartial<T> = { [P in keyof T]?: RecursivePartial<T[P]> };
+export type RecursivePartial<T> = { [P in keyof T]?: RecursivePartial<T[P]> };
 
 export interface FullTheme {
   Avatar: Partial<AvatarProps>;


### PR DESCRIPTION
Need to have RecursivePartial to extend FullTheme for adding variables on colors. For example: adding `colors. backgroundColor`

```
interface ExtendedFullTheme extends FullTheme {
  colors: RecursivePartial<CustomColors>;
}

export const themes: { [key in ThemeName]: Partial<ExtendedFullTheme> } = {
  'JUST WHITE': {
    colors: {
      primary: '#000000',
      backgroundColor: '#fffff',
    },
  },

...

```