### PR TITLE
Allow function components to Input.inputComponent

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -830,7 +830,7 @@ export interface InputProps extends TextInputProperties {
   /**
    * Renders component in place of the React Native `TextInput` (optional)
    */
-  inputComponent?: React.ComponentClass<any>;
+   inputComponent?: React.ComponentType<any>;
 
   /**
    * 	Adds styling to input component (optional)


### PR DESCRIPTION
Hello,

Some small change

I can't assign function component to `Input.inputComponent`. This change should fix that.

Sample:
```.tsx
  private renderEmailInput = (props: any) => {
    return <TextInput {...props} editable={!this.isFieldDisabled('email')} />;
  };
```

@iRoachie can you code review? Ty in advance.
