### PR TITLE
Fix ButtonGroup color runtime exception

### DIFF
--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -197,7 +197,7 @@ const styles = {
     backgroundColor: 'transparent',
   },
   disabledText: theme => ({
-    color: color(theme.colors.disabled).darken(0.3),
+    color: color(theme.colors.disabled).darken(0.3).toString(),
   }),
   disabledSelected: theme => ({
     backgroundColor: theme.colors.disabled,

--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -197,7 +197,9 @@ const styles = {
     backgroundColor: 'transparent',
   },
   disabledText: theme => ({
-    color: color(theme.colors.disabled).darken(0.3).toString(),
+    color: color(theme.colors.disabled)
+      .darken(0.3)
+      .toString(),
   }),
   disabledSelected: theme => ({
     backgroundColor: theme.colors.disabled,

--- a/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
+++ b/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
@@ -221,15 +221,7 @@ exports[`ButtonGroup Component Disabled should disable all items 1`] = `
         <Themed.Text
           style={
             Object {
-              "color": Object {
-                "color": Array [
-                  208,
-                  8,
-                  63,
-                ],
-                "model": "hsl",
-                "valpha": 1,
-              },
+              "color": "hsl(208, 8%, 63%)",
               "fontSize": 16.25,
               "fontWeight": "500",
             }
@@ -278,15 +270,7 @@ exports[`ButtonGroup Component Disabled should disable all items 1`] = `
         <Themed.Text
           style={
             Object {
-              "color": Object {
-                "color": Array [
-                  208,
-                  8,
-                  63,
-                ],
-                "model": "hsl",
-                "valpha": 1,
-              },
+              "color": "hsl(208, 8%, 63%)",
               "fontSize": 16.25,
               "fontWeight": "500",
             }
@@ -333,15 +317,7 @@ exports[`ButtonGroup Component Disabled should disable all items 1`] = `
         <Themed.Text
           style={
             Object {
-              "color": Object {
-                "color": Array [
-                  208,
-                  8,
-                  63,
-                ],
-                "model": "hsl",
-                "valpha": 1,
-              },
+              "color": "hsl(208, 8%, 63%)",
               "fontSize": 16.25,
               "fontWeight": "500",
             }
@@ -459,15 +435,7 @@ exports[`ButtonGroup Component Disabled should disable only some items 1`] = `
         <Themed.Text
           style={
             Object {
-              "color": Object {
-                "color": Array [
-                  208,
-                  8,
-                  63,
-                ],
-                "model": "hsl",
-                "valpha": 1,
-              },
+              "color": "hsl(208, 8%, 63%)",
               "fontSize": 16.25,
               "fontWeight": "500",
             }


### PR DESCRIPTION
Just a minor fix :). The color object should be converted to a string as per [color lib's](https://www.npmjs.com/package/color) docs;

This is the runtime exception I encountered.
```
ExceptionsManager.js:82 
Warning: Failed prop type: Invalid prop `color` supplied to `TextElement`: [object Object]
Valid color formats are
  - '#f0f' (#rgb)
  - '#f0fc' (#rgba)
  - '#ff00ff' (#rrggbb)
  - '#ff00ff00' (#rrggbbaa)
  - 'rgb(255, 255, 255)'
  - 'rgba(255, 255, 255, 1.0)'
  - 'hsl(360, 100%, 100%)'
  - 'hsla(360, 100%, 100%, 1.0)'
  - 'transparent'
  - 'red'
  - 0xff00ff00 (0xrrggbbaa)

Bad object: {
  "fontSize": 16.51,
  "color": {
    "model": "hsl",
    "color": [
      208,
      8,
      63
    ],
    "valpha": 1
  },
  "fontWeight": "500"
}

```