### PR TITLE
Add information about styling ListItems

### DIFF
--- a/docs/listitem.md
+++ b/docs/listitem.md
@@ -7,6 +7,8 @@ ListItems are used to display rows of information, such as a contact list,
 playlist, or menu. They are very customizeable and can contain switches,
 avatars, badges, icons, and more.
 
+ListItems are not styled by default.  For an example of styling lists, [see this comment](https://github.com/react-native-training/react-native-elements/issues/1565#issuecomment-436982251).
+
 ![Lists](/react-native-elements/img/lists.png)
 
 ## Usage


### PR DESCRIPTION
This seems like an important change to me because the writing here doesn't match the images.  Adding the example code will _not_ produce the pictured results, because there is no styling in the example code.  The code in this comment does produce nice results.

See one frustrated user here: https://github.com/react-native-training/react-native-elements/issues/1565#issuecomment-499344338 - we also hit this issue and spent probably a couple hours trying to figure out why styling had died after an upgrade.

I believe this issue will be a significant hurdle for new users, and hurts the initial experience quite a lot.   It's just not possible to use ListItems without styling (they will look terrible) and this is a library that usually provides at least reasonable styling right away, so at minimum an example seems called for.  This PR is one way to do it, ofc more docs could be written as well.

Thanks for considering - we use this lib heavily and want it to be a success!