### PR TITLE
Ignore folders from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.ci/
+.github/
+docs/
+website/


### PR DESCRIPTION
The npm package in the current version (1.1.0) contains the `website` folder, which increases the package size from ~1MB to 33MB. Additional files can probably be ignored, too.