### PR TITLE
fix(Text): Reorder style declarations for h1, h2, h3, and h4

### DIFF
--- a/src/text/__tests__/Text.android.js
+++ b/src/text/__tests__/Text.android.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { ThemeProvider } from '../../config';
+import TextThemed from '../Text';
+
+jest.mock('Platform', () => ({
+  OS: 'android',
+  select: ({ android }) => android,
+}));
+
+describe('Text Component (Android)', () => {
+  it('should apply styles from the theme', () => {
+    const theme = {
+      Text: {
+        h2Style: {
+          fontWeight: '200',
+        },
+      },
+    };
+
+    const component = renderer.create(
+      <ThemeProvider theme={theme}>
+        <TextThemed h2>Hey</TextThemed>
+      </ThemeProvider>
+    );
+
+    expect(
+      component.root.findByType(TextThemed).children[0].children[0].props.style
+        .fontWeight
+    ).toBe('200');
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/text/__tests__/Text.js
+++ b/src/text/__tests__/Text.js
@@ -77,6 +77,28 @@ describe('Text Component', () => {
     expect(component.toJSON()).toMatchSnapshot();
   });
 
+  it('should apply styles from the theme', () => {
+    const theme = {
+      Text: {
+        h2Style: {
+          fontWeight: '200',
+        },
+      },
+    };
+
+    const component = renderer.create(
+      <ThemeProvider theme={theme}>
+        <TextThemed h2>Hey</TextThemed>
+      </ThemeProvider>
+    );
+
+    expect(
+      component.root.findByType(TextThemed).children[0].children[0].props.style
+        .fontWeight
+    ).toBe('200');
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
   it('local props should override style props on theme', () => {
     const theme = {
       Text: {

--- a/src/text/__tests__/__snapshots__/Text.android.js.snap
+++ b/src/text/__tests__/__snapshots__/Text.android.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Text Component (Android) should apply styles from the theme 1`] = `
+<Text
+  style={
+    Object {
+      "fontFamily": "sans-serif",
+      "fontSize": 42.5,
+      "fontWeight": "200",
+    }
+  }
+  theme={
+    Object {
+      "Text": Object {
+        "h2Style": Object {
+          "fontWeight": "200",
+        },
+      },
+      "colors": Object {
+        "disabled": "hsl(208, 8%, 90%)",
+        "divider": "#bcbbc1",
+        "error": "#ff190c",
+        "grey0": "#393e42",
+        "grey1": "#43484d",
+        "grey2": "#5e6977",
+        "grey3": "#86939e",
+        "grey4": "#bdc6cf",
+        "grey5": "#e1e8ee",
+        "greyOutline": "#bbb",
+        "platform": Object {
+          "android": Object {
+            "error": "#f44336",
+            "primary": "#2196f3",
+            "secondary": "#9C27B0",
+            "success": "#4caf50",
+            "warning": "#ffeb3b",
+          },
+          "ios": Object {
+            "error": "#ff3b30",
+            "primary": "#007aff",
+            "secondary": "#5856d6",
+            "success": "#4cd964",
+            "warning": "#ffcc00",
+          },
+        },
+        "primary": "#2089dc",
+        "searchBg": "#303337",
+        "secondary": "#8F0CE8",
+        "success": "#52c41a",
+        "warning": "#faad14",
+      },
+    }
+  }
+  updateTheme={[Function]}
+>
+  Hey
+</Text>
+`;

--- a/src/text/__tests__/__snapshots__/Text.js.snap
+++ b/src/text/__tests__/__snapshots__/Text.js.snap
@@ -55,6 +55,62 @@ exports[`Text Component local props should override style props on theme 1`] = `
 </Text>
 `;
 
+exports[`Text Component should apply styles from the theme 1`] = `
+<Text
+  style={
+    Object {
+      "fontSize": 42.5,
+      "fontWeight": "200",
+    }
+  }
+  theme={
+    Object {
+      "Text": Object {
+        "h2Style": Object {
+          "fontWeight": "200",
+        },
+      },
+      "colors": Object {
+        "disabled": "hsl(208, 8%, 90%)",
+        "divider": "#bcbbc1",
+        "error": "#ff190c",
+        "grey0": "#393e42",
+        "grey1": "#43484d",
+        "grey2": "#5e6977",
+        "grey3": "#86939e",
+        "grey4": "#bdc6cf",
+        "grey5": "#e1e8ee",
+        "greyOutline": "#bbb",
+        "platform": Object {
+          "android": Object {
+            "error": "#f44336",
+            "primary": "#2196f3",
+            "secondary": "#9C27B0",
+            "success": "#4caf50",
+            "warning": "#ffeb3b",
+          },
+          "ios": Object {
+            "error": "#ff3b30",
+            "primary": "#007aff",
+            "secondary": "#5856d6",
+            "success": "#4cd964",
+            "warning": "#ffcc00",
+          },
+        },
+        "primary": "#2089dc",
+        "searchBg": "#303337",
+        "secondary": "#8F0CE8",
+        "success": "#52c41a",
+        "warning": "#faad14",
+      },
+    }
+  }
+  updateTheme={[Function]}
+>
+  Hey
+</Text>
+`;
+
 exports[`Text Component should render without issues 1`] = `
 <Text
   style={Object {}}


### PR DESCRIPTION
Reorders the style declarations for headers so that the fontWeight property can be overridden on Android.