### PR TITLE
fix(SearchBar-ios): Hide clear icon on cancel

### DIFF
--- a/src/searchbar/SearchBar-ios.js
+++ b/src/searchbar/SearchBar-ios.js
@@ -57,6 +57,7 @@ class SearchBar extends Component {
 
   cancel = () => {
     this.blur();
+    this.onChangeText('');
     this.props.onCancel();
   };
 


### PR DESCRIPTION
Fixes #1977

Also clears the text in the input as is the native behavior on iOS