### PR TITLE
fix(SearchBar-ios): Stop layoutAnimation effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "jest": {
     "preset": "react-native",
+    "timers": "fake",
     "coverageDirectory": "./coverage/",
     "testPathIgnorePatterns": [
       "./src/searchbar/__tests__/common.js"

--- a/src/searchbar/SearchBar-ios.js
+++ b/src/searchbar/SearchBar-ios.js
@@ -56,9 +56,12 @@ class SearchBar extends Component {
   };
 
   cancel = () => {
-    this.blur();
     this.onChangeText('');
-    this.props.onCancel();
+
+    setTimeout(() => {
+      this.blur();
+      this.props.onCancel();
+    }, 0);
   };
 
   onFocus = () => {

--- a/src/searchbar/__tests__/common.js
+++ b/src/searchbar/__tests__/common.js
@@ -190,6 +190,8 @@ export function commonPlatformTest(SearchBar) {
       };
 
       instance.cancel();
+
+      jest.runAllTimers();
       expect(onCancel).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
Changes in https://github.com/react-native-training/react-native-elements/commit/78ff4d81ee4b71a312a16a775b9438971a9280a8 mean that sometimes the JS thread will update the UI based on the onChangeText callback and do the layout animation for the SearchBar together.

This results in any content that depends on the onChangeText callback getting this animation applied. This fix allows the onChangeText callback and the blur to run in different frames.

![Kapture 2019-07-27 at 0 23 10](https://user-images.githubusercontent.com/5962998/61990028-7c1bcd80-b006-11e9-83bc-312256eb4f1d.gif)
