### PR TITLE
fix(Input): allow to pass React.forwardRef as inputComponent (#1901)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "deepmerge": "^3.1.0",
     "hoist-non-react-statics": "^3.1.0",
     "opencollective-postinstall": "^2.0.0",
-    "prop-types": "^15.5.8",
+    "prop-types": "^15.7.2",
     "react-native-ratings": "^6.3.0",
     "react-native-status-bar-height": "^2.2.0"
   },

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -154,7 +154,7 @@ Input.propTypes = {
   rightIcon: nodeType,
   rightIconContainerStyle: ViewPropTypes.style,
   inputStyle: TextPropTypes.style,
-  inputComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  inputComponent: PropTypes.elementType,
   errorProps: PropTypes.object,
   errorStyle: TextPropTypes.style,
   errorMessage: PropTypes.string,


### PR DESCRIPTION
Fix for https://github.com/react-native-training/react-native-elements/issues/1901