### PR TITLE
fix(ButtonGroup): Correct type for selectedIndex

### DIFF
--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -244,6 +244,7 @@ ButtonGroup.propTypes = {
 };
 
 ButtonGroup.defaultProps = {
+  selectedIndex: null,
   selectedIndexes: [],
   selectMultiple: false,
   containerBorderRadius: 3,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -534,7 +534,7 @@ export interface ButtonGroupProps {
   /**
    * Current selected index of array of buttons
    */
-  selectedIndex: number;
+  selectedIndex?: number | null;
 
   /**
    * The indexes that are selected. Used with 'selectMultiple'


### PR DESCRIPTION
Allow selectedIndex to be null or optional. Will default to null if no value set.

Fixes #1852