### PR TITLE
fix(SearchBar): Show clear based on empty check

### DIFF
--- a/src/searchbar/SearchBar-android.js
+++ b/src/searchbar/SearchBar-android.js
@@ -63,19 +63,20 @@ class SearchBar extends Component {
 
   onChangeText = text => {
     this.props.onChangeText(text);
-    this.setState({ isEmpty: text === '' });
   };
 
   constructor(props) {
     super(props);
-    const { value } = props;
+
     this.state = {
       hasFocus: false,
-      isEmpty: value ? value === '' : true,
     };
   }
 
   render() {
+    const hasContent =
+      typeof this.props.value === 'string' && this.props.value !== '';
+
     const {
       clearIcon,
       containerStyle,
@@ -89,7 +90,7 @@ class SearchBar extends Component {
       loadingProps,
       ...attributes
     } = this.props;
-    const { hasFocus, isEmpty } = this.state;
+    const { hasFocus } = this.state;
     const { style: loadingStyle, ...otherLoadingProps } = loadingProps;
 
     return (
@@ -130,7 +131,7 @@ class SearchBar extends Component {
                   {...otherLoadingProps}
                 />
               )}
-              {!isEmpty &&
+              {hasContent &&
                 renderNode(Icon, clearIcon, {
                   ...defaultClearIcon,
                   key: 'cancel',

--- a/src/searchbar/SearchBar-default.js
+++ b/src/searchbar/SearchBar-default.js
@@ -23,14 +23,6 @@ const defaultClearIcon = theme => ({
 });
 
 class SearchBar extends React.Component {
-  constructor(props) {
-    super(props);
-    const { value } = props;
-    this.state = {
-      isEmpty: value ? value === '' : true,
-    };
-  }
-
   focus = () => {
     this.input.focus();
   };
@@ -55,11 +47,12 @@ class SearchBar extends React.Component {
 
   onChangeText = text => {
     this.props.onChangeText(text);
-    this.setState({ isEmpty: text === '' });
   };
 
   render() {
     const { theme, ...rest } = this.props;
+    const hasContent =
+      typeof this.props.value === 'string' && this.props.value !== '';
 
     const {
       lightTheme,
@@ -77,7 +70,6 @@ class SearchBar extends React.Component {
       ...attributes
     } = rest;
 
-    const { isEmpty } = this.state;
     const { style: loadingStyle, ...otherLoadingProps } = loadingProps;
 
     return (
@@ -124,7 +116,7 @@ class SearchBar extends React.Component {
                 />
               )}
 
-              {!isEmpty &&
+              {hasContent &&
                 renderNode(Icon, clearIcon, {
                   ...defaultClearIcon(theme),
                   key: 'cancel',

--- a/src/searchbar/SearchBar-ios.js
+++ b/src/searchbar/SearchBar-ios.js
@@ -32,11 +32,9 @@ const defaultClearIcon = {
 class SearchBar extends Component {
   constructor(props) {
     super(props);
-    const { value } = props;
 
     this.state = {
       hasFocus: false,
-      isEmpty: value ? value === '' : true,
       cancelButtonWidth: null,
     };
   }
@@ -84,10 +82,12 @@ class SearchBar extends Component {
 
   onChangeText = text => {
     this.props.onChangeText(text);
-    this.setState({ isEmpty: text === '' });
   };
 
   render() {
+    const hasContent =
+      typeof this.props.value === 'string' && this.props.value !== '';
+
     const {
       cancelButtonProps,
       cancelButtonTitle,
@@ -103,7 +103,7 @@ class SearchBar extends Component {
       searchIcon,
       ...attributes
     } = this.props;
-    const { hasFocus, isEmpty } = this.state;
+    const { hasFocus } = this.state;
 
     const { style: loadingStyle, ...otherLoadingProps } = loadingProps;
 
@@ -152,7 +152,7 @@ class SearchBar extends Component {
                   {...otherLoadingProps}
                 />
               )}
-              {!isEmpty &&
+              {hasContent &&
                 renderNode(Icon, clearIcon, {
                   ...defaultClearIcon,
                   key: 'cancel',


### PR DESCRIPTION
Changes logic of showing clear button from using state to one that simply checks the value prop. This ensures that when the component's value is updated programmatically that the clear button will show correctly.

Fixes #1846

<p float="left">
<img src="https://user-images.githubusercontent.com/5962998/62347589-3492b700-b4c8-11e9-8d56-448cae7bd262.gif" width="300" >
<img src="https://user-images.githubusercontent.com/5962998/62347607-36f51100-b4c8-11e9-8c6b-c6be7872fc98.gif" width="300" >
</p>
