### PR TITLE
feat(Image): Allow children to be displayed while image loads

### DIFF
--- a/docs/avatar.md
+++ b/docs/avatar.md
@@ -260,9 +260,9 @@ Extra styling for icon component (optional)
 
 Optional properties to pass to the avatar e.g "resizeMode"
 
-|           Type           | Default |
-| :----------------------: | :-----: |
-| object (imageProperties) |  none   |
+|                Type                | Default |
+| :--------------------------------: | :-----: |
+| {[...Image props](image.md#props)} |  none   |
 
 ---
 

--- a/docs/card.md
+++ b/docs/card.md
@@ -169,9 +169,9 @@ add an image as the heading with the image prop (optional)
 
 optional properties to pass to the image if provided e.g "resizeMode"
 
-|           Type           | Default |
-| :----------------------: | :-----: |
-| object (ImageProperties) |  none   |
+|                 Type                 | Default |
+| :----------------------------------: | :-----: |
+| {[...Image props](image.md#props)} ) |  none   |
 
 ---
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -36,7 +36,7 @@ import { Image } from 'react-native-elements';
 ## Props
 
 > Also receives all
-> [Image](https://facebook.github.io/react-native/docs/image#props) props
+> [React Native Image](https://facebook.github.io/react-native/docs/image#props) props
 
 - [`containerStyle`](#containerstyle)
 - [`placeholderStyle`](#placeholderstyle)

--- a/docs/tile.md
+++ b/docs/tile.md
@@ -201,9 +201,9 @@ Styling for the image (optional)
 
 Optional properties to pass to the image if provided e.g "resizeMode" (options)
 
-|                                     Type                                     | Default |
-| :--------------------------------------------------------------------------: | :-----: |
-| {[...Image props](https://facebook.github.io/react-native/docs/image#props)} |  none   |
+|                Type                | Default |
+| :--------------------------------: | :-----: |
+| {[...Image props](image.md#props)} |  none   |
 
 ---
 

--- a/src/avatar/__tests__/__snapshots__/Avatar.js.snap
+++ b/src/avatar/__tests__/__snapshots__/Avatar.js.snap
@@ -661,6 +661,7 @@ exports[`Avatar Component should apply values from theme 1`] = `
   updateTheme={[Function]}
 >
   <View
+    accessibilityIgnoresInvertColors={true}
     style={
       Object {
         "backgroundColor": "#bdbdbd",
@@ -678,11 +679,19 @@ exports[`Avatar Component should apply values from theme 1`] = `
         }
       }
       style={
-        Object {
-          "flex": 1,
-          "height": null,
-          "width": null,
-        }
+        Array [
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          Object {
+            "height": null,
+            "width": null,
+          },
+        ]
       }
       testID="RNE__Image"
       theme={
@@ -758,6 +767,15 @@ exports[`Avatar Component should apply values from theme 1`] = `
         testID="RNE__Image__placeholder"
       />
     </View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "height": null,
+          "width": null,
+        }
+      }
+    />
   </View>
 </View>
 `;

--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -2,10 +2,9 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Animated,
-  Image as RNImage,
+  Image as ImageNative,
   StyleSheet,
   View,
-  ImageBackground,
   Platform,
 } from 'react-native';
 
@@ -18,6 +17,7 @@ const Image = ({
   containerStyle,
   style,
   ImageComponent,
+  children,
   ...attributes
 }) => {
   const [placeholderOpacity] = useState(new Animated.Value(1));
@@ -40,11 +40,20 @@ const Image = ({
   };
 
   return (
-    <View style={StyleSheet.flatten([styles.container, containerStyle])}>
+    <View
+      accessibilityIgnoresInvertColors={true}
+      style={StyleSheet.flatten([styles.container, containerStyle])}
+    >
       <ImageComponent
         {...attributes}
         onLoad={onLoad}
-        style={style}
+        style={[
+          StyleSheet.absoluteFill,
+          {
+            width: style.width,
+            height: style.height,
+          },
+        ]}
         testID="RNE__Image"
       />
 
@@ -70,6 +79,8 @@ const Image = ({
           {PlaceholderContent}
         </View>
       </Animated.View>
+
+      <View style={style}>{children}</View>
     </View>
   );
 };
@@ -90,15 +101,15 @@ const styles = {
 };
 
 Image.propTypes = {
-  ...RNImage.propTypes,
+  ...ImageNative.propTypes,
   ImageComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   PlaceholderContent: nodeType,
   containerStyle: ViewPropTypes.style,
-  placeholderStyle: RNImage.propTypes.style,
+  placeholderStyle: ImageNative.propTypes.style,
 };
 
 Image.defaultProps = {
-  ImageComponent: ImageBackground,
+  ImageComponent: ImageNative,
   style: {},
 };
 

--- a/src/image/__tests__/__snapshots__/Image.js.snap
+++ b/src/image/__tests__/__snapshots__/Image.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Image Component should apply values from theme 1`] = `
 <View
+  accessibilityIgnoresInvertColors={true}
   style={
     Object {
       "backgroundColor": "transparent",
@@ -9,80 +10,74 @@ exports[`Image Component should apply values from theme 1`] = `
     }
   }
 >
-  <View
-    accessibilityIgnoresInvertColors={true}
-    style={Object {}}
-  >
-    <Image
-      onLoad={[Function]}
-      replaceTheme={[Function]}
-      source={
-        Object {
-          "uri": "https://i.imgur.com/0y8Ftya.jpg",
-        }
+  <Image
+    onLoad={[Function]}
+    replaceTheme={[Function]}
+    source={
+      Object {
+        "uri": "https://i.imgur.com/0y8Ftya.jpg",
       }
-      style={
-        Array [
-          Object {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          },
-          Object {
-            "height": undefined,
-            "width": undefined,
-          },
-          undefined,
-        ]
-      }
-      testID="RNE__Image"
-      theme={
+    }
+    style={
+      Array [
         Object {
-          "Image": Object {
-            "placeholderStyle": Object {
-              "backgroundColor": "red",
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        Object {
+          "height": undefined,
+          "width": undefined,
+        },
+      ]
+    }
+    testID="RNE__Image"
+    theme={
+      Object {
+        "Image": Object {
+          "placeholderStyle": Object {
+            "backgroundColor": "red",
+          },
+        },
+        "colors": Object {
+          "disabled": "hsl(208, 8%, 90%)",
+          "divider": "#bcbbc1",
+          "error": "#ff190c",
+          "grey0": "#393e42",
+          "grey1": "#43484d",
+          "grey2": "#5e6977",
+          "grey3": "#86939e",
+          "grey4": "#bdc6cf",
+          "grey5": "#e1e8ee",
+          "greyOutline": "#bbb",
+          "platform": Object {
+            "android": Object {
+              "error": "#f44336",
+              "primary": "#2196f3",
+              "secondary": "#9C27B0",
+              "success": "#4caf50",
+              "warning": "#ffeb3b",
+            },
+            "ios": Object {
+              "error": "#ff3b30",
+              "primary": "#007aff",
+              "secondary": "#5856d6",
+              "success": "#4cd964",
+              "warning": "#ffcc00",
             },
           },
-          "colors": Object {
-            "disabled": "hsl(208, 8%, 90%)",
-            "divider": "#bcbbc1",
-            "error": "#ff190c",
-            "grey0": "#393e42",
-            "grey1": "#43484d",
-            "grey2": "#5e6977",
-            "grey3": "#86939e",
-            "grey4": "#bdc6cf",
-            "grey5": "#e1e8ee",
-            "greyOutline": "#bbb",
-            "platform": Object {
-              "android": Object {
-                "error": "#f44336",
-                "primary": "#2196f3",
-                "secondary": "#9C27B0",
-                "success": "#4caf50",
-                "warning": "#ffeb3b",
-              },
-              "ios": Object {
-                "error": "#ff3b30",
-                "primary": "#007aff",
-                "secondary": "#5856d6",
-                "success": "#4cd964",
-                "warning": "#ffcc00",
-              },
-            },
-            "primary": "#2089dc",
-            "searchBg": "#303337",
-            "secondary": "#8F0CE8",
-            "success": "#52c41a",
-            "warning": "#faad14",
-          },
-        }
+          "primary": "#2089dc",
+          "searchBg": "#303337",
+          "secondary": "#8F0CE8",
+          "success": "#52c41a",
+          "warning": "#faad14",
+        },
       }
-      updateTheme={[Function]}
-    />
-  </View>
+    }
+    updateTheme={[Function]}
+  />
   <View
     accessibilityElementsHidden={true}
     importantForAccessibility="no-hide-descendants"
@@ -109,11 +104,15 @@ exports[`Image Component should apply values from theme 1`] = `
       testID="RNE__Image__placeholder"
     />
   </View>
+  <View
+    style={Object {}}
+  />
 </View>
 `;
 
 exports[`Image Component should render on android 1`] = `
 <View
+  accessibilityIgnoresInvertColors={true}
   style={
     Object {
       "backgroundColor": "transparent",
@@ -121,14 +120,28 @@ exports[`Image Component should render on android 1`] = `
     }
   }
 >
-  <ImageBackground
+  <Image
     onLoad={[Function]}
     source={
       Object {
         "uri": "https://i.imgur.com/0y8Ftya.jpg",
       }
     }
-    style={Object {}}
+    style={
+      Array [
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        Object {
+          "height": undefined,
+          "width": undefined,
+        },
+      ]
+    }
     testID="RNE__Image"
   />
   <AnimatedComponent
@@ -161,11 +174,15 @@ exports[`Image Component should render on android 1`] = `
       testID="RNE__Image__placeholder"
     />
   </AnimatedComponent>
+  <View
+    style={Object {}}
+  />
 </View>
 `;
 
 exports[`Image Component should render on ios 1`] = `
 <View
+  accessibilityIgnoresInvertColors={true}
   style={
     Object {
       "backgroundColor": "transparent",
@@ -173,14 +190,28 @@ exports[`Image Component should render on ios 1`] = `
     }
   }
 >
-  <ImageBackground
+  <Image
     onLoad={[Function]}
     source={
       Object {
         "uri": "https://i.imgur.com/0y8Ftya.jpg",
       }
     }
-    style={Object {}}
+    style={
+      Array [
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        Object {
+          "height": undefined,
+          "width": undefined,
+        },
+      ]
+    }
     testID="RNE__Image"
   />
   <AnimatedComponent
@@ -213,5 +244,8 @@ exports[`Image Component should render on ios 1`] = `
       testID="RNE__Image__placeholder"
     />
   </AnimatedComponent>
+  <View
+    style={Object {}}
+  />
 </View>
 `;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -212,7 +212,7 @@ export interface AvatarProps {
   /**
    * Optional properties to pass to the image if provided e.g "resizeMode"
    */
-  imageProps?: Partial<RNImageProps>;
+  imageProps?: Partial<ImageProps>;
 
   /**
    * Size of Avatar
@@ -499,7 +499,7 @@ export interface CardProps {
   /**
    * Optional properties to pass to the image if provided e.g "resizeMode"
    */
-  imageProps?: Partial<RNImageProps>;
+  imageProps?: Partial<ImageProps>;
 }
 
 /**
@@ -1903,13 +1903,13 @@ export interface TileProps {
   /**
    * Optional properties to pass to the image if provided e.g "resizeMode"
    */
-  imageProps?: Partial<RNImageProps>;
+  imageProps?: Partial<ImageProps>;
 }
 
 /**
  * Tile component
  */
-export class Tile extends React.Component<TileProps, any> {}
+export class Tile extends React.Component<TileProps> {}
 
 export interface ImageProps extends RNImageProps {
   /**

--- a/src/tile/FeaturedTile.js
+++ b/src/tile/FeaturedTile.js
@@ -51,14 +51,12 @@ const FeaturedTile = props => {
     imageContainer: {
       alignItems: 'center',
       justifyContent: 'center',
-      backgroundColor: '#ffffff',
       width,
       height,
     },
     overlayContainer: {
       flex: 1,
       alignItems: 'center',
-      backgroundColor: 'rgba(0,0,0,0.2)',
       alignSelf: 'stretch',
       justifyContent: 'center',
       paddingLeft: 25,

--- a/src/tile/Tile.js
+++ b/src/tile/Tile.js
@@ -4,7 +4,7 @@ import {
   View,
   StyleSheet,
   Dimensions,
-  Image as NativeImage,
+  Image as ImageNative,
   TouchableOpacity,
 } from 'react-native';
 
@@ -76,12 +76,17 @@ const Tile = props => {
     >
       <ImageComponent
         resizeMode="cover"
-        {...imageProps}
         source={imageSrc}
-        style={StyleSheet.flatten([
+        containerStyle={StyleSheet.flatten([
           styles.imageContainer,
           imageContainerStyle && imageContainerStyle,
         ])}
+        style={{
+          ...StyleSheet.absoluteFillObject,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+        {...imageProps}
       >
         <View
           style={StyleSheet.flatten([
@@ -92,6 +97,7 @@ const Tile = props => {
           {icon && <Icon {...icon} />}
         </View>
       </ImageComponent>
+
       <View
         style={StyleSheet.flatten([
           styles.contentContainer,
@@ -116,7 +122,7 @@ Tile.propTypes = {
   title: PropTypes.string,
   icon: PropTypes.object,
   caption: PropTypes.node,
-  imageSrc: NativeImage.propTypes.source,
+  imageSrc: ImageNative.propTypes.source,
   onPress: PropTypes.func,
   activeOpacity: PropTypes.number,
   containerStyle: ViewPropTypes.style,
@@ -143,9 +149,6 @@ Tile.defaultProps = {
 
 const styles = StyleSheet.create({
   imageContainer: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#ffffff',
     flex: 2,
   },
   text: {

--- a/src/tile/__tests__/__snapshots__/FeaturedTile.js.snap
+++ b/src/tile/__tests__/__snapshots__/FeaturedTile.js.snap
@@ -20,7 +20,6 @@ exports[`FeaturedTitle component should apply custom image props 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "#ffffff",
         "height": 600,
         "justifyContent": "center",
         "width": 750,
@@ -32,7 +31,6 @@ exports[`FeaturedTitle component should apply custom image props 1`] = `
         Object {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "backgroundColor": "rgba(0,0,0,0.2)",
           "bottom": 0,
           "flex": 1,
           "justifyContent": "center",
@@ -96,7 +94,6 @@ exports[`FeaturedTitle component should apply values from theme 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "#ffffff",
         "height": 600,
         "justifyContent": "center",
         "width": 750,
@@ -132,7 +129,6 @@ exports[`FeaturedTitle component should apply values from theme 1`] = `
         Object {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "backgroundColor": "rgba(0,0,0,0.2)",
           "bottom": 0,
           "flex": 1,
           "justifyContent": "center",
@@ -237,7 +233,6 @@ exports[`FeaturedTitle component should render component in caption 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "#ffffff",
         "height": 600,
         "justifyContent": "center",
         "width": 750,
@@ -249,7 +244,6 @@ exports[`FeaturedTitle component should render component in caption 1`] = `
         Object {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "backgroundColor": "rgba(0,0,0,0.2)",
           "bottom": 0,
           "flex": 1,
           "justifyContent": "center",
@@ -317,7 +311,6 @@ exports[`FeaturedTitle component should render string in caption 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "#ffffff",
         "height": 600,
         "justifyContent": "center",
         "width": 750,
@@ -329,7 +322,6 @@ exports[`FeaturedTitle component should render string in caption 1`] = `
         Object {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "backgroundColor": "rgba(0,0,0,0.2)",
           "bottom": 0,
           "flex": 1,
           "justifyContent": "center",
@@ -402,7 +394,6 @@ exports[`FeaturedTitle component should render with Icon 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "#ffffff",
         "height": 70,
         "justifyContent": "center",
         "width": 750,
@@ -414,7 +405,6 @@ exports[`FeaturedTitle component should render with Icon 1`] = `
         Object {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "backgroundColor": "rgba(0,0,0,0.2)",
           "bottom": 0,
           "flex": 1,
           "height": 70,
@@ -484,7 +474,6 @@ exports[`FeaturedTitle component should render with width and height 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "#ffffff",
         "height": 20,
         "justifyContent": "center",
         "width": 34,
@@ -496,7 +485,6 @@ exports[`FeaturedTitle component should render with width and height 1`] = `
         Object {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "backgroundColor": "rgba(0,0,0,0.2)",
           "bottom": 0,
           "flex": 1,
           "justifyContent": "center",
@@ -557,7 +545,6 @@ exports[`FeaturedTitle component should render without issues 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "#ffffff",
         "height": 600,
         "justifyContent": "center",
         "width": 750,
@@ -569,7 +556,6 @@ exports[`FeaturedTitle component should render without issues 1`] = `
         Object {
           "alignItems": "center",
           "alignSelf": "stretch",
-          "backgroundColor": "rgba(0,0,0,0.2)",
           "bottom": 0,
           "flex": 1,
           "justifyContent": "center",

--- a/src/tile/__tests__/__snapshots__/Tile.js.snap
+++ b/src/tile/__tests__/__snapshots__/Tile.js.snap
@@ -12,6 +12,11 @@ exports[`Tile component should apply custom image props 1`] = `
   width={750}
 >
   <Themed.Image
+    containerStyle={
+      Object {
+        "flex": 2,
+      }
+    }
     resizeMode="contain"
     source={
       Object {
@@ -21,9 +26,12 @@ exports[`Tile component should apply custom image props 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "#ffffff",
-        "flex": 2,
+        "bottom": 0,
         "justifyContent": "center",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
       }
     }
   >
@@ -80,102 +88,82 @@ exports[`Tile component should apply styles from theme 1`] = `
   }
 >
   <View
+    accessibilityIgnoresInvertColors={true}
     style={
       Object {
         "backgroundColor": "transparent",
+        "flex": 2,
         "position": "relative",
       }
     }
   >
-    <View
-      accessibilityIgnoresInvertColors={true}
-      style={
+    <Image
+      onLoad={[Function]}
+      replaceTheme={[Function]}
+      resizeMode="cover"
+      source={
         Object {
-          "alignItems": "center",
-          "backgroundColor": "#ffffff",
-          "flex": 2,
-          "justifyContent": "center",
+          "url": "http://google.com",
         }
       }
-    >
-      <Image
-        onLoad={[Function]}
-        replaceTheme={[Function]}
-        resizeMode="cover"
-        source={
+      style={
+        Array [
           Object {
-            "url": "http://google.com",
-          }
-        }
-        style={
-          Array [
-            Object {
-              "bottom": 0,
-              "left": 0,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            },
-            Object {
-              "height": undefined,
-              "width": undefined,
-            },
-            undefined,
-          ]
-        }
-        testID="RNE__Image"
-        theme={
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
           Object {
-            "Tile": Object {
-              "title": "Mary is friendly",
-            },
-            "colors": Object {
-              "disabled": "hsl(208, 8%, 90%)",
-              "divider": "#bcbbc1",
-              "error": "#ff190c",
-              "grey0": "#393e42",
-              "grey1": "#43484d",
-              "grey2": "#5e6977",
-              "grey3": "#86939e",
-              "grey4": "#bdc6cf",
-              "grey5": "#e1e8ee",
-              "greyOutline": "#bbb",
-              "platform": Object {
-                "android": Object {
-                  "error": "#f44336",
-                  "primary": "#2196f3",
-                  "secondary": "#9C27B0",
-                  "success": "#4caf50",
-                  "warning": "#ffeb3b",
-                },
-                "ios": Object {
-                  "error": "#ff3b30",
-                  "primary": "#007aff",
-                  "secondary": "#5856d6",
-                  "success": "#4cd964",
-                  "warning": "#ffcc00",
-                },
+            "height": undefined,
+            "width": undefined,
+          },
+        ]
+      }
+      testID="RNE__Image"
+      theme={
+        Object {
+          "Tile": Object {
+            "title": "Mary is friendly",
+          },
+          "colors": Object {
+            "disabled": "hsl(208, 8%, 90%)",
+            "divider": "#bcbbc1",
+            "error": "#ff190c",
+            "grey0": "#393e42",
+            "grey1": "#43484d",
+            "grey2": "#5e6977",
+            "grey3": "#86939e",
+            "grey4": "#bdc6cf",
+            "grey5": "#e1e8ee",
+            "greyOutline": "#bbb",
+            "platform": Object {
+              "android": Object {
+                "error": "#f44336",
+                "primary": "#2196f3",
+                "secondary": "#9C27B0",
+                "success": "#4caf50",
+                "warning": "#ffeb3b",
               },
-              "primary": "#2089dc",
-              "searchBg": "#303337",
-              "secondary": "#8F0CE8",
-              "success": "#52c41a",
-              "warning": "#faad14",
+              "ios": Object {
+                "error": "#ff3b30",
+                "primary": "#007aff",
+                "secondary": "#5856d6",
+                "success": "#4cd964",
+                "warning": "#ffcc00",
+              },
             },
-          }
+            "primary": "#2089dc",
+            "searchBg": "#303337",
+            "secondary": "#8F0CE8",
+            "success": "#52c41a",
+            "warning": "#faad14",
+          },
         }
-        updateTheme={[Function]}
-      />
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "alignSelf": "center",
-            "justifyContent": "center",
-          }
-        }
-      />
-    </View>
+      }
+      updateTheme={[Function]}
+    />
     <View
       accessibilityElementsHidden={true}
       importantForAccessibility="no-hide-descendants"
@@ -196,11 +184,38 @@ exports[`Tile component should apply styles from theme 1`] = `
           Object {
             "alignItems": "center",
             "backgroundColor": "#bdbdbd",
-            "flex": 2,
+            "bottom": 0,
             "justifyContent": "center",
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
           }
         }
         testID="RNE__Image__placeholder"
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "alignSelf": "center",
+            "justifyContent": "center",
+          }
+        }
       />
     </View>
   </View>
@@ -320,6 +335,12 @@ exports[`Tile component should render tile with icon 1`] = `
   width={750}
 >
   <Themed.Image
+    containerStyle={
+      Object {
+        "flex": 2,
+        "height": 70,
+      }
+    }
     resizeMode="cover"
     source={
       Object {
@@ -329,10 +350,12 @@ exports[`Tile component should render tile with icon 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "#ffffff",
-        "flex": 2,
-        "height": 70,
+        "bottom": 0,
         "justifyContent": "center",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
       }
     }
   >
@@ -391,6 +414,11 @@ exports[`Tile component should render with active opacity 1`] = `
   width={750}
 >
   <Themed.Image
+    containerStyle={
+      Object {
+        "flex": 2,
+      }
+    }
     resizeMode="cover"
     source={
       Object {
@@ -400,9 +428,12 @@ exports[`Tile component should render with active opacity 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "#ffffff",
-        "flex": 2,
+        "bottom": 0,
         "justifyContent": "center",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
       }
     }
   >
@@ -452,6 +483,11 @@ exports[`Tile component should render without issues 1`] = `
   width={750}
 >
   <Themed.Image
+    containerStyle={
+      Object {
+        "flex": 2,
+      }
+    }
     resizeMode="cover"
     source={
       Object {
@@ -461,9 +497,12 @@ exports[`Tile component should render without issues 1`] = `
     style={
       Object {
         "alignItems": "center",
-        "backgroundColor": "#ffffff",
-        "flex": 2,
+        "bottom": 0,
         "justifyContent": "center",
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
       }
     }
   >


### PR DESCRIPTION
Since https://github.com/react-native-training/react-native-elements/commit/e2795821fa85bbce48282b9c92d2260658d5c35e the Image component supports nesting children being based from ImageBackground. This meant however that children of the Image would not be visible until the image loaded which is incorrect behaviour.

This commit fixes this, allowing children to be visible while the image loads in the background. Also instead of using the ImageBackground component from react native, we implement our own based on [the source](https://github.com/facebook/react-native/blob/master/Libraries/Image/ImageBackground.js). This is so we can place the animated placeholder between the content and the image.

e.g (background -> animated placeholder -> our content)

Also makes some small tweaks to Tile and FeaturedTile so that they display correctly with the new changes to Image.

Since Tile, Avatar, and Card now use RNE Image, the docs and types have been updated to reflect.

#### Before
![before](https://user-images.githubusercontent.com/5962998/62409096-65deb600-b5a0-11e9-9e9f-3a2b5e23cd32.gif)

#### After
![after](https://user-images.githubusercontent.com/5962998/62409097-6a0ad380-b5a0-11e9-86bf-35aab6f5bf96.gif)
