### PR TITLE
Added React.ComponentElement to input label type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -873,7 +873,7 @@ export interface InputProps extends TextInputProperties {
   /**
    * 	Adds label (optional)
    */
-  label?: string  | React.ComponentElement;
+  label?: string | React.ReactElement<{}>;
 
   /**
    *  props to be passed to the React Native Text component used to display the label (optional)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -873,7 +873,7 @@ export interface InputProps extends TextInputProperties {
   /**
    * 	Adds label (optional)
    */
-  label?: string;
+  label?: string  | React.ComponentElement;
 
   /**
    *  props to be passed to the React Native Text component used to display the label (optional)


### PR DESCRIPTION
Added React.ComponentElement to match the accepted input types as stated in the [docs](https://react-native-training.github.io/react-native-elements/docs/input.html#label).