### PR TITLE
fix(Image): Blank placeholder when source is null

### DIFF
--- a/src/image/Image.js
+++ b/src/image/Image.js
@@ -21,7 +21,7 @@ const Image = ({
   ...attributes
 }) => {
   const [placeholderOpacity] = useState(new Animated.Value(1));
-  const hasImage = typeof attributes.source !== 'undefined';
+  const hasImage = Boolean(attributes.source);
 
   const onLoad = () => {
     const minimumWait = 100;


### PR DESCRIPTION
Fixes a bug where when the source on Avatar is set to null, then the title would never show.

```jsx
<Avatar title="MD" source={null} />
```

The result would just be grey. This is because the Image component was explicitly checking if attributes.source was 'undefined'.