### PR TITLE
Remove containerBorderRadius props

### DIFF
--- a/docs/button_group.md
+++ b/docs/button_group.md
@@ -83,7 +83,6 @@ render () {
 - [`buttonStyle`](#buttonstyle)
 - [`buttons`](#buttons)
 - [`Component`](#Component)
-- [`containerBorderRadius`](#containerborderradius)
 - [`containerStyle`](#containerstyle)
 - [`disabled`](#disabled)
 - [`disabledStyle`](#disabledstyle)
@@ -132,16 +131,6 @@ Choose other button component such as TouchableOpacity (optional)
 |          Type          |      Default       |
 | :--------------------: | :----------------: |
 | React Native Component | TouchableHighlight |
-
----
-
-### `containerBorderRadius`
-
-Set's the border radius for the first and last button in the button group
-
-|  Type  | Default |
-| :----: | :-----: |
-| number |    3    |
 
 ---
 

--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -45,6 +45,7 @@ const ButtonGroup = props => {
   } = rest;
 
   let innerBorderWidth = 1;
+  const defaultBorderRadius = 3;
 
   if (
     innerBorderStyle &&
@@ -89,12 +90,12 @@ const ButtonGroup = props => {
               },
               i === buttons.length - 1 && {
                 ...lastBorderStyle,
-                borderBottomRightRadius: 3,
-                borderTopRightRadius: 3,
+                borderBottomRightRadius: defaultBorderRadius,
+                borderTopRightRadius: defaultBorderRadius,
               },
               i === 0 && {
-                borderBottomLeftRadius: 3,
-                borderTopLeftRadius: 3,
+                borderBottomLeftRadius: defaultBorderRadius,
+                borderTopLeftRadius: defaultBorderRadius,
               },
             ])}
           >

--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -36,7 +36,6 @@ const ButtonGroup = props => {
     onHideUnderlay,
     onShowUnderlay,
     setOpacityTo,
-    containerBorderRadius,
     disabled,
     disabledStyle,
     disabledTextStyle,
@@ -74,6 +73,7 @@ const ButtonGroup = props => {
             style={StyleSheet.flatten([
               // FIXME: This is a workaround to the borderColor and borderRadius bug
               // react-native ref: https://github.com/facebook/react-native/issues/8236
+
               styles.button,
               i < buttons.length - 1 && {
                 borderRightWidth: i === 0 ? 0 : innerBorderWidth,
@@ -89,12 +89,6 @@ const ButtonGroup = props => {
               },
               i === buttons.length - 1 && {
                 ...lastBorderStyle,
-                borderTopRightRadius: containerBorderRadius,
-                borderBottomRightRadius: containerBorderRadius,
-              },
-              i === 0 && {
-                borderTopLeftRadius: containerBorderRadius,
-                borderBottomLeftRadius: containerBorderRadius,
               },
             ])}
           >
@@ -230,7 +224,6 @@ ButtonGroup.propTypes = {
     NativeText.propTypes.style,
   ]),
   buttonStyle: ViewPropTypes.style,
-  containerBorderRadius: PropTypes.number,
   selectMultiple: PropTypes.bool,
   theme: PropTypes.object,
   disabled: PropTypes.oneOfType([
@@ -247,7 +240,6 @@ ButtonGroup.defaultProps = {
   selectedIndex: null,
   selectedIndexes: [],
   selectMultiple: false,
-  containerBorderRadius: 3,
   disabled: false,
   Component: Platform.select({
     android: TouchableNativeFeedback,

--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -89,6 +89,12 @@ const ButtonGroup = props => {
               },
               i === buttons.length - 1 && {
                 ...lastBorderStyle,
+                borderBottomRightRadius: 3,
+                borderTopRightRadius: 3,
+              },
+              i === 0 && {
+                borderBottomLeftRadius: 3,
+                borderTopLeftRadius: 3,
               },
             ])}
           >


### PR DESCRIPTION
This PR addresses #1784 

I've removed containerBorderRadius from ButtonGroup docs,
and removed the containerBorderRadius from ButtonGroup component.