### PR TITLE
Use ImageBackground only when backgroundImage is provided for Header

### DIFF
--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -77,7 +77,9 @@ class Header extends Component {
       linearGradientProps,
       ViewComponent = linearGradientProps && global.Expo
         ? global.Expo.LinearGradient
-        : ImageBackground,
+        : backgroundImage
+        ? ImageBackground
+        : View,
       theme,
       ...attributes
     } = this.props;

--- a/src/header/__tests__/Header.js
+++ b/src/header/__tests__/Header.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, ImageBackground } from 'react-native';
+import { Button, ImageBackground, View } from 'react-native';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { create } from 'react-test-renderer';
@@ -96,7 +96,7 @@ describe('Header Component', () => {
 
     expect(
       component
-        .find(ImageBackground)
+        .find(View)
         .first()
         .props().style.backgroundColor
     ).toBe('#aaa');
@@ -109,7 +109,7 @@ describe('Header Component', () => {
 
     expect(
       component
-        .find(ImageBackground)
+        .find(View)
         .at(0)
         .props().style.backgroundColor
     ).toBe('#ccc');
@@ -173,7 +173,7 @@ describe('Header Component', () => {
 
     expect(
       component
-        .find(ImageBackground)
+        .find(View)
         .first()
         .props().imageStyle
     ).toEqual({ opacity: 0.1 });
@@ -181,7 +181,11 @@ describe('Header Component', () => {
 
   it('should render with backgroundImageStyle', () => {
     const component = shallow(
-      <Header theme={theme} backgroundImageStyle={{ opacity: 0.1 }} />
+      <Header
+        theme={theme}
+        backgroundImage={{ uri: 'http://google.com' }}
+        backgroundImageStyle={{ opacity: 0.1 }}
+      />
     );
 
     expect(component.length).toBe(1);

--- a/src/header/__tests__/__snapshots__/Header.js.snap
+++ b/src/header/__tests__/__snapshots__/Header.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Header Component should apply values from theme 1`] = `
 <View
-  accessibilityIgnoresInvertColors={true}
+  replaceTheme={[Function]}
   style={
     Object {
       "alignItems": "center",
@@ -16,28 +16,9 @@ exports[`Header Component should apply values from theme 1`] = `
       "paddingTop": 20,
     }
   }
+  testID="headerContainer"
+  updateTheme={[Function]}
 >
-  <Image
-    replaceTheme={[Function]}
-    style={
-      Array [
-        Object {
-          "bottom": 0,
-          "left": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-        },
-        Object {
-          "height": 64,
-          "width": undefined,
-        },
-        undefined,
-      ]
-    }
-    testID="headerContainer"
-    updateTheme={[Function]}
-  />
   <View
     style={
       Object {
@@ -66,7 +47,7 @@ exports[`Header Component should apply values from theme 1`] = `
 `;
 
 exports[`Header Component should render center component by passing a config through props 1`] = `
-<ImageBackground
+<View
   style={
     Object {
       "alignItems": "center",
@@ -112,11 +93,11 @@ exports[`Header Component should render center component by passing a config thr
       }
     }
   />
-</ImageBackground>
+</View>
 `;
 
 exports[`Header Component should render left component by passing a component through props 1`] = `
-<ImageBackground
+<View
   style={
     Object {
       "alignItems": "center",
@@ -165,11 +146,11 @@ exports[`Header Component should render left component by passing a component th
       }
     }
   />
-</ImageBackground>
+</View>
 `;
 
 exports[`Header Component should render left component by passing a config through props 1`] = `
-<ImageBackground
+<View
   style={
     Object {
       "alignItems": "center",
@@ -215,11 +196,11 @@ exports[`Header Component should render left component by passing a config throu
       }
     }
   />
-</ImageBackground>
+</View>
 `;
 
 exports[`Header Component should render right component by passing a component through props 1`] = `
-<ImageBackground
+<View
   style={
     Object {
       "alignItems": "center",
@@ -268,11 +249,11 @@ exports[`Header Component should render right component by passing a component t
       title="Test button"
     />
   </Children>
-</ImageBackground>
+</View>
 `;
 
 exports[`Header Component should render right component by passing a config through props 1`] = `
-<ImageBackground
+<View
   style={
     Object {
       "alignItems": "center",
@@ -318,7 +299,7 @@ exports[`Header Component should render right component by passing a config thro
   >
     <Component />
   </Children>
-</ImageBackground>
+</View>
 `;
 
 exports[`Header Component should render with backgroundImage 1`] = `
@@ -381,6 +362,11 @@ exports[`Header Component should render with backgroundImageStyle 1`] = `
       "opacity": 0.1,
     }
   }
+  source={
+    Object {
+      "uri": "http://google.com",
+    }
+  }
   style={
     Object {
       "alignItems": "center",
@@ -428,7 +414,7 @@ exports[`Header Component should render with backgroundImageStyle 1`] = `
 `;
 
 exports[`Header Component should render without issues 1`] = `
-<ImageBackground
+<View
   style={
     Object {
       "alignItems": "center",
@@ -472,5 +458,5 @@ exports[`Header Component should render without issues 1`] = `
       }
     }
   />
-</ImageBackground>
+</View>
 `;


### PR DESCRIPTION
Otherwise use simple View. This commit is to address an issue on old Android phones. BackgroundImage without source will crash on Android.
Discussion and workaround can be found here https://github.com/react-native-training/react-native-elements/issues/1938