### PR TITLE
fix: Remove props from native components 

### DIFF
--- a/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
+++ b/src/buttons/__tests__/__snapshots__/ButtonGroup.js.snap
@@ -555,7 +555,6 @@ exports[`ButtonGroup Component should apply values from theme 1`] = `
         }
       >
         <Text
-          replaceTheme={[Function]}
           style={
             Object {
               "color": "red",
@@ -606,7 +605,6 @@ exports[`ButtonGroup Component should apply values from theme 1`] = `
               },
             }
           }
-          updateTheme={[Function]}
         >
           Button 1
         </Text>
@@ -651,7 +649,6 @@ exports[`ButtonGroup Component should apply values from theme 1`] = `
         }
       >
         <Text
-          replaceTheme={[Function]}
           style={
             Object {
               "color": "#5e6977",
@@ -702,7 +699,6 @@ exports[`ButtonGroup Component should apply values from theme 1`] = `
               },
             }
           }
-          updateTheme={[Function]}
         >
           Button 2
         </Text>
@@ -745,7 +741,6 @@ exports[`ButtonGroup Component should apply values from theme 1`] = `
         }
       >
         <Text
-          replaceTheme={[Function]}
           style={
             Object {
               "color": "#5e6977",
@@ -796,7 +791,6 @@ exports[`ButtonGroup Component should apply values from theme 1`] = `
               },
             }
           }
-          updateTheme={[Function]}
         >
           Button 3
         </Text>

--- a/src/card/__tests__/__snapshots__/Card.js.snap
+++ b/src/card/__tests__/__snapshots__/Card.js.snap
@@ -31,7 +31,6 @@ exports[`Card Component should apply values from theme 1`] = `
   >
     <View>
       <Text
-        replaceTheme={[Function]}
         style={
           Object {
             "color": "#43484d",
@@ -82,7 +81,6 @@ exports[`Card Component should apply values from theme 1`] = `
             },
           }
         }
-        updateTheme={[Function]}
       >
         Yea b
       </Text>

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -12,6 +12,10 @@ const isIOS = Platform.OS === 'ios';
 
 const conditionalStyle = (condition, style) => (condition ? style : {});
 
+export const patchWebProps = ({ updateTheme, replaceTheme, ...rest }) => {
+  return rest;
+};
+
 export {
   renderNode,
   getIconType,

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -12,7 +12,12 @@ const isIOS = Platform.OS === 'ios';
 
 const conditionalStyle = (condition, style) => (condition ? style : {});
 
-export const patchWebProps = ({ updateTheme, replaceTheme, ...rest }) => {
+export const patchWebProps = ({
+  updateTheme,
+  replaceTheme,
+  onClear,
+  ...rest
+}) => {
   return rest;
 };
 

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -10,7 +10,7 @@ import {
   StyleSheet,
 } from 'react-native';
 
-import { nodeType, renderNode } from '../helpers';
+import { nodeType, renderNode, patchWebProps } from '../helpers';
 import { fonts, withTheme, ViewPropTypes, TextPropTypes } from '../config';
 
 import Icon from '../icons/Icon';
@@ -114,7 +114,7 @@ class Input extends React.Component {
             testID="RNE__Input__text-input"
             underlineColorAndroid="transparent"
             editable={!disabled}
-            {...attributes}
+            {...patchWebProps(attributes)}
             ref={ref => {
               this.input = ref;
             }}

--- a/src/input/__tests__/__snapshots__/Input.js.snap
+++ b/src/input/__tests__/__snapshots__/Input.js.snap
@@ -761,7 +761,6 @@ exports[`Input component should apply values from theme 1`] = `
       editable={true}
       placeholder="Enter text"
       rejectResponderTermination={true}
-      replaceTheme={[Function]}
       style={
         Object {
           "alignSelf": "center",
@@ -773,7 +772,6 @@ exports[`Input component should apply values from theme 1`] = `
       }
       testID="RNE__Input__text-input"
       underlineColorAndroid="transparent"
-      updateTheme={[Function]}
     />
   </View>
 </View>

--- a/src/list/__tests__/__snapshots__/ListItem.js.snap
+++ b/src/list/__tests__/__snapshots__/ListItem.js.snap
@@ -25,7 +25,6 @@ exports[`ListItem component should apply values from theme 1`] = `
       }
     >
       <Text
-        replaceTheme={[Function]}
         style={
           Object {
             "backgroundColor": "transparent",
@@ -73,7 +72,6 @@ exports[`ListItem component should apply values from theme 1`] = `
             },
           }
         }
-        updateTheme={[Function]}
       >
         List Title
       </Text>

--- a/src/pricing/__tests__/__snapshots__/PricingCard.js.snap
+++ b/src/pricing/__tests__/__snapshots__/PricingCard.js.snap
@@ -30,7 +30,6 @@ exports[`PricingCard component should apply values from theme 1`] = `
     }
   >
     <Text
-      replaceTheme={[Function]}
       style={
         Object {
           "color": "#2089dc",
@@ -80,12 +79,10 @@ exports[`PricingCard component should apply values from theme 1`] = `
           },
         }
       }
-      updateTheme={[Function]}
     >
       ALL YOU CAN EAT
     </Text>
     <Text
-      replaceTheme={[Function]}
       style={
         Object {
           "fontSize": 50,
@@ -135,12 +132,10 @@ exports[`PricingCard component should apply values from theme 1`] = `
           },
         }
       }
-      updateTheme={[Function]}
     >
       $0
     </Text>
     <Text
-      replaceTheme={[Function]}
       style={
         Object {
           "color": "#86939e",
@@ -190,12 +185,10 @@ exports[`PricingCard component should apply values from theme 1`] = `
           },
         }
       }
-      updateTheme={[Function]}
     >
       1 User
     </Text>
     <Text
-      replaceTheme={[Function]}
       style={
         Object {
           "color": "#86939e",
@@ -245,12 +238,10 @@ exports[`PricingCard component should apply values from theme 1`] = `
           },
         }
       }
-      updateTheme={[Function]}
     >
       Basic Support
     </Text>
     <Text
-      replaceTheme={[Function]}
       style={
         Object {
           "color": "#86939e",
@@ -300,7 +291,6 @@ exports[`PricingCard component should apply values from theme 1`] = `
           },
         }
       }
-      updateTheme={[Function]}
     >
       All Core Features
     </Text>

--- a/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
@@ -129,7 +129,6 @@ exports[`SearchBar wrapper component should apply values from theme 1`] = `
         onBlur={[Function]}
         onCancel={[Function]}
         onChangeText={[Function]}
-        onClear={[Function]}
         onFocus={[Function]}
         placeholder="Enter search term"
         platform="android"

--- a/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
+++ b/src/searchbar/__tests__/__snapshots__/SearchBar.js.snap
@@ -134,7 +134,6 @@ exports[`SearchBar wrapper component should apply values from theme 1`] = `
         placeholder="Enter search term"
         platform="android"
         rejectResponderTermination={true}
-        replaceTheme={[Function]}
         style={
           Object {
             "alignSelf": "center",
@@ -148,7 +147,6 @@ exports[`SearchBar wrapper component should apply values from theme 1`] = `
         }
         testID="searchInput"
         underlineColorAndroid="transparent"
-        updateTheme={[Function]}
         value=""
       />
       <View

--- a/src/text/Text.js
+++ b/src/text/Text.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Text, StyleSheet, Platform } from 'react-native';
 
 import { fonts, withTheme } from '../config';
+import { patchWebProps } from '../helpers';
 import normalize from '../helpers/normalizeText';
 
 const TextElement = props => {
@@ -34,7 +35,7 @@ const TextElement = props => {
         h3 && StyleSheet.flatten([{ fontSize: normalize(28) }, h3Style]),
         h4 && StyleSheet.flatten([{ fontSize: normalize(22) }, h4Style]),
       ])}
-      {...rest}
+      {...patchWebProps(rest)}
     >
       {children}
     </Text>

--- a/src/text/__tests__/__snapshots__/Text.js.snap
+++ b/src/text/__tests__/__snapshots__/Text.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Text Component local props should override style props on theme 1`] = `
 <Text
-  replaceTheme={[Function]}
   style={
     Object {
       "fontSize": 42.5,
@@ -50,7 +49,6 @@ exports[`Text Component local props should override style props on theme 1`] = `
       },
     }
   }
-  updateTheme={[Function]}
 >
   Hey
 </Text>
@@ -64,7 +62,6 @@ exports[`Text Component should render without issues 1`] = `
 
 exports[`Text Component should use values from the theme 1`] = `
 <Text
-  replaceTheme={[Function]}
   style={
     Object {
       "fontSize": 27.5,
@@ -110,7 +107,6 @@ exports[`Text Component should use values from the theme 1`] = `
       },
     }
   }
-  updateTheme={[Function]}
 >
   Hey
 </Text>

--- a/src/tile/__tests__/__snapshots__/FeaturedTile.js.snap
+++ b/src/tile/__tests__/__snapshots__/FeaturedTile.js.snap
@@ -153,7 +153,6 @@ exports[`FeaturedTitle component should apply values from theme 1`] = `
         }
       />
       <Text
-        replaceTheme={[Function]}
         style={
           Object {
             "backgroundColor": "rgba(0,0,0,0)",
@@ -204,7 +203,6 @@ exports[`FeaturedTitle component should apply values from theme 1`] = `
             },
           }
         }
-        updateTheme={[Function]}
       >
         I am featured
       </Text>

--- a/src/tile/__tests__/__snapshots__/Tile.js.snap
+++ b/src/tile/__tests__/__snapshots__/Tile.js.snap
@@ -230,7 +230,6 @@ exports[`Tile component should apply styles from theme 1`] = `
     }
   >
     <Text
-      replaceTheme={[Function]}
       style={
         Object {
           "backgroundColor": "rgba(0,0,0,0)",
@@ -279,7 +278,6 @@ exports[`Tile component should apply styles from theme 1`] = `
           },
         }
       }
-      updateTheme={[Function]}
     >
       Mary is friendly
     </Text>


### PR DESCRIPTION
Most properties are spread into native elements to pass properties directly. However, since some of these props aren't dom properties they error on react-native-web.

Fixes #1747